### PR TITLE
docs: describe building without SDL

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ make
 
 Binaries will be in ../build/bin
 
+### Building without SDL
+
+To build without SDL support, run:
+
+```
+mkdir build && cd build && cmake -DSDL=OFF .. && make
+```
+
+SDL-dependent examples and tests will be skipped when this flag is off.
+
 You will also need to do something similar to the following to get units and the code in Examples/ and Tests/ to work...
 
 ```


### PR DESCRIPTION
## Summary
- document how to build the project without SDL support
- note that SDL-dependent examples and tests are skipped when SDL is disabled

## Testing
- `mkdir -p build && cd build && cmake -DSDL=OFF .. && make && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68976ff699e4832ab2256463e26a9ac5