### PR TITLE
Improve readln type detection

### DIFF
--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -4,7 +4,7 @@
 PSCAL = ../pscal
 
 # List of test files
-TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p
+TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p ReadlnString.p
 
 all: test
 

--- a/Tests/ReadlnString.p
+++ b/Tests/ReadlnString.p
@@ -1,0 +1,23 @@
+program ReadlnStringTest;
+
+var
+  f: Text;
+  s: string;
+
+begin
+  assign(f, 'readln_test.txt');
+  rewrite(f);
+  writeln(f, 'Test');
+  close(f);
+
+  assign(f, 'readln_test.txt');
+  reset(f);
+  readln(f, s);
+  close(f);
+
+  if s = 'Test' then
+    writeln('PASS')
+  else
+    writeln('FAIL: ', s);
+end.
+


### PR DESCRIPTION
## Summary
- Resolve `readln` target types using `resolveLValueToPtr` and handle string inputs with a dynamically sized buffer passed via `makeString`.
- Add regression test that writes and reads a string via `readln`.

## Testing
- `cmake -S . -B build` *(fails: Could not find SDL2)*
- `make -C Tests test` *(fails: ../pscal not found)*

------
https://chatgpt.com/codex/tasks/task_e_689746cae318832ab4476dbadccf7c4a