### PR TITLE
Add PSCAL env override and binary check to tall script

### DIFF
--- a/Misc/tall
+++ b/Misc/tall
@@ -1,11 +1,11 @@
 #!/bin/bash
-#BIN="$HOME/.bin"          # all your executables live here
-BIN="$HOME/Dropbox/PBuild/build/bin"          # all your executables live here
+# Set PSCAL to use a different interpreter, e.g.,
+#   PSCAL=/path/to/pscal ./tall
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TESTS="${TESTS:-$ROOT/Tests}"  # all your .p / .pas files live here
 
-PSCAL="$BIN/pscal"       # plain interpreter
+PSCAL="${PSCAL:-$ROOT/build/bin/pscal}"       # plain interpreter
 
 for f in "$TESTS/TestSuite7.p" \
          "$TESTS/MathSuite01.p" \
@@ -14,7 +14,10 @@ do
   [ -r "$f" ] || echo "Missing test file: $f"
 done
 
-[ -x "$PSCAL" ] || echo "pscal binary not found/executable: $PSCAL"
+if [[ ! -x "$PSCAL" ]]; then
+  echo "pscal binary not found or not executable: $PSCAL" >&2
+  exit 1
+fi
 
 run () {
   local label=$1; shift


### PR DESCRIPTION
## Summary
- Allow overriding PSCAL location via environment variable with a sensible default.
- Exit early with an error when PSCAL binary is missing or not executable.

## Testing
- `bash -n Misc/tall`
- `if bash Misc/tall; then echo succeeded; else echo failed; fi`

------
https://chatgpt.com/codex/tasks/task_e_689673e40a78832a901ef4bcfeaf8e6a