### PR TITLE
Use 16-bit constant indices for array bounds

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -763,7 +763,7 @@ static void compileNode(AST* node, BytecodeChunk* chunk, int current_line_approx
                                     
                                     // Use the new helper for the lower bound
                                     if (lower_b.type == TYPE_INTEGER) {
-                                        writeBytecodeChunk(chunk, (uint8_t)addIntConstant(chunk, lower_b.i_val), getLine(varNameNode));
+                                        emitConstantIndex16(chunk, addIntConstant(chunk, lower_b.i_val), getLine(varNameNode));
                                     } else {
                                         fprintf(stderr, "L%d: Compiler error: Array bound did not evaluate to a constant integer.\n", getLine(varNameNode));
                                         compiler_had_error = true;
@@ -772,7 +772,7 @@ static void compileNode(AST* node, BytecodeChunk* chunk, int current_line_approx
                                     
                                     // Use the new helper for the upper bound
                                     if (upper_b.type == TYPE_INTEGER) {
-                                        writeBytecodeChunk(chunk, (uint8_t)addIntConstant(chunk, upper_b.i_val), getLine(varNameNode));
+                                        emitConstantIndex16(chunk, addIntConstant(chunk, upper_b.i_val), getLine(varNameNode));
                                     } else {
                                         fprintf(stderr, "L%d: Compiler error: Array bound did not evaluate to a constant integer.\n", getLine(varNameNode));
                                         compiler_had_error = true;
@@ -782,8 +782,8 @@ static void compileNode(AST* node, BytecodeChunk* chunk, int current_line_approx
                                 } else {
                                     fprintf(stderr, "L%d: Compiler error: Malformed array definition for '%s'.\n", getLine(varNameNode), varNameNode->token->value);
                                     compiler_had_error = true;
-                                    writeBytecodeChunk(chunk, 0, getLine(varNameNode));
-                                    writeBytecodeChunk(chunk, 0, getLine(varNameNode));
+                                    emitShort(chunk, 0, getLine(varNameNode));
+                                    emitShort(chunk, 0, getLine(varNameNode));
                                 }
                             }
 
@@ -876,7 +876,7 @@ static void compileNode(AST* node, BytecodeChunk* chunk, int current_line_approx
                                 Value upper_b = evaluateCompileTimeValue(subrange->right);
 
                                 if (lower_b.type == TYPE_INTEGER) {
-                                    writeBytecodeChunk(chunk, (uint8_t)addIntConstant(chunk, lower_b.i_val), getLine(varNameNode));
+                                    emitConstantIndex16(chunk, addIntConstant(chunk, lower_b.i_val), getLine(varNameNode));
                                 } else {
                                     fprintf(stderr, "L%d: Compiler error: Array bound did not evaluate to a constant integer.\n", getLine(varNameNode));
                                     compiler_had_error = true;
@@ -884,7 +884,7 @@ static void compileNode(AST* node, BytecodeChunk* chunk, int current_line_approx
                                 freeValue(&lower_b);
 
                                 if (upper_b.type == TYPE_INTEGER) {
-                                    writeBytecodeChunk(chunk, (uint8_t)addIntConstant(chunk, upper_b.i_val), getLine(varNameNode));
+                                    emitConstantIndex16(chunk, addIntConstant(chunk, upper_b.i_val), getLine(varNameNode));
                                 } else {
                                     fprintf(stderr, "L%d: Compiler error: Array bound did not evaluate to a constant integer.\n", getLine(varNameNode));
                                     compiler_had_error = true;
@@ -894,8 +894,8 @@ static void compileNode(AST* node, BytecodeChunk* chunk, int current_line_approx
                             } else {
                                 fprintf(stderr, "L%d: Compiler error: Malformed array definition for '%s'.\n", getLine(varNameNode), varNameNode->token->value);
                                 compiler_had_error = true;
-                                writeBytecodeChunk(chunk, 0, getLine(varNameNode));
-                                writeBytecodeChunk(chunk, 0, getLine(varNameNode));
+                                emitShort(chunk, 0, getLine(varNameNode));
+                                emitShort(chunk, 0, getLine(varNameNode));
                             }
                         }
 

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -338,8 +338,13 @@ static InterpretResult handleDefineGlobal(VM* vm, Value varNameVal) {
         }
 
         for (int i = 0; i < dimension_count; i++) {
-            uint8_t lower_idx = READ_BYTE();
-            uint8_t upper_idx = READ_BYTE();
+            uint16_t lower_idx = READ_SHORT(vm);
+            uint16_t upper_idx = READ_SHORT(vm);
+            if (lower_idx >= vm->chunk->constants_count || upper_idx >= vm->chunk->constants_count) {
+                runtimeError(vm, "VM Error: Array bound constant index out of range for '%s'.", varNameVal.s_val);
+                free(lower_bounds); free(upper_bounds);
+                return INTERPRET_RUNTIME_ERROR;
+            }
             Value lower_val = vm->chunk->constants[lower_idx];
             Value upper_val = vm->chunk->constants[upper_idx];
             if (lower_val.type != TYPE_INTEGER || upper_val.type != TYPE_INTEGER) {
@@ -1704,8 +1709,13 @@ comparison_error_label:
                 }
 
                 for (int i = 0; i < dimension_count; i++) {
-                    uint8_t lower_idx = READ_BYTE();
-                    uint8_t upper_idx = READ_BYTE();
+                    uint16_t lower_idx = READ_SHORT(vm);
+                    uint16_t upper_idx = READ_SHORT(vm);
+                    if (lower_idx >= vm->chunk->constants_count || upper_idx >= vm->chunk->constants_count) {
+                        runtimeError(vm, "VM Error: Array bound constant index out of range.");
+                        free(lower_bounds); free(upper_bounds);
+                        return INTERPRET_RUNTIME_ERROR;
+                    }
                     Value lower_val = vm->chunk->constants[lower_idx];
                     Value upper_val = vm->chunk->constants[upper_idx];
                     if (lower_val.type != TYPE_INTEGER || upper_val.type != TYPE_INTEGER) {


### PR DESCRIPTION
## Summary
- Preserve large constant indices by emitting 16-bit operands for array bounds
- Update VM and disassembler to read 16-bit bound indices for global and local arrays
- Adjust error handling to emit 16-bit placeholders

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `./build/bin/pscal --dump-bytecode Examples/SDLInteractiveMandelbrot` *(fails: Undefined procedure or function 'updatetexture')*


------
https://chatgpt.com/codex/tasks/task_e_6896ed3e2adc832a8b02307f3f541b95