### PR TITLE
Add CharAt nested function to nested routine test

### DIFF
--- a/Tests/NestedRoutine_Suite.p
+++ b/Tests/NestedRoutine_Suite.p
@@ -20,6 +20,11 @@ procedure Outer;
         InnerFunc := g + currentline;
     end;
 
+    function CharAt(i: integer): char;
+    begin
+        CharAt := outtext[i];
+    end;
+
 begin
     g := 5;
     currentline := 0;
@@ -28,6 +33,7 @@ begin
     writeln('InnerFunc=', InnerFunc);
     writeln('currentline=', currentline);
     writeln('outtext=', outtext);
+    writeln('CharAt(2)=', CharAt(2));
 end;
 
 begin


### PR DESCRIPTION
## Summary
- Extend nested routine test with nested `CharAt` function accessing captured `outtext`
- Call `CharAt` to exercise upvalue string indexing in the compiler

## Testing
- `./build/bin/pscal Tests/NestedRoutine_Suite.p` *(fails: Operands must be numbers for arithmetic operation '+' (or strings/chars for '+'). Got NIL and INTEGER)*

------
https://chatgpt.com/codex/tasks/task_e_689817737e10832abdb04e3429982d65