### PR TITLE
Handle exit builtin return value in functions

### DIFF
--- a/Tests/ExitFunctionReturnTest.p
+++ b/Tests/ExitFunctionReturnTest.p
@@ -1,0 +1,15 @@
+program ExitFunctionReturnTest;
+
+function Flag(): boolean;
+begin
+  Flag := true;
+  exit;
+  Flag := false; { unreachable }
+end;
+
+begin
+  if Flag() then
+    writeln('ok')
+  else
+    writeln('fail');
+end.

--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -4,7 +4,7 @@
 PSCAL = ../build/bin/pscal
 
 # List of test files
-TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p StringTruncationTest.p LowHighCharTest.p GlobalEnumTest.p EnumComparisonTest.p EnumCaseTest.p RecordFieldIndexTest.p CompileTimeBounds.p SuccEnumTest.p NestedRoutine_Suite.p NestedRoutineAccessTest.p ExitEarlyTest.p
+TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p StringTruncationTest.p LowHighCharTest.p GlobalEnumTest.p EnumComparisonTest.p EnumCaseTest.p RecordFieldIndexTest.p CompileTimeBounds.p SuccEnumTest.p NestedRoutine_Suite.p NestedRoutineAccessTest.p ExitEarlyTest.p ExitFunctionReturnTest.p
 
 # SDL-specific tests
 SDL_TESTS = SDLFeaturesTest SDLRenderCopyTest.p

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -1571,6 +1571,15 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
                         fprintf(stderr, "L%d: exit does not take arguments.\n", line);
                         compiler_had_error = true;
                     }
+
+                    int slot = -1;
+                    if (current_function_compiler) {
+                        slot = resolveLocal(current_function_compiler, current_function_compiler->name);
+                    }
+                    if (slot != -1) {
+                        writeBytecodeChunk(chunk, OP_GET_LOCAL, line);
+                        writeBytecodeChunk(chunk, (uint8_t)slot, line);
+                    }
                     writeBytecodeChunk(chunk, OP_EXIT, line);
                 } else {
                     BuiltinRoutineType type = getBuiltinType(calleeName);


### PR DESCRIPTION
## Summary
- Ensure built-in `exit` pushes the current function's result variable before exiting
- Add regression test covering `exit` in a function returning a boolean

## Testing
- `cd build && make -j$(nproc)`
- `cd Tests && make test`

------
https://chatgpt.com/codex/tasks/task_e_68982a5d8ea0832ab394d4a1366e3d11