### PR TITLE
Handle fixed-length global strings in VM

### DIFF
--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -4,7 +4,7 @@
 PSCAL = ../pscal
 
 # List of test files
-TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p
+TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p StringTruncationTest.p
 
 all: test
 

--- a/Tests/StringTruncationTest.p
+++ b/Tests/StringTruncationTest.p
@@ -1,0 +1,18 @@
+program StringTruncationTest;
+
+var
+  s: string[5];
+
+begin
+  s := 'abcdefghij';
+  if s = 'abcde' then
+    writeln('TRUNC PASS')
+  else
+    writeln('TRUNC FAIL');
+
+  if length(s) = 5 then
+    writeln('LENGTH PASS')
+  else
+    writeln('LENGTH FAIL');
+end.
+

--- a/src/compiler/bytecode.h
+++ b/src/compiler/bytecode.h
@@ -46,7 +46,8 @@ typedef enum {
     //   If var_type_enum == TYPE_ARRAY:
     //       [dim_count] { [lower_idx][upper_idx] }*dim_count [elem_var_type][elem_type_name_idx]
     //   Else:
-    //       [type_name_const_idx]   // may be 0 when not applicable
+    //       [type_name_const_idx] [len_const_idx if var_type_enum == TYPE_STRING]
+    //         // len_const_idx references an integer constant; 0 means dynamic length
     OP_DEFINE_GLOBAL,
     OP_GET_GLOBAL,    // Get a global variable's value (takes constant index for name)
     OP_SET_GLOBAL,    // Set a global variable's value (takes constant index for name)

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -693,6 +693,18 @@ static void compileNode(AST* node, BytecodeChunk* chunk, int current_line_approx
                             // records, dynamic strings, and fixed-length strings.
                             const char* type_name = (type_specifier_node && type_specifier_node->token) ? type_specifier_node->token->value : "";
                             writeBytecodeChunk(chunk, (uint8_t)addStringConstant(chunk, type_name), getLine(varNameNode));
+
+                            if (node->var_type == TYPE_STRING) {
+                                int max_len = 0;
+                                if (actual_type_def_node && actual_type_def_node->right) {
+                                    Value len_val = evaluateCompileTimeValue(actual_type_def_node->right);
+                                    if (len_val.type == TYPE_INTEGER) {
+                                        max_len = (int)len_val.i_val;
+                                    }
+                                    freeValue(&len_val);
+                                }
+                                writeBytecodeChunk(chunk, (uint8_t)addIntConstant(chunk, max_len), getLine(varNameNode));
+                            }
                         }
                         resolveGlobalVariableIndex(chunk, varNameNode->token->value, getLine(varNameNode));
                     }

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1397,10 +1397,30 @@ comparison_error_label:
 
                 } else {
                     uint8_t type_name_idx = READ_BYTE();
+                    int str_len = 0;
+                    if (declaredType == TYPE_STRING) {
+                        uint8_t len_idx = READ_BYTE();
+                        Value len_val = vm->chunk->constants[len_idx];
+                        if (len_val.type == TYPE_INTEGER) {
+                            str_len = (int)len_val.i_val;
+                        }
+                    }
                     Value typeNameVal = vm->chunk->constants[type_name_idx];
                     AST* type_def_node = NULL;
 
-                    if (typeNameVal.type == TYPE_STRING && typeNameVal.s_val) {
+                    if (declaredType == TYPE_STRING && str_len > 0) {
+                        Token* strTok = newToken(TOKEN_IDENTIFIER, "string", 0, 0);
+                        type_def_node = newASTNode(AST_VARIABLE, strTok);
+                        setTypeAST(type_def_node, TYPE_STRING);
+                        freeToken(strTok);
+                        char buf[32];
+                        snprintf(buf, sizeof(buf), "%d", str_len);
+                        Token* lenTok = newToken(TOKEN_INTEGER_CONST, buf, 0, 0);
+                        AST* lenNode = newASTNode(AST_NUMBER, lenTok);
+                        setTypeAST(lenNode, TYPE_INTEGER);
+                        freeToken(lenTok);
+                        setRight(type_def_node, lenNode);
+                    } else if (typeNameVal.type == TYPE_STRING && typeNameVal.s_val) {
                         type_def_node = lookupType(typeNameVal.s_val);
                     }
 


### PR DESCRIPTION
## Summary
- Emit fixed-length metadata for `string[n]` globals and record a length constant
- Teach VM to read the length and initialise values with fixed-size buffers
- Add regression test ensuring long assignments are truncated and length returns `n`

## Testing
- `cmake ..`
- `make`
- `./bin/pscal ../Tests/StringTruncationTest.p`

------
https://chatgpt.com/codex/tasks/task_e_6896696ddfe4832abbf7a4d27fefed8e