### PR TITLE
Handle succ for enum values

### DIFF
--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -4,7 +4,7 @@
 PSCAL = ../build/bin/pscal
 
 # List of test files
-TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p StringTruncationTest.p LowHighCharTest.p GlobalEnumTest.p EnumComparisonTest.p EnumCaseTest.p RecordFieldIndexTest.p CompileTimeBounds.p
+TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p StringTruncationTest.p LowHighCharTest.p GlobalEnumTest.p EnumComparisonTest.p EnumCaseTest.p RecordFieldIndexTest.p CompileTimeBounds.p SuccEnumTest.p
 
 all: test
 

--- a/Tests/SuccEnumTest.p
+++ b/Tests/SuccEnumTest.p
@@ -1,0 +1,17 @@
+program EnumSuccTest;
+
+type
+  TColor = (cRed, cGreen, cBlue, cYellow);
+
+procedure AssertEqualEnum(expected, actual: TColor; testName: string);
+begin
+  if ord(expected) = ord(actual) then
+    writeln(testName, ': PASS')
+  else
+    writeln(testName, ': FAIL (expected ', ord(expected), ', got ', ord(actual), ')');
+end;
+
+begin
+  AssertEqualEnum(cGreen, succ(cRed), 'Succ(cRed)');
+  AssertEqualEnum(cYellow, succ(cBlue), 'Succ(cBlue)');
+end.

--- a/Tests/TypeTestSuite
+++ b/Tests/TypeTestSuite
@@ -439,6 +439,7 @@ begin
   AssertEqualEnum(cYellow, high(TColor), 'High(TColor)');
   AssertEqualEnum(cGreen, succ(cRed), 'Succ(cRed)');
   AssertEqualEnum(cBlue, succ(cGreen), 'Succ(cGreen)');
+  AssertEqualEnum(cYellow, succ(cBlue), 'Succ(cBlue)');
   // AssertEqualEnum(cBlue, pred(cYellow), 'Pred(cYellow)');
 
   // Test assignment using Ord (if supported)

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -211,7 +211,14 @@ Value vm_builtin_succ(VM* vm, int arg_count, Value* args) {
         case TYPE_INTEGER: return makeInt(arg.i_val + 1);
         case TYPE_CHAR:    return makeChar(arg.c_val + 1);
         case TYPE_BOOLEAN: return makeBoolean(arg.i_val + 1 > 1 ? 1 : arg.i_val + 1);
-        // Enums would require more type info
+        case TYPE_ENUM: {
+            int ordinal = arg.enum_val.ordinal;
+            if (arg.enum_meta && ordinal + 1 >= arg.enum_meta->member_count) {
+                runtimeError(vm, "Succ enum overflow.");
+                return makeVoid();
+            }
+            return makeEnum(arg.enum_val.enum_name, ordinal + 1);
+        }
         default:
             runtimeError(vm, "Succ requires an ordinal type argument. Got %s.", varTypeToString(arg.type));
             return makeVoid();


### PR DESCRIPTION
## Summary
- support `succ` for enums, including bounds checking against metadata
- expand TypeTestSuite and add a dedicated SuccEnum test

## Testing
- `cmake .. && make -j4`
- `cd Tests && make test`

------
https://chatgpt.com/codex/tasks/task_e_6897702df154832abab9f30a2fa25e05