### PR TITLE
Rename SDLInteractiveMandelbrot constants to avoid globals

### DIFF
--- a/Examples/SDLInteractiveMandelbrot
+++ b/Examples/SDLInteractiveMandelbrot
@@ -4,13 +4,13 @@ PROGRAM SDLTextureMandelbrotZoomFixed;
 USES CRT;
 
 CONST
-  WindowWidth   = 640;
-  WindowHeight  = 480;
-  WindowTitle   = 'Mandelbrot (Zoom Fixed - LMB:Zoom, RMB:Reset, Q:Quit)';
-  MaxIterations = 50;
-  ZoomFactor    = 2.0;
-  BytesPerPixel = 4;
-  TextureUpdateIntervalRows = 1;
+  MandelWindowWidth   = 640;
+  MandelWindowHeight  = 480;
+  MandelWindowTitle   = 'Mandelbrot (Zoom Fixed - LMB:Zoom, RMB:Reset, Q:Quit)';
+  MandelMaxIterations = 50;
+  MandelZoomFactor    = 2.0;
+  MandelBytesPerPixel = 4;
+  MandelTextureUpdateIntervalRows = 1;
 
   InitialMinRe  = -2.0;
   InitialMaxRe  =  1.0;
@@ -23,7 +23,7 @@ CONST
   StatusLineY    = 10;
 
 TYPE
-  FlatPixelBuffer = ARRAY[0..(WindowWidth * WindowHeight * BytesPerPixel) - 1] OF Byte;
+  FlatPixelBuffer = ARRAY[0..(MandelWindowWidth * MandelWindowHeight * MandelBytesPerPixel) - 1] OF Byte;
 
 VAR
   x0, y0, zx, zy, zxTemp : Real;
@@ -49,9 +49,9 @@ VAR
 // This procedure recalculates MaxIm and scaling factors based on CURRENT MinRe, MaxRe, MinIm
 PROCEDURE UpdateScalingAndDependentViewParams;
 BEGIN
-  // GetMaxX/Y are based on InitGraph, which uses WindowWidth/Height constants for texture too
-  ViewPixelWidth  := WindowWidth;  // Assuming texture matches window size
-  ViewPixelHeight := WindowHeight;
+  // GetMaxX/Y are based on InitGraph, which uses MandelWindowWidth/Height constants for texture too
+  ViewPixelWidth  := MandelWindowWidth;  // Assuming texture matches window size
+  ViewPixelHeight := MandelWindowHeight;
 
   ReRange := MaxRe - MinRe;
   IF ViewPixelWidth > 0 THEN
@@ -71,7 +71,7 @@ BEGIN
   // Update console display
   GotoXY(1, 2); ClrEol; Write('View: Re[', MinRe:0:4,'..',MaxRe:0:4,'], Im[',MinIm:0:4,'..',MaxIm:0:4,']');
   GotoXY(1, ControlsStartY + 4); ClrEol;
-  Write('Max Iter: ', MaxIterations, ', Zoom Factor: ', ZoomFactor:0:1, ', Texture ID: ', MandelTextureID); ClrEol;
+  Write('Max Iter: ', MandelMaxIterations, ', Zoom Factor: ', MandelZoomFactor:0:1, ', Texture ID: ', MandelTextureID); ClrEol;
 END;
 
 PROCEDURE ResetViewToInitial;
@@ -99,18 +99,18 @@ BEGIN
     FOR LocalPx := 0 TO ViewPixelWidth - 1 DO BEGIN
       x0 := MinRe + (LocalPx * ScaleRe); y0 := MaxIm - (LocalPy * ScaleIm);
       zx := 0.0; zy := 0.0; Iteration := 0;
-      WHILE (zx*zx + zy*zy <= 4.0) AND (Iteration < MaxIterations) DO
+      WHILE (zx*zx + zy*zy <= 4.0) AND (Iteration < MandelMaxIterations) DO
       BEGIN zxTemp := zx*zx - zy*zy + x0; zy := 2*zx*zy + y0; zx := zxTemp; Iteration := Iteration + 1; END;
-      IF Iteration = MaxIterations THEN BEGIN R_calc := 0; G_calc := 0; B_calc := 0; END
+      IF Iteration = MandelMaxIterations THEN BEGIN R_calc := 0; G_calc := 0; B_calc := 0; END
       ELSE BEGIN
         R_calc := ((Iteration * 12) MOD 256 + 256) MOD 256; G_calc := ((Iteration * 8 + 80) MOD 256 + 256) MOD 256; B_calc := ((Iteration * 5 + 160) MOD 256 + 256) MOD 256;
       END;
-      BufferBaseIdx := (LocalPy * ViewPixelWidth + LocalPx) * BytesPerPixel;
+      BufferBaseIdx := (LocalPy * ViewPixelWidth + LocalPx) * MandelBytesPerPixel;
       PixelData[BufferBaseIdx + 0] := R_calc; PixelData[BufferBaseIdx + 1] := G_calc; PixelData[BufferBaseIdx + 2] := B_calc; PixelData[BufferBaseIdx + 3] := 255;
     END; // Px
     PercentDone := Trunc( (LocalPy + 1) * 100.0 / ViewPixelHeight );
     GotoXY(1, StatusLineY); ClrEol; Write('Processing: Row ', LocalPy + 1, '/', ViewPixelHeight, '. ~', PercentDone, '%');
-    IF (((LocalPy + 1) MOD TextureUpdateIntervalRows = 0) OR (LocalPy = ViewPixelHeight - 1)) THEN
+    IF (((LocalPy + 1) MOD MandelTextureUpdateIntervalRows = 0) OR (LocalPy = ViewPixelHeight - 1)) THEN
     BEGIN UpdateAndDisplayTextureInProgress; END;
   END; // Py
   GotoXY(1, StatusLineY); ClrEol; Write('Render complete. Click, R-Click, or Q.');
@@ -125,8 +125,8 @@ BEGIN // Main Program
   GotoXY(1, ControlsStartY + 3); Write('- Q Key (in terminal): Quit');
   GotoXY(1, ControlsStartY + 5); Write('----------------------------------------------------------');
 
-  InitGraph(WindowWidth, WindowHeight, WindowTitle);
-  MandelTextureID := CreateTexture(WindowWidth, WindowHeight);
+  InitGraph(MandelWindowWidth, MandelWindowHeight, MandelWindowTitle);
+  MandelTextureID := CreateTexture(MandelWindowWidth, MandelWindowHeight);
   IF MandelTextureID < 0 THEN BEGIN GotoXY(1, StatusLineY); WriteLn('Error: No Texture! Halting.'); ReadKey; CloseGraph; NormVideo; ShowCursor; HALT; END;
 
   ResetViewToInitial; // Sets MinRe,MaxRe,MinIm to defaults AND calculates scales/MaxIm
@@ -149,7 +149,7 @@ BEGIN // Main Program
       IF NOT RedrawNeeded THEN BEGIN
         NewCenterX := MinRe + (MouseX * ScaleRe); NewCenterY := MaxIm - (MouseY * ScaleIm);
         CurrentViewWidthRe  := MaxRe - MinRe; CurrentViewHeightIm := MaxIm - MinIm;
-        NewViewWidthRe  := CurrentViewWidthRe / ZoomFactor; NewViewHeightIm := CurrentViewHeightIm / ZoomFactor;
+        NewViewWidthRe  := CurrentViewWidthRe / MandelZoomFactor; NewViewHeightIm := CurrentViewHeightIm / MandelZoomFactor;
         MinRe := NewCenterX - (NewViewWidthRe / 2.0); MaxRe := NewCenterX + (NewViewWidthRe / 2.0);
         MinIm := NewCenterY - (NewViewHeightIm / 2.0);
         UpdateScalingAndDependentViewParams; // <<<< CALL THE CORRECT PROCEDURE HERE


### PR DESCRIPTION
## Summary
- make SDLInteractiveMandelbrot constants unique with a Mandel prefix

## Testing
- `./bin/pscal ../Examples/SDLInteractiveMandelbrot 2>&1 | head -n 50` *(fails: Undefined procedure or function 'updatetexture', 'cleardevice', 'rendercopy', 'updatescreen', 'graphloop', 'initgraph', 'createtexture', 'closegraph', 'getmousestate', 'destroytexture')*


------
https://chatgpt.com/codex/tasks/task_e_6896e9290e90832ab544beb110bc89d0