### PR TITLE
Use pointer alias for Hangman word list nodes

### DIFF
--- a/Examples/hangman5
+++ b/Examples/hangman5
@@ -29,11 +29,11 @@ const
 
 type
   { *** ADDED: Linked List for Word Storage *** }
+  PWordNode = ^TWordNode;
   TWordNode = record
     data: string[MAX_LENGTH]; { Store word directly - adjust size if needed }
-    next: ^TWordNode;
+    next: PWordNode;
   end;
-  PWordNode = ^TWordNode;
   { *** END ADDED *** }
 
 var


### PR DESCRIPTION
## Summary
- Define `PWordNode` before `TWordNode` and use it for the `next` field to mirror LinkedList pointer patterns.

## Testing
- `cmake ..` *(fails: FindSDL2.cmake not found)*
- `apt-get update` *(fails: repositories not signed)*
- `./Examples/hangman5` *(fails: pscal not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896952e1b98832a9b7a065bc99eb032