### PR TITLE
Handle ordinal return types for succ, low, high

### DIFF
--- a/src/ast.h
+++ b/src/ast.h
@@ -41,5 +41,5 @@ bool verifyASTLinks(AST *node, AST *expectedParent);
 void freeTypeTableASTNodes(void);
 AST* findDeclarationInScope(const char* varName, AST* currentScopeNode);
 AST* findStaticDeclarationInAST(const char* varName, AST* currentScopeNode, AST* globalProgramNode);
-VarType getBuiltinReturnType(const char* name);
+VarType getBuiltInFunctionReturnType(AST *callNode);
 #endif // AST_H


### PR DESCRIPTION
## Summary
- add `getBuiltInFunctionReturnType` to infer built-in return type from call
- make procedure call annotation use new return-type helper
- expose new helper in `ast.h`

## Testing
- `cmake .. && make` *(fails: Could not find package SDL2)*
- `make -C Tests test` *(fails: ../pscal not found)*

------
https://chatgpt.com/codex/tasks/task_e_68975fe10ec4832ab5c03d0da8b45b6c