### PR TITLE
Support file variable initialization in bytecode

### DIFF
--- a/src/compiler/bytecode.c
+++ b/src/compiler/bytecode.c
@@ -148,6 +148,7 @@ int getInstructionLength(BytecodeChunk* chunk, int offset) {
         case OP_GET_CHAR_ADDRESS:
         case OP_WRITE:
         case OP_WRITE_LN:
+        case OP_INIT_LOCAL_FILE:
             return 2; // 1-byte opcode + 1-byte operand
         case OP_INIT_LOCAL_ARRAY: {
             int current_pos = offset + 1; // after opcode
@@ -379,6 +380,11 @@ int disassembleInstruction(BytecodeChunk* chunk, int offset, HashTable* procedur
             uint8_t dim_count = chunk->code[offset + 2];
             printf("%-16s Slot:%d Dims:%d\n", "OP_INIT_LOCAL_ARRAY", slot, dim_count);
             return offset + 5 + dim_count * 2;
+        }
+        case OP_INIT_LOCAL_FILE: {
+            uint8_t slot = chunk->code[offset + 1];
+            printf("%-16s %4d (slot)\n", "OP_INIT_LOCAL_FILE", slot);
+            return offset + 2;
         }
         case OP_GET_LOCAL_ADDRESS: {
             uint8_t slot = chunk->code[offset + 1];

--- a/src/compiler/bytecode.h
+++ b/src/compiler/bytecode.h
@@ -56,6 +56,7 @@ typedef enum {
     OP_GET_LOCAL,     // Get local scoped variables
     OP_SET_LOCAL,     // Set local scoped variables
     OP_INIT_LOCAL_ARRAY, // Initialize local array variable
+    OP_INIT_LOCAL_FILE,  // Initialize local file variable
     OP_GET_LOCAL_ADDRESS,
     
     OP_GET_FIELD_ADDRESS,

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -798,6 +798,9 @@ static void compileNode(AST* node, BytecodeChunk* chunk, int current_line_approx
                         writeBytecodeChunk(chunk, (uint8_t)elem_type->var_type, getLine(varNameNode));
                         const char* elem_type_name = (elem_type && elem_type->token) ? elem_type->token->value : "";
                         writeBytecodeChunk(chunk, (uint8_t)addStringConstant(chunk, elem_type_name), getLine(varNameNode));
+                    } else if (node->var_type == TYPE_FILE) {
+                        writeBytecodeChunk(chunk, OP_INIT_LOCAL_FILE, getLine(varNameNode));
+                        writeBytecodeChunk(chunk, (uint8_t)slot, getLine(varNameNode));
                     }
                 }
             }

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1595,6 +1595,14 @@ comparison_error_label:
                 *target_slot = array_val;
                 break;
             }
+            case OP_INIT_LOCAL_FILE: {
+                uint8_t slot = READ_BYTE();
+                CallFrame* frame = &vm->frames[vm->frameCount - 1];
+                Value* target_slot = &frame->slots[slot];
+                freeValue(target_slot);
+                *target_slot = makeValueForType(TYPE_FILE, NULL, NULL);
+                break;
+            }
             case OP_JUMP_IF_FALSE: {
                 uint16_t offset_val = READ_SHORT(vm);
                 Value condition_value = pop(vm);


### PR DESCRIPTION
## Summary
- add OP_INIT_LOCAL_FILE opcode and emit it for local file declarations
- implement OP_INIT_LOCAL_FILE in VM and disassembler
- update opcode tables for correct debugging and instruction sizing

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `make -C Tests test PSCAL=../build/bin/pscal`

------
https://chatgpt.com/codex/tasks/task_e_68967c3feb1c832ab371cd0174bb0f99