### PR TITLE
Adjust word node type declaration in hangman example

### DIFF
--- a/Examples/hangman5
+++ b/Examples/hangman5
@@ -29,11 +29,11 @@ const
 
 type
   { *** ADDED: Linked List for Word Storage *** }
-  PWordNode = ^TWordNode;
   TWordNode = record
     data: string[MAX_LENGTH]; { Store word directly - adjust size if needed }
-    next: PWordNode;
+    next: ^TWordNode;
   end;
+  PWordNode = ^TWordNode;
   { *** END ADDED *** }
 
 var


### PR DESCRIPTION
## Summary
- reorder `TWordNode` record and `PWordNode` pointer alias in `hangman5`

## Testing
- `cmake ..` *(fails: Could not find package configuration file provided by SDL2)*
- `Examples/hangman5` *(fails: /usr/bin/env: ‘pscal’: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68968fd66224832a9a622de5fb271657