### PR TITLE
Discover tests via script location

### DIFF
--- a/Misc/tall
+++ b/Misc/tall
@@ -2,7 +2,8 @@
 #BIN="$HOME/.bin"          # all your executables live here
 BIN="$HOME/Dropbox/PBuild/build/bin"          # all your executables live here
 
-TESTS="$HOME/git/pscal/Tests"  # all your .p / .pas files live here
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TESTS="${TESTS:-$ROOT/Tests}"  # all your .p / .pas files live here
 
 PSCAL="$BIN/pscal"       # plain interpreter
 


### PR DESCRIPTION
## Summary
- Use the script's directory to determine the repository root in `Misc/tall`.
- Default the `TESTS` path to the repo's `Tests` directory with override support.
- Pre-flight test checks now rely on the `TESTS` variable.

## Testing
- `bash -n Misc/tall`
- `shellcheck Misc/tall` *(fails: command not found)*
- `apt-get install -y shellcheck` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689671f04d68832ab25e0c3e78d73106