### PR TITLE
Handle enum arguments in succ

### DIFF
--- a/Tests/TypeTestSuite
+++ b/Tests/TypeTestSuite
@@ -435,8 +435,17 @@ begin
   AssertEqualInt(3, ord(cYellow), 'Ord(cYellow)');
   AssertEqualEnum(cRed, low(TColor), 'Low(TColor)');
   AssertEqualEnum(cYellow, high(TColor), 'High(TColor)');
+
+  // Succ on enum literals
   AssertEqualEnum(cGreen, succ(cRed), 'Succ(cRed)');
   AssertEqualEnum(cBlue, succ(cGreen), 'Succ(cGreen)');
+
+  // Succ on enum variables
+  testEnum := cRed;
+  testEnum := succ(testEnum);
+  AssertEqualEnum(cGreen, testEnum, 'Succ(testEnum=cRed)');
+  testEnum := succ(testEnum);
+  AssertEqualEnum(cBlue, testEnum, 'Succ(testEnum=cGreen)');
   // AssertEqualEnum(cBlue, pred(cYellow), 'Pred(cYellow)');
 
   // Test assignment using Ord (if supported)


### PR DESCRIPTION
## Summary
- ensure `succ` resolves enum types, checks bounds, and returns the next enumerator
- keep enum metadata on results and test enum succession on literals and variables

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "SDL2" with any of the following names: SDL2Config.cmake sdl2-config.cmake)*
- `apt-get update` *(fails: repository http://archive.ubuntu.com/ubuntu noble InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689746d845e0832a89de1068be79496c