### PR TITLE
Fix string element access base pointer

### DIFF
--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1301,7 +1301,8 @@ comparison_error_label:
                 uint8_t dimension_count = READ_BYTE();
 
                 if (dimension_count == 1) {
-                    Value* base_ptr = vm->stackTop - 1;
+                    // The index is on top of the stack, so the base pointer is just below it
+                    Value* base_ptr = vm->stackTop - 2;
                     if (base_ptr->type == TYPE_POINTER) {
                         Value* base_val = (Value*)base_ptr->ptr_val;
                         if (base_val && base_val->type == TYPE_STRING) {


### PR DESCRIPTION
## Summary
- Correct OP_GET_ELEMENT_ADDRESS to read base pointer from stackTop-2 when indexing strings
- Leave existing array element path untouched for non-strings

## Testing
- `make -C Tests test` *(fails: Runtime Error: Operands must be numbers for arithmetic operation '+' (or strings/chars for '+'). Got NIL and INTEGER)*

------
https://chatgpt.com/codex/tasks/task_e_6897ef213e68832aa27b78449988407a