### PR TITLE
Ensure Low(char) test uses chr(0)

### DIFF
--- a/Tests/TypeTestSuite
+++ b/Tests/TypeTestSuite
@@ -308,7 +308,7 @@ begin
   AssertEqualChar('1', upcase('1'), 'Upcase(1)');
 
   // Low / High / Succ / Pred (if implemented)
-  AssertEqualChar(#0, low(char), 'Low(char)');   // #0 is ASCII NUL
+  AssertEqualChar(chr(0), low(char), 'Low(char)');   // chr(0) is ASCII NUL
   AssertEqualChar(#255, high(char), 'High(char)'); // Depends on char implementation (often 8-bit)
   AssertEqualInt(0, ord(low(char)), 'Ord(Low(char))');
   AssertEqualInt(255, ord(high(char)), 'Ord(High(char))');


### PR DESCRIPTION
## Summary
- confirm vm_builtin_low returns makeChar(0) for TYPE_CHAR
- use chr(0) in TypeTestSuite's Low(char) assertion so null char is explicit

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `build/bin/pscal Tests/TypeTestSuite`


------
https://chatgpt.com/codex/tasks/task_e_6897cd173e14832a9783ef71b38edbcc