### PR TITLE
Support nested procedure scopes

### DIFF
--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -4,7 +4,7 @@
 PSCAL = ../build/bin/pscal
 
 # List of test files
-TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p StringTruncationTest.p LowHighCharTest.p GlobalEnumTest.p EnumComparisonTest.p EnumCaseTest.p RecordFieldIndexTest.p CompileTimeBounds.p SuccEnumTest.p
+TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p StringTruncationTest.p LowHighCharTest.p GlobalEnumTest.p EnumComparisonTest.p EnumCaseTest.p RecordFieldIndexTest.p CompileTimeBounds.p SuccEnumTest.p NestedRoutine_Suite.p
 
 # SDL-specific tests
 SDL_TESTS = SDLFeaturesTest SDLRenderCopyTest.p

--- a/Tests/NestedRoutine_Suite.p
+++ b/Tests/NestedRoutine_Suite.p
@@ -1,0 +1,28 @@
+program NestedRoutine_Suite;
+
+var g: integer;
+
+procedure Outer;
+
+    procedure InnerProc;
+    begin
+        g := g + 1;
+    end;
+
+    function InnerFunc: integer;
+    begin
+        InnerProc;
+        InnerFunc := g;
+    end;
+
+begin
+    g := 5;
+    InnerProc;
+    writeln('InnerFunc=', InnerFunc);
+end;
+
+begin
+    g := 10;
+    Outer;
+    writeln('g=', g);
+end.

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -3403,7 +3403,7 @@ void registerBuiltinFunction(const char *name, ASTNodeType declType, const char*
     configureBuiltinDummyAST(dummy, name);
 
     // --- Add to procedure table and free dummy AST ---
-    addProcedure(dummy, unit_context_name_param_for_addproc);
+    addProcedure(dummy, unit_context_name_param_for_addproc, procedure_table);
     freeAST(dummy); // This will free the dummy node and its tree (params, return type node)
 }
 

--- a/src/frontend/parser.h
+++ b/src/frontend/parser.h
@@ -15,8 +15,7 @@ typedef struct {
 
 AST *parsePointerType(Parser *parser);
 
-void addProcedure(AST *proc_decl, const char* unit_context_name);
-Symbol *lookupProcedure(const char *name_to_lookup);
+void addProcedure(AST *proc_decl, const char* unit_context_name, HashTable *proc_table);
 
 // Full parser API
 AST *buildProgramAST(Parser *parser, BytecodeChunk* chunk);
@@ -50,7 +49,6 @@ AST *expr(Parser *parser);
 AST *term(Parser *parser);
 AST *unitParser(Parser *parser, int recursion_depth, const char* unit_name_being_parsed, BytecodeChunk* chunk); 
 AST *enumDeclaration(Parser *parser);
-Symbol *lookupProcedure(const char *name_to_lookup);
 
 // Other stuff
 void errorParser(Parser *parser, const char *msg);

--- a/src/globals.c
+++ b/src/globals.c
@@ -24,6 +24,7 @@ HashTable *localSymbols = NULL;  // Current local symbol table (initialized to N
 // Procedure table for storing information about declared procedures and functions.
 // This remains a linked list of Procedure structs.
 HashTable *procedure_table = NULL; // Initialized to NULL.
+HashTable *current_procedure_table = NULL; // Pointer to current procedure scope.
 
 // User-defined type table for storing information about declared types (records, enums, etc.).
 // This remains a linked list of TypeEntry structs.

--- a/src/globals.h
+++ b/src/globals.h
@@ -41,6 +41,7 @@ extern HashTable *localSymbols;
 extern Symbol *current_function_symbol;
 
 extern HashTable *procedure_table; // Procedure table is now a HashTable
+extern HashTable *current_procedure_table; // Pointer to current procedure scope
 extern TypeEntry *type_table;      // TypeEntry definition comes from types.h
 
 // --- CRT State Variables ---

--- a/src/main.c
+++ b/src/main.c
@@ -59,6 +59,7 @@ void initSymbolSystem(void) {
         fprintf(stderr, "FATAL: Failed to create procedure hash table.\n");
         EXIT_FAILURE_HANDLER();
     }
+    current_procedure_table = procedure_table;
     DEBUG_PRINT("[DEBUG MAIN] Created procedure hash table %p.\n", (void*)procedure_table);
 #ifdef SDL
     InitializeTextureSystem();

--- a/src/symbol/symbol.h
+++ b/src/symbol/symbol.h
@@ -40,6 +40,7 @@ typedef struct Symbol_s Symbol;
 #define HASHTABLE_SIZE 256
 struct SymbolTable_s {
     Symbol *buckets[HASHTABLE_SIZE];
+    struct SymbolTable_s *parent; /* For scoped procedure tables */
 };
 typedef struct SymbolTable_s HashTable;
 
@@ -77,5 +78,10 @@ void hashTableInsert(HashTable *table, Symbol *symbol);
 
 // --- Other related prototypes ---
 void nullifyPointerAliasesByAddrValue(HashTable* table, uintptr_t disposedAddrValue);
+
+// --- Scoped procedure table helpers ---
+HashTable *pushProcedureTable(void);
+void popProcedureTable(bool free_table);
+Symbol *lookupProcedure(const char *name);
 
 #endif // symbol_h


### PR DESCRIPTION
## Summary
- add parent-aware hash tables and helpers for pushing/popping procedure scopes
- update parser to maintain scoped procedure tables for nested routines
- extend interpreter and compiler to look up procedures by traversing scope stack
- provide regression test covering nested routine definitions

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `make -C Tests` *(fails: VM Error: Could not retrieve procedure symbol for called address 000B)*

------
https://chatgpt.com/codex/tasks/task_e_6897e37b554c832a99f09de2ef525f31