### PR TITLE
Support more arithmetic in compile-time evaluation

### DIFF
--- a/Tests/CompileTimeBounds.p
+++ b/Tests/CompileTimeBounds.p
@@ -1,0 +1,11 @@
+program CompileTimeBounds;
+
+var
+  arrMul: array[1..2*3] of integer;
+  arrMinus: array[1..10-4] of integer;
+  arrDiv: array[1..8/2] of integer;
+  arrMod: array[1..20 mod 7] of integer;
+
+begin
+  arrMul[1] := 42;
+end.

--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -4,7 +4,7 @@
 PSCAL = ../pscal
 
 # List of test files
-TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p StringTruncationTest.p LowHighCharTest.p GlobalEnumTest.p EnumComparisonTest.p EnumCaseTest.p RecordFieldIndexTest.p
+TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p StringTruncationTest.p LowHighCharTest.p GlobalEnumTest.p EnumComparisonTest.p EnumCaseTest.p RecordFieldIndexTest.p CompileTimeBounds.p
 
 all: test
 

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -374,14 +374,60 @@ Value evaluateCompileTimeValue(AST* node) {
                     right_val.type != TYPE_VOID && right_val.type != TYPE_UNKNOWN) {
 
                     if (left_val.type == TYPE_INTEGER && right_val.type == TYPE_INTEGER) {
-                        if (node->token->type == TOKEN_INT_DIV) {
-                            if (right_val.i_val == 0) {
-                                fprintf(stderr, "Compile-time Error: Division by zero in constant expression.\n");
-                            } else {
-                                result = makeInt(left_val.i_val / right_val.i_val);
-                            }
-                        } else if (node->token->type == TOKEN_PLUS) {
-                            result = makeInt(left_val.i_val + right_val.i_val);
+                        switch (node->token->type) {
+                            case TOKEN_INT_DIV:
+                            case TOKEN_SLASH: // Treat '/' as integer division for const eval when both operands are integers
+                                if (right_val.i_val == 0) {
+                                    fprintf(stderr, "Compile-time Error: Division by zero in constant expression.\n");
+                                } else {
+                                    result = makeInt(left_val.i_val / right_val.i_val);
+                                }
+                                break;
+                            case TOKEN_PLUS:
+                                result = makeInt(left_val.i_val + right_val.i_val);
+                                break;
+                            case TOKEN_MINUS:
+                                result = makeInt(left_val.i_val - right_val.i_val);
+                                break;
+                            case TOKEN_MUL:
+                                result = makeInt(left_val.i_val * right_val.i_val);
+                                break;
+                            case TOKEN_MOD:
+                                if (right_val.i_val == 0) {
+                                    fprintf(stderr, "Compile-time Error: Division by zero in constant expression.\n");
+                                } else {
+                                    result = makeInt(left_val.i_val % right_val.i_val);
+                                }
+                                break;
+                            default:
+                                break;
+                        }
+                    } else if (left_val.type == TYPE_REAL || right_val.type == TYPE_REAL) {
+                        double a = (left_val.type == TYPE_REAL) ? left_val.r_val : (double)left_val.i_val;
+                        double b = (right_val.type == TYPE_REAL) ? right_val.r_val : (double)right_val.i_val;
+                        switch (node->token->type) {
+                            case TOKEN_PLUS:
+                                result = makeReal(a + b);
+                                break;
+                            case TOKEN_MINUS:
+                                result = makeReal(a - b);
+                                break;
+                            case TOKEN_MUL:
+                                result = makeReal(a * b);
+                                break;
+                            case TOKEN_SLASH:
+                                if (b == 0.0) {
+                                    fprintf(stderr, "Compile-time Error: Division by zero in constant expression.\n");
+                                } else {
+                                    result = makeReal(a / b);
+                                }
+                                break;
+                            case TOKEN_INT_DIV:
+                            case TOKEN_MOD:
+                                fprintf(stderr, "Compile-time Error: Invalid operator for real constant expression.\n");
+                                break;
+                            default:
+                                break;
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- extend compiler constant evaluator to support multiplication, subtraction, division, and modulo for integers and reals
- add regression test exercising array bounds with arithmetic expressions

## Testing
- `make -C Tests test`
- `./pscal Tests/CompileTimeBounds.p`


------
https://chatgpt.com/codex/tasks/task_e_6896e16eada0832ab36799a391f7af44