### PR TITLE
Add 16-bit global definition opcode

### DIFF
--- a/src/compiler/bytecode.h
+++ b/src/compiler/bytecode.h
@@ -49,6 +49,7 @@ typedef enum {
     //       [type_name_const_idx] [len_const_idx if var_type_enum == TYPE_STRING]
     //         // len_const_idx references an integer constant; 0 means dynamic length
     OP_DEFINE_GLOBAL,
+    OP_DEFINE_GLOBAL16, // 16-bit name index variant of OP_DEFINE_GLOBAL
     OP_GET_GLOBAL,    // Get a global variable's value (takes constant index for name)
     OP_SET_GLOBAL,    // Set a global variable's value (takes constant index for name)
     OP_GET_GLOBAL_ADDRESS,

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -121,6 +121,11 @@ static void emitGlobalNameIdx(BytecodeChunk* chunk, OpCode op8, OpCode op16,
     }
 }
 
+// Helper to emit OP_DEFINE_GLOBAL or OP_DEFINE_GLOBAL16 depending on index size.
+static void emitDefineGlobal(BytecodeChunk* chunk, int name_idx, int line) {
+    emitGlobalNameIdx(chunk, OP_DEFINE_GLOBAL, OP_DEFINE_GLOBAL16, name_idx, line);
+}
+
 // --- Forward Declarations for Recursive Compilation ---
 static void compileNode(AST* node, BytecodeChunk* chunk, int current_line_approx);
 static void compileRValue(AST* node, BytecodeChunk* chunk, int current_line_approx);
@@ -663,8 +668,7 @@ static void compileNode(AST* node, BytecodeChunk* chunk, int current_line_approx
                     AST* varNameNode = node->children[i];
                     if (varNameNode && varNameNode->token) {
                         int var_name_idx = addStringConstant(chunk, varNameNode->token->value);
-                        writeBytecodeChunk(chunk, OP_DEFINE_GLOBAL, getLine(varNameNode));
-                        writeBytecodeChunk(chunk, (uint8_t)var_name_idx, getLine(varNameNode));
+                        emitDefineGlobal(chunk, var_name_idx, getLine(varNameNode));
                         writeBytecodeChunk(chunk, (uint8_t)node->var_type, getLine(varNameNode)); // The overall type (e.g., TYPE_ARRAY)
 
                         if (node->var_type == TYPE_ARRAY) {


### PR DESCRIPTION
## Summary
- Extend bytecode with OP_DEFINE_GLOBAL16 and support 16-bit global name indices
- Update VM and disassembler to handle OP_DEFINE_GLOBAL16
- Emit OP_DEFINE_GLOBAL16 from compiler when a global name index exceeds 8 bits

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `./build/bin/pscal --dump-bytecode Examples/hangman5` *(runtime error: Argument to new() must be of pointer type. Got NIL.)*


------
https://chatgpt.com/codex/tasks/task_e_6896c856f820832aadd3ec97ed65d841