### PR TITLE
Add logging for nested env and test nested variable access

### DIFF
--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -4,7 +4,7 @@
 PSCAL = ../build/bin/pscal
 
 # List of test files
-TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p StringTruncationTest.p LowHighCharTest.p GlobalEnumTest.p EnumComparisonTest.p EnumCaseTest.p RecordFieldIndexTest.p CompileTimeBounds.p SuccEnumTest.p NestedRoutine_Suite.p
+TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p StringTruncationTest.p LowHighCharTest.p GlobalEnumTest.p EnumComparisonTest.p EnumCaseTest.p RecordFieldIndexTest.p CompileTimeBounds.p SuccEnumTest.p NestedRoutine_Suite.p NestedRoutineAccessTest.p
 
 # SDL-specific tests
 SDL_TESTS = SDLFeaturesTest SDLRenderCopyTest.p

--- a/Tests/NestedRoutineAccessTest.p
+++ b/Tests/NestedRoutineAccessTest.p
@@ -1,0 +1,38 @@
+program NestedRoutineAccessTest;
+
+var g: integer;
+
+procedure Outer;
+    var currentline: integer;
+        outtext: string[20];
+
+    procedure InnerProc;
+    begin
+        g := g + 1;
+        currentline := currentline + 1;
+        outtext := 'changed';
+    end;
+
+    function InnerFunc: integer;
+    begin
+        InnerProc;
+        InnerFunc := g + currentline;
+    end;
+
+begin
+    g := 5;
+    currentline := 0;
+    outtext := 'start';
+    InnerProc;
+    if InnerFunc = g + currentline then
+        writeln('PASS: Nested routines can access outer vars')
+    else
+        writeln('FAIL: Nested routines cannot access outer vars');
+    writeln('currentline=', currentline);
+    writeln('outtext=', outtext);
+end;
+
+begin
+    g := 10;
+    Outer;
+end.

--- a/src/backend_ast/interpreter.c
+++ b/src/backend_ast/interpreter.c
@@ -334,6 +334,15 @@ Value executeProcedureCall(AST *node) {
 
     SymbolEnvSnapshot snapshot;
     saveLocalEnv(&snapshot); // Save caller's local environment
+#ifdef DEBUG
+    DEBUG_PRINT("[DEBUG EXEC_PROC] New local env %p chained to parent %p for '%s'\n",
+                (void*)localSymbols,
+                localSymbols ? (void*)localSymbols->parent : NULL,
+                name_to_lookup);
+    Symbol *dbg_sym = lookupSymbol("currentline");
+    DEBUG_PRINT("[DEBUG EXEC_PROC] lookupSymbol('currentline') before declarations: %s\n",
+                dbg_sym ? "found" : "not found");
+#endif
     pushProcedureTable();
 
     // Bind arguments to local symbols in the new scope
@@ -606,6 +615,12 @@ static void processLocalDeclarations(AST* declarationsNode) {
                         insertGlobalSymbol(varName, declNode->var_type, typeNode);
                     } else {
                         insertLocalSymbol(varName, declNode->var_type, typeNode, true);
+#ifdef DEBUG
+                        Symbol *chk = lookupLocalSymbol(varName);
+                        DEBUG_PRINT("[DEBUG processLocalDeclarations] Post-insert lookup for '%s': %s\n",
+                                    varName,
+                                    chk ? "found" : "NOT FOUND");
+#endif
                     }
                     // Value initialization (including base_type_node for pointers)
                     // is handled within insertGlobalSymbol/insertLocalSymbol via makeValueForType.


### PR DESCRIPTION
## Summary
- log local env chaining and `currentline` visibility during procedure calls
- record local variable insertion via `processLocalDeclarations`
- add nested routine access test and integrate into test suite

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/bin/pscal Tests/NestedRoutineAccessTest.p` *(fails: Operands must be numbers for arithmetic operation '+' (or strings/chars for '+'). Got NIL and INTEGER)*

------
https://chatgpt.com/codex/tasks/task_e_6898176586ac832abba340a523f8d588