### PR TITLE
Implement Low/High for char and enums

### DIFF
--- a/Tests/LowHighCharTest.p
+++ b/Tests/LowHighCharTest.p
@@ -1,5 +1,8 @@
 program LowHighCharTest;
 
+type
+  TColor = (Red, Green, Blue);
+
 procedure AssertEqualChar(expected, actual: char; testName: string);
 begin
   write('START: ', testName, ': ');
@@ -9,7 +12,23 @@ begin
     writeln('FAIL (expected: ''', expected, ''', got: ''', actual, ''')');
 end;
 
+procedure AssertEqualColor(expected, actual: TColor; testName: string);
+begin
+  write('START: ', testName, ': ');
+  if ord(expected) = ord(actual) then
+    writeln('PASS')
+  else
+    writeln('FAIL (expected: ', ord(expected), ', got: ', ord(actual), ')');
+end;
+
+var
+  cLow, cHigh: TColor;
+
 begin
   AssertEqualChar(chr(0), low(char), 'low(char)');
   AssertEqualChar(chr(255), high(char), 'high(char)');
+  cLow := low(TColor);
+  cHigh := high(TColor);
+  AssertEqualColor(Red, cLow, 'low(TColor)');
+  AssertEqualColor(Blue, cHigh, 'high(TColor)');
 end.


### PR DESCRIPTION
## Summary
- Map builtin Low/High arguments to VarType and support lookupType for enums
- Delegate AST-level Low/High to shared VM implementations
- Add regression test covering Low/High for char and an example enum

## Testing
- `cd Tests && ../pscal LowHighCharTest.p`


------
https://chatgpt.com/codex/tasks/task_e_68967e99a8b4832a8b6afb7b05904d5d