### PR TITLE
Support 16-bit global name indices in VM and compiler

### DIFF
--- a/src/compiler/bytecode.c
+++ b/src/compiler/bytecode.c
@@ -161,6 +161,9 @@ int getInstructionLength(BytecodeChunk* chunk, int offset) {
         }
         case OP_CONSTANT16:
         case OP_GET_FIELD_ADDRESS16:
+        case OP_GET_GLOBAL16:
+        case OP_SET_GLOBAL16:
+        case OP_GET_GLOBAL_ADDRESS16:
             return 3; // 1 byte opcode + 2-byte operand
         case OP_JUMP:
         case OP_JUMP_IF_FALSE:
@@ -365,6 +368,21 @@ int disassembleInstruction(BytecodeChunk* chunk, int offset, HashTable* procedur
             uint8_t name_index = chunk->code[offset + 1];
             printf("%-16s %4d '%s'\n", "OP_GET_GLOBAL_ADDRESS", name_index, AS_STRING(chunk->constants[name_index]));
             return offset + 2;
+        }
+        case OP_GET_GLOBAL16: {
+            uint16_t name_index = (uint16_t)((chunk->code[offset + 1] << 8) | chunk->code[offset + 2]);
+            printf("%-16s %4d '%s'\n", "OP_GET_GLOBAL16", name_index, AS_STRING(chunk->constants[name_index]));
+            return offset + 3;
+        }
+        case OP_SET_GLOBAL16: {
+            uint16_t name_index = (uint16_t)((chunk->code[offset + 1] << 8) | chunk->code[offset + 2]);
+            printf("%-16s %4d '%s'\n", "OP_SET_GLOBAL16", name_index, AS_STRING(chunk->constants[name_index]));
+            return offset + 3;
+        }
+        case OP_GET_GLOBAL_ADDRESS16: {
+            uint16_t name_index = (uint16_t)((chunk->code[offset + 1] << 8) | chunk->code[offset + 2]);
+            printf("%-16s %4d '%s'\n", "OP_GET_GLOBAL_ADDRESS16", name_index, AS_STRING(chunk->constants[name_index]));
+            return offset + 3;
         }
         case OP_GET_LOCAL: {
             uint8_t slot = chunk->code[offset + 1];

--- a/src/compiler/bytecode.h
+++ b/src/compiler/bytecode.h
@@ -52,7 +52,10 @@ typedef enum {
     OP_GET_GLOBAL,    // Get a global variable's value (takes constant index for name)
     OP_SET_GLOBAL,    // Set a global variable's value (takes constant index for name)
     OP_GET_GLOBAL_ADDRESS,
-    
+    OP_GET_GLOBAL16,  // 16-bit name index variant of OP_GET_GLOBAL
+    OP_SET_GLOBAL16,  // 16-bit name index variant of OP_SET_GLOBAL
+    OP_GET_GLOBAL_ADDRESS16, // 16-bit name index variant of OP_GET_GLOBAL_ADDRESS
+
     OP_GET_LOCAL,     // Get local scoped variables
     OP_SET_LOCAL,     // Set local scoped variables
     OP_INIT_LOCAL_ARRAY, // Initialize local array variable


### PR DESCRIPTION
## Summary
- Add OP_GET_GLOBAL16, OP_SET_GLOBAL16, and OP_GET_GLOBAL_ADDRESS16 opcodes
- Teach VM, disassembler, and compiler to emit/interpret new 16-bit global name instructions
- Replace direct uint8_t casts with emitGlobalNameIdx helper to choose 8- or 16-bit variant

## Testing
- `cmake -B build`
- `cmake --build build`
- `printf "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nn\n" | ./build/bin/pscal --dump-bytecode Examples/hangman5`


------
https://chatgpt.com/codex/tasks/task_e_6896c37ade04832a8442bef2943fee07