### PR TITLE
Handle enum metadata in succ builtin

### DIFF
--- a/Tests/SuccEnumTest.p
+++ b/Tests/SuccEnumTest.p
@@ -13,5 +13,6 @@ end;
 
 begin
   AssertEqualEnum(cGreen, succ(cRed), 'Succ(cRed)');
+  AssertEqualEnum(cBlue, succ(cGreen), 'Succ(cGreen)');
   AssertEqualEnum(cYellow, succ(cBlue), 'Succ(cBlue)');
 end.

--- a/Tests/TypeTestSuite
+++ b/Tests/TypeTestSuite
@@ -440,6 +440,8 @@ begin
   AssertEqualEnum(cGreen, succ(cRed), 'Succ(cRed)');
   AssertEqualEnum(cBlue, succ(cGreen), 'Succ(cGreen)');
   AssertEqualEnum(cYellow, succ(cBlue), 'Succ(cBlue)');
+  testEnum := succ(cRed);
+  AssertEqualEnum(cBlue, succ(testEnum), 'Succ(Succ(cRed))');
   // AssertEqualEnum(cBlue, pred(cYellow), 'Pred(cYellow)');
 
   // Test assignment using Ord (if supported)


### PR DESCRIPTION
## Summary
- fix `succ` for enum values by checking `enum_meta` overflow and copying metadata to results
- ensure interpreter variant of `succ` preserves enum metadata
- expand enum succession tests for single and chained calls

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `make -C Tests`
- `./build/bin/pscal Tests/TypeTestSuite` *(fails: Field 'name' not found in record)*

------
https://chatgpt.com/codex/tasks/task_e_689773b11954832a80aff55b63fce633