### PR TITLE
Support type tokens in low/high and test char bounds

### DIFF
--- a/Tests/LowHighCharTest.p
+++ b/Tests/LowHighCharTest.p
@@ -1,0 +1,15 @@
+program LowHighCharTest;
+
+procedure AssertEqualChar(expected, actual: char; testName: string);
+begin
+  write('START: ', testName, ': ');
+  if expected = actual then
+    writeln('PASS')
+  else
+    writeln('FAIL (expected: ''', expected, ''', got: ''', actual, ''')');
+end;
+
+begin
+  AssertEqualChar(chr(0), low(char), 'low(char)');
+  AssertEqualChar(chr(255), high(char), 'high(char)');
+end.

--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -4,7 +4,7 @@
 PSCAL = ../pscal
 
 # List of test files
-TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p StringTruncationTest.p
+TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p StringTruncationTest.p LowHighCharTest.p
 
 all: test
 

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -673,38 +673,95 @@ Value vm_builtin_dec(VM* vm, int arg_count, Value* args) {
 }
 
 Value vm_builtin_low(VM* vm, int arg_count, Value* args) {
-    if (arg_count != 1 || args[0].type != TYPE_STRING) { runtimeError(vm, "Low() expects a single type identifier."); return makeInt(0); }
-    const char* typeName = AS_STRING(args[0]);
+    if (arg_count != 1) {
+        runtimeError(vm, "Low() expects a single type identifier.");
+        return makeInt(0);
+    }
 
-    if (strcasecmp(typeName, "integer") == 0) return makeInt(-2147483648);
-    if (strcasecmp(typeName, "char") == 0) return makeChar((char)0);
-    if (strcasecmp(typeName, "boolean") == 0) return makeBoolean(false);
-    if (strcasecmp(typeName, "byte") == 0) return makeInt(0);
-    if (strcasecmp(typeName, "word") == 0) return makeInt(0);
+    Value arg = args[0];
+    const char* typeName = NULL;
+    VarType t = TYPE_UNKNOWN;
 
-    AST* typeDef = lookupType(typeName);
-    if (typeDef && typeDef->var_type == TYPE_ENUM) return makeEnum(typeName, 0);
+    if (arg.type == TYPE_STRING) {
+        typeName = AS_STRING(arg);
+        if (strcasecmp(typeName, "integer") == 0)      t = TYPE_INTEGER;
+        else if (strcasecmp(typeName, "char") == 0)    t = TYPE_CHAR;
+        else if (strcasecmp(typeName, "boolean") == 0) t = TYPE_BOOLEAN;
+        else if (strcasecmp(typeName, "byte") == 0)    t = TYPE_BYTE;
+        else if (strcasecmp(typeName, "word") == 0)    t = TYPE_WORD;
+    } else {
+        t = arg.type;
+    }
 
-    runtimeError(vm, "Low() not supported for type '%s'.", typeName);
+    switch (t) {
+        case TYPE_INTEGER: return makeInt(-2147483648);
+        case TYPE_CHAR:    return makeChar((char)0);
+        case TYPE_BOOLEAN: return makeBoolean(false);
+        case TYPE_BYTE:    return makeInt(0);
+        case TYPE_WORD:    return makeInt(0);
+        case TYPE_ENUM: {
+            const char* enumName = typeName ? typeName : arg.enum_val.enum_name;
+            if (enumName) {
+                AST* typeDef = lookupType(enumName);
+                if (typeDef && typeDef->var_type == TYPE_ENUM) return makeEnum(enumName, 0);
+            }
+            break;
+        }
+        default:
+            break;
+    }
+
+    if (typeName)
+        runtimeError(vm, "Low() not supported for type '%s'.", typeName);
+    else
+        runtimeError(vm, "Low() not supported for provided type.");
     return makeInt(0);
 }
 
 Value vm_builtin_high(VM* vm, int arg_count, Value* args) {
-    if (arg_count != 1 || args[0].type != TYPE_STRING) { runtimeError(vm, "High() expects a single type identifier."); return makeInt(0); }
-    const char* typeName = AS_STRING(args[0]);
-
-    if (strcasecmp(typeName, "integer") == 0) return makeInt(2147483647);
-    if (strcasecmp(typeName, "char") == 0) return makeChar((char)255);
-    if (strcasecmp(typeName, "boolean") == 0) return makeBoolean(true);
-    if (strcasecmp(typeName, "byte") == 0) return makeInt(255);
-    if (strcasecmp(typeName, "word") == 0) return makeInt(65535);
-
-    AST* typeDef = lookupType(typeName);
-    if (typeDef && typeDef->var_type == TYPE_ENUM && typeDef->type == AST_ENUM_TYPE) {
-        return makeEnum(typeName, typeDef->child_count - 1);
+    if (arg_count != 1) {
+        runtimeError(vm, "High() expects a single type identifier.");
+        return makeInt(0);
     }
 
-    runtimeError(vm, "High() not supported for type '%s'.", typeName);
+    Value arg = args[0];
+    const char* typeName = NULL;
+    VarType t = TYPE_UNKNOWN;
+
+    if (arg.type == TYPE_STRING) {
+        typeName = AS_STRING(arg);
+        if (strcasecmp(typeName, "integer") == 0)      t = TYPE_INTEGER;
+        else if (strcasecmp(typeName, "char") == 0)    t = TYPE_CHAR;
+        else if (strcasecmp(typeName, "boolean") == 0) t = TYPE_BOOLEAN;
+        else if (strcasecmp(typeName, "byte") == 0)    t = TYPE_BYTE;
+        else if (strcasecmp(typeName, "word") == 0)    t = TYPE_WORD;
+    } else {
+        t = arg.type;
+    }
+
+    switch (t) {
+        case TYPE_INTEGER: return makeInt(2147483647);
+        case TYPE_CHAR:    return makeChar((char)255);
+        case TYPE_BOOLEAN: return makeBoolean(true);
+        case TYPE_BYTE:    return makeInt(255);
+        case TYPE_WORD:    return makeInt(65535);
+        case TYPE_ENUM: {
+            const char* enumName = typeName ? typeName : arg.enum_val.enum_name;
+            if (enumName) {
+                AST* typeDef = lookupType(enumName);
+                if (typeDef && typeDef->var_type == TYPE_ENUM && typeDef->type == AST_ENUM_TYPE)
+                    return makeEnum(enumName, typeDef->child_count - 1);
+            }
+            break;
+        }
+        default:
+            break;
+    }
+
+    if (typeName)
+        runtimeError(vm, "High() not supported for type '%s'.", typeName);
+    else
+        runtimeError(vm, "High() not supported for provided type.");
     return makeInt(0);
 }
 


### PR DESCRIPTION
## Summary
- Allow `low` and `high` builtins to accept either string type names or direct type tokens, producing a `TYPE_CHAR` value when the type is `char`
- Verify comparison logic by adding a regression test that checks `low(char)` and `high(char)` via `AssertEqualChar`

## Testing
- `./build/bin/pscal Tests/LowHighCharTest.p`

------
https://chatgpt.com/codex/tasks/task_e_68966bb9672c832aaa4493ad95b9fb72