### PR TITLE
Support 16-bit global type name operands

### DIFF
--- a/src/compiler/bytecode.c
+++ b/src/compiler/bytecode.c
@@ -187,10 +187,11 @@ int getInstructionLength(BytecodeChunk* chunk, int offset) {
                     current_pos += 2; // Skip element VarType and element type name index
                 }
             } else {
-                // Simple types store the type name index and, for strings, an extra length constant.
-                current_pos++; // type name index
+                // Simple types store a 16-bit type name index and, for strings,
+                // an extra 16-bit length constant.
+                current_pos += 2; // type name index (16-bit)
                 if (declaredType == TYPE_STRING) {
-                    current_pos++; // length constant index
+                    current_pos += 2; // length constant index (16-bit)
                 }
             }
             return (current_pos - offset); // Return the total calculated length
@@ -209,9 +210,9 @@ int getInstructionLength(BytecodeChunk* chunk, int offset) {
                     current_pos += 2; // element var type and element type name index
                 }
             } else {
-                current_pos++; // type name index
+                current_pos += 2; // type name index (16-bit)
                 if (declaredType == TYPE_STRING) {
-                    current_pos++; // length constant index
+                    current_pos += 2; // length constant index (16-bit)
                 }
             }
             return (current_pos - offset);
@@ -359,13 +360,18 @@ int disassembleInstruction(BytecodeChunk* chunk, int offset, HashTable* procedur
                     }
                 }
             } else {
-                if (current_offset < chunk->count) {
-                    uint8_t type_name_idx = chunk->code[current_offset++];
-                    if (type_name_idx > 0 && type_name_idx < chunk->constants_count && chunk->constants[type_name_idx].type == TYPE_STRING) {
+                if (current_offset + 1 < chunk->count) {
+                    uint16_t type_name_idx =
+                        (uint16_t)((chunk->code[current_offset] << 8) | chunk->code[current_offset + 1]);
+                    current_offset += 2;
+                    if (type_name_idx > 0 && type_name_idx < chunk->constants_count &&
+                        chunk->constants[type_name_idx].type == TYPE_STRING) {
                         printf("('%s')", chunk->constants[type_name_idx].s_val);
                     }
-                    if (declaredType == TYPE_STRING && current_offset < chunk->count) {
-                        uint8_t len_idx = chunk->code[current_offset++];
+                    if (declaredType == TYPE_STRING && current_offset + 1 < chunk->count) {
+                        uint16_t len_idx =
+                            (uint16_t)((chunk->code[current_offset] << 8) | chunk->code[current_offset + 1]);
+                        current_offset += 2;
                         if (len_idx < chunk->constants_count && chunk->constants[len_idx].type == TYPE_INTEGER) {
                             printf(" len=%lld", chunk->constants[len_idx].i_val);
                         }
@@ -411,14 +417,18 @@ int disassembleInstruction(BytecodeChunk* chunk, int offset, HashTable* procedur
                     }
                 }
             } else {
-                if (current_offset < chunk->count) {
-                    uint8_t type_name_idx = chunk->code[current_offset++];
+                if (current_offset + 1 < chunk->count) {
+                    uint16_t type_name_idx =
+                        (uint16_t)((chunk->code[current_offset] << 8) | chunk->code[current_offset + 1]);
+                    current_offset += 2;
                     if (type_name_idx > 0 && type_name_idx < chunk->constants_count &&
                         chunk->constants[type_name_idx].type == TYPE_STRING) {
                         printf("('%s')", chunk->constants[type_name_idx].s_val);
                     }
-                    if (declaredType == TYPE_STRING && current_offset < chunk->count) {
-                        uint8_t len_idx = chunk->code[current_offset++];
+                    if (declaredType == TYPE_STRING && current_offset + 1 < chunk->count) {
+                        uint16_t len_idx =
+                            (uint16_t)((chunk->code[current_offset] << 8) | chunk->code[current_offset + 1]);
+                        current_offset += 2;
                         if (len_idx < chunk->constants_count && chunk->constants[len_idx].type == TYPE_INTEGER) {
                             printf(" len=%lld", chunk->constants[len_idx].i_val);
                         }

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -99,6 +99,16 @@ static void emitConstant(BytecodeChunk* chunk, int constant_index, int line) {
     }
 }
 
+// Emits a 16-bit constant pool index without selecting an opcode.
+static void emitConstantIndex16(BytecodeChunk* chunk, int constant_index, int line) {
+    if (constant_index < 0 || constant_index > 0xFFFF) {
+        fprintf(stderr, "L%d: Compiler error: constant index out of range (%d).\n", line, constant_index);
+        compiler_had_error = true;
+        return;
+    }
+    emitShort(chunk, (uint16_t)constant_index, line);
+}
+
 // Helper to emit global-variable opcodes that take a name index operand.
 // Selects 8-bit or 16-bit variants based on the index value.
 static void emitGlobalNameIdx(BytecodeChunk* chunk, OpCode op8, OpCode op16,
@@ -734,7 +744,7 @@ static void compileNode(AST* node, BytecodeChunk* chunk, int current_line_approx
                                  */
                                 type_name = actual_type_def_node->token->value;
                             }
-                            writeBytecodeChunk(chunk, (uint8_t)addStringConstant(chunk, type_name), getLine(varNameNode));
+                            emitConstantIndex16(chunk, addStringConstant(chunk, type_name), getLine(varNameNode));
 
                             if (node->var_type == TYPE_STRING) {
                                 int max_len = 0;
@@ -745,7 +755,7 @@ static void compileNode(AST* node, BytecodeChunk* chunk, int current_line_approx
                                     }
                                     freeValue(&len_val);
                                 }
-                                writeBytecodeChunk(chunk, (uint8_t)addIntConstant(chunk, max_len), getLine(varNameNode));
+                                emitConstantIndex16(chunk, addIntConstant(chunk, max_len), getLine(varNameNode));
                             }
                         }
                         resolveGlobalVariableIndex(chunk, varNameNode->token->value, getLine(varNameNode));

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -399,10 +399,11 @@ static InterpretResult handleDefineGlobal(VM* vm, Value varNameVal) {
             *(sym->value) = array_val;
         }
     } else {
-        uint8_t type_name_idx = READ_BYTE();
+        uint16_t type_name_idx = READ_SHORT(vm);
         int str_len = 0;
+        uint16_t len_idx = 0;
         if (declaredType == TYPE_STRING) {
-            uint8_t len_idx = READ_BYTE();
+            len_idx = READ_SHORT(vm);
             Value len_val = vm->chunk->constants[len_idx];
             if (len_val.type == TYPE_INTEGER) {
                 str_len = (int)len_val.i_val;


### PR DESCRIPTION
## Summary
- allow global type names and string lengths to use 16-bit constant indices
- teach VM to read 16-bit type-name and string-length operands
- update bytecode length and disassembly for new operand widths

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy ./build/bin/pscal /tmp/hangman5.p`

------
https://chatgpt.com/codex/tasks/task_e_6896cc5a3ae8832a9fbc08b1652b3d86