### PR TITLE
Handle fixed-length strings in value copying

### DIFF
--- a/src/backend_ast/interpreter.c
+++ b/src/backend_ast/interpreter.c
@@ -2548,7 +2548,20 @@ Value makeCopyOfValue(const Value *src) {
 
     switch (src->type) {
         case TYPE_STRING:
-            if (src->s_val) {
+            if (src->max_length > 0) {
+                v.s_val = malloc(src->max_length + 1);
+                if (!v.s_val) {
+                    fprintf(stderr, "Memory allocation failed in makeCopyOfValue (string)\n");
+                    EXIT_FAILURE_HANDLER();
+                }
+                if (src->s_val) {
+                    strncpy(v.s_val, src->s_val, src->max_length);
+                    v.s_val[src->max_length] = '\0';
+                } else {
+                    v.s_val[0] = '\0';
+                }
+                v.max_length = src->max_length;
+            } else if (src->s_val) {
                 size_t len = strlen(src->s_val);
                 v.s_val = malloc(len + 1);
                 if (!v.s_val) {


### PR DESCRIPTION
## Summary
- Copy fixed-length strings using their declared max length
- Preserve max_length when duplicating string values

## Testing
- `./build/bin/pscal Tests/TypeTestSuite` *(fails: Runtime Error: Operands must be numbers for arithmetic operation '+' (or strings/chars for '+'). Got SET and SET)*

------
https://chatgpt.com/codex/tasks/task_e_6897bc53bd00832a9592d0f5550ae80e