### PR TITLE
Handle low(char) as character type and test ordinal zero

### DIFF
--- a/Tests/TypeTestSuite
+++ b/Tests/TypeTestSuite
@@ -127,10 +127,10 @@ end;
 procedure AssertEqualChar(expected, actual: char; testName: string);
 begin
   write('START: ', testName, ': ');
-  if expected = actual then
+  if ord(expected) = ord(actual) then
     writeln('PASS')
   else
-    writeln('FAIL (expected: ''', expected, ''', got: ''', actual, ''')');
+    writeln('FAIL (expected ord: ', ord(expected), ', got ord: ', ord(actual), ')');
 end;
 
 procedure AssertEqualBool(expected, actual: boolean; testName: string);
@@ -309,6 +309,7 @@ begin
 
   // Low / High / Succ / Pred (if implemented)
   AssertEqualChar(#0, low(char), 'Low(char)');   // #0 is ASCII NUL
+  AssertEqualInt(0, ord(low(char)), 'Ord(Low(Char))');
   AssertEqualChar(#255, high(char), 'High(char)'); // Depends on char implementation (often 8-bit)
   AssertEqualChar('B', succ('A'), 'Succ(A)');
   // AssertEqualChar('A', pred('B'), 'Pred(B)'); // Uncomment if Pred is implemented

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -2312,7 +2312,8 @@ Value executeBuiltinLow(AST *node) {
         // For simplicity let's return 0 for now as MIN_INT isn't defined
         // return makeInt(0);
     } else if (strcasecmp(typeName, "char") == 0) {
-        return makeChar((char)0); // Low(Char) is ASCII 0
+        // Low(Char) is ASCII NUL (ordinal 0) and must stay TYPE_CHAR
+        return makeChar(0);
     } else if (strcasecmp(typeName, "boolean") == 0) {
         return makeBoolean(0); // Low(Boolean) is False (ordinal 0)
     } else if (strcasecmp(typeName, "byte") == 0) {


### PR DESCRIPTION
## Summary
- ensure `low(char)` returns a character value with ordinal zero
- compare characters by ordinal to handle NUL
- test that `ord(low(char))` equals 0

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "SDL2")*

------
https://chatgpt.com/codex/tasks/task_e_689746d1f3c8832ab678d2a60a36e43d