### PR TITLE
Handle char type for low/high builtins

### DIFF
--- a/Tests/TypeTestSuite
+++ b/Tests/TypeTestSuite
@@ -310,6 +310,8 @@ begin
   // Low / High / Succ / Pred (if implemented)
   AssertEqualChar(#0, low(char), 'Low(char)');   // #0 is ASCII NUL
   AssertEqualChar(#255, high(char), 'High(char)'); // Depends on char implementation (often 8-bit)
+  AssertEqualInt(0, ord(low(char)), 'Ord(Low(char))');
+  AssertEqualInt(255, ord(high(char)), 'Ord(High(char))');
   AssertEqualChar('B', succ('A'), 'Succ(A)');
   // AssertEqualChar('A', pred('B'), 'Pred(B)'); // Uncomment if Pred is implemented
 end;

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -544,7 +544,7 @@ static inline long long coerceDeltaToI64(const Value* v) {
 Value vm_builtin_ord(VM* vm, int arg_count, Value* args) {
     if (arg_count != 1) { runtimeError(vm, "ord expects 1 argument."); return makeInt(0); }
     Value arg = args[0];
-    if (arg.type == TYPE_CHAR) return makeInt((long long)arg.c_val);
+    if (arg.type == TYPE_CHAR) return makeInt((unsigned char)arg.c_val);
     if (arg.type == TYPE_BOOLEAN) return makeInt(arg.i_val);
     if (arg.type == TYPE_ENUM) return makeInt(arg.enum_val.ordinal);
     if (arg.type == TYPE_INTEGER) return makeInt(arg.i_val);
@@ -710,7 +710,7 @@ Value vm_builtin_low(VM* vm, int arg_count, Value* args) {
 
     switch (t) {
         case TYPE_INTEGER: return makeInt(-2147483648);
-        case TYPE_CHAR:    return makeChar((char)0);
+        case TYPE_CHAR:    return makeChar(0);
         case TYPE_BOOLEAN: return makeBoolean(false);
         case TYPE_BYTE:    return makeInt(0);
         case TYPE_WORD:    return makeInt(0);
@@ -767,7 +767,7 @@ Value vm_builtin_high(VM* vm, int arg_count, Value* args) {
 
     switch (t) {
         case TYPE_INTEGER: return makeInt(2147483647);
-        case TYPE_CHAR:    return makeChar((char)255);
+        case TYPE_CHAR:    return makeChar(255);
         case TYPE_BOOLEAN: return makeBoolean(true);
         case TYPE_BYTE:    return makeInt(255);
         case TYPE_WORD:    return makeInt(65535);

--- a/src/frontend/parser.c
+++ b/src/frontend/parser.c
@@ -2555,6 +2555,16 @@ AST *factor(Parser *parser) {
              } else { node->children = NULL; node->child_count = 0; node->child_capacity=0; } // Empty arg list '()'
              if (!parser->current_token || parser->current_token->type != TOKEN_RPAREN) { errorParser(parser,"Expected ) after args"); return node;}
              eat(parser, TOKEN_RPAREN); // Eat ')'
+
+             // If this is a builtin low/high call on 'char', mark result type as char
+             if (node->token && isBuiltin(node->token->value) && node->child_count == 1) {
+                 if (strcasecmp(node->token->value, "low") == 0 || strcasecmp(node->token->value, "high") == 0) {
+                     AST* arg0 = node->children[0];
+                     if (arg0 && arg0->token && strcasecmp(arg0->token->value, "char") == 0) {
+                         setTypeAST(node, TYPE_CHAR);
+                     }
+                 }
+             }
              // Type annotation will set the function's return type later
         }
         // Check if lvalue returned a simple variable that might be a parameter-less function


### PR DESCRIPTION
## Summary
- ensure low() and high() built-ins return char values for char types
- tag low/high calls on 'char' as TYPE_CHAR during parsing
- add tests for low(char)/high(char) return values

## Testing
- `./build/bin/pscal Tests/TypeTestSuite` *(fails: VM Execution Failed (Runtime Error))*

------
https://chatgpt.com/codex/tasks/task_e_6896888d719c832a8a3f99e66d3c4671