### PR TITLE
Ensure Tests Makefile only runs existing test files

### DIFF
--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -4,7 +4,8 @@
 PSCAL = ../pscal
 
 # List of test files
-TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p ReadlnString.p
+# Use all .p files in this directory to avoid references to removed tests
+TESTS := $(wildcard *.p)
 
 all: test
 


### PR DESCRIPTION
## Summary
- Automatically gather Pascal test files for the test suite
- Remove references to deleted tests

## Testing
- `make -C Tests test` *(fails: `../pscal: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6897dafc0f1c832ab92bdf1b624c06c4