### PR TITLE
Conditionally run SDL tests and examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,6 +235,9 @@ add_pscal_executable(pscal)
 add_pscal_executable(dscal)
 # add_pscal_executable(hscal) // Lets not build this normally
 
+# ---- Examples ----
+add_subdirectory(Examples)
+
 # ---- optional install ----
 include(GNUInstallDirs)
 install(TARGETS pscal dscal

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.24)
+project(pscal_examples NONE)
+
+# Path to the pscal interpreter built by main project
+set(PSCAL_BIN ${CMAKE_BINARY_DIR}/bin/pscal)
+
+# Basic example target
+add_custom_target(run_basic_examples
+    COMMAND ${CMAKE_COMMAND} -E echo "Running basic examples..."
+    COMMAND ${PSCAL_BIN} ${CMAKE_CURRENT_SOURCE_DIR}/AreaCalculation.p
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+# SDL examples are only run when SDL option is enabled
+if(SDL)
+    add_custom_target(run_sdl_examples
+        COMMAND ${CMAKE_COMMAND} -E echo "Running SDL examples..."
+        COMMAND ${PSCAL_BIN} ${CMAKE_CURRENT_SOURCE_DIR}/SDLSimplePong
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+else()
+    add_custom_target(run_sdl_examples
+        COMMAND ${CMAKE_COMMAND} -E echo "Skipping SDL examples: SDL option is OFF"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+endif()

--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -6,15 +6,33 @@ PSCAL = ../build/bin/pscal
 # List of test files
 TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p StringTruncationTest.p LowHighCharTest.p GlobalEnumTest.p EnumComparisonTest.p EnumCaseTest.p RecordFieldIndexTest.p CompileTimeBounds.p
 
+# SDL-specific tests
+SDL_TESTS = SDLFeaturesTest SDLRenderCopyTest.p
+
+# Detect if SDL was enabled in the build (via CMakeCache)
+SDL_ENABLED := $(shell grep -q '^SDL:BOOL=ON$$' ../build/CMakeCache.txt 2>/dev/null && echo 1 || echo 0)
+
 all: test
 
 test:
 	@echo "Running tests..."
 	@for t in $(TESTS); do \
-		echo "----------------------------------------------------"; \
-		echo "Running $$t:"; \
-		$(PSCAL) $$t; \
-		echo "----------------------------------------------------"; \
-		echo ""; \
+	echo "----------------------------------------------------"; \
+	echo "Running $$t:"; \
+	$(PSCAL) $$t; \
+	echo "----------------------------------------------------"; \
+	echo ""; \
 	done
-
+	@if [ $(SDL_ENABLED) -eq 1 ]; then \
+	echo "Running SDL tests..."; \
+	for t in $(SDL_TESTS); do \
+	echo "----------------------------------------------------"; \
+	echo "Running $$t:"; \
+	$(PSCAL) $$t; \
+	echo "----------------------------------------------------"; \
+	echo ""; \
+	done; \
+	else \
+	echo "Skipping SDL tests (SDL option is OFF)"; \
+	fi
+	


### PR DESCRIPTION
## Summary
- Detect SDL build option in Tests/Makefile and only run SDL test cases when enabled
- Add Examples/CMakeLists.txt with conditional SDL example targets and wire it into main CMakeLists.txt

## Testing
- `make -C Tests`
- `cmake --build build --target run_sdl_examples`


------
https://chatgpt.com/codex/tasks/task_e_68976ffa864c832a9a5671dc71d3c014