### PR TITLE
Add opcode for initializing local pointer variables

### DIFF
--- a/src/compiler/bytecode.c
+++ b/src/compiler/bytecode.c
@@ -150,6 +150,8 @@ int getInstructionLength(BytecodeChunk* chunk, int offset) {
         case OP_WRITE_LN:
         case OP_INIT_LOCAL_FILE:
             return 2; // 1-byte opcode + 1-byte operand
+        case OP_INIT_LOCAL_POINTER:
+            return 4; // opcode + slot byte + 2-byte type name index
         case OP_INIT_LOCAL_ARRAY: {
             int current_pos = offset + 1; // after opcode
             current_pos++; // slot
@@ -488,6 +490,17 @@ int disassembleInstruction(BytecodeChunk* chunk, int offset, HashTable* procedur
             uint8_t slot = chunk->code[offset + 1];
             printf("%-16s %4d (slot)\n", "OP_INIT_LOCAL_FILE", slot);
             return offset + 2;
+        }
+        case OP_INIT_LOCAL_POINTER: {
+            uint8_t slot = chunk->code[offset + 1];
+            uint16_t name_idx = (uint16_t)(chunk->code[offset + 2] << 8) | chunk->code[offset + 3];
+            printf("%-16s %4d (slot) %4d", "OP_INIT_LOCAL_POINTER", slot, name_idx);
+            if (name_idx < chunk->constants_count &&
+                chunk->constants[name_idx].type == TYPE_STRING) {
+                printf(" '%s'", chunk->constants[name_idx].s_val);
+            }
+            printf("\n");
+            return offset + 4;
         }
         case OP_GET_LOCAL_ADDRESS: {
             uint8_t slot = chunk->code[offset + 1];

--- a/src/compiler/bytecode.h
+++ b/src/compiler/bytecode.h
@@ -61,6 +61,7 @@ typedef enum {
     OP_SET_LOCAL,     // Set local scoped variables
     OP_INIT_LOCAL_ARRAY, // Initialize local array variable
     OP_INIT_LOCAL_FILE,  // Initialize local file variable
+    OP_INIT_LOCAL_POINTER, // Initialize local pointer variable
     OP_GET_LOCAL_ADDRESS,
 
     OP_GET_FIELD_ADDRESS,

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -842,6 +842,17 @@ static void compileNode(AST* node, BytecodeChunk* chunk, int current_line_approx
                     } else if (node->var_type == TYPE_FILE) {
                         writeBytecodeChunk(chunk, OP_INIT_LOCAL_FILE, getLine(varNameNode));
                         writeBytecodeChunk(chunk, (uint8_t)slot, getLine(varNameNode));
+                    } else if (node->var_type == TYPE_POINTER) {
+                        writeBytecodeChunk(chunk, OP_INIT_LOCAL_POINTER, getLine(varNameNode));
+                        writeBytecodeChunk(chunk, (uint8_t)slot, getLine(varNameNode));
+
+                        const char* type_name = "";
+                        if (type_specifier_node && type_specifier_node->token && type_specifier_node->token->value) {
+                            type_name = type_specifier_node->token->value;
+                        } else if (actual_type_def_node && actual_type_def_node->token && actual_type_def_node->token->value) {
+                            type_name = actual_type_def_node->token->value;
+                        }
+                        emitConstantIndex16(chunk, addStringConstant(chunk, type_name), getLine(varNameNode));
                     }
                 }
             }

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1744,6 +1744,20 @@ comparison_error_label:
                 *target_slot = makeValueForType(TYPE_FILE, NULL, NULL);
                 break;
             }
+            case OP_INIT_LOCAL_POINTER: {
+                uint8_t slot = READ_BYTE();
+                uint16_t type_name_idx = READ_SHORT(vm);
+                AST* type_def = NULL;
+                Value type_name_val = vm->chunk->constants[type_name_idx];
+                if (type_name_val.type == TYPE_STRING && type_name_val.s_val && type_name_val.s_val[0] != '\0') {
+                    type_def = lookupType(type_name_val.s_val);
+                }
+                CallFrame* frame = &vm->frames[vm->frameCount - 1];
+                Value* target_slot = &frame->slots[slot];
+                freeValue(target_slot);
+                *target_slot = makeValueForType(TYPE_POINTER, type_def, NULL);
+                break;
+            }
             case OP_JUMP_IF_FALSE: {
                 uint16_t offset_val = READ_SHORT(vm);
                 Value condition_value = pop(vm);


### PR DESCRIPTION
## Summary
- define `OP_INIT_LOCAL_POINTER` to set up local pointer variables with base type info
- emit `OP_INIT_LOCAL_POINTER` for local pointer declarations and decode in bytecode
- implement VM handling of `OP_INIT_LOCAL_POINTER`

## Testing
- `cmake .. && make -j$(nproc)`
- `./bin/pscal ../tmp_local_pointer.p`


------
https://chatgpt.com/codex/tasks/task_e_6896ce0d9878832aa5bd7787bf701044