### PR TITLE
Handle legacy program file list

### DIFF
--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -4,7 +4,7 @@
 PSCAL = ../build/bin/pscal
 
 # List of test files
-TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p StringTruncationTest.p LowHighCharTest.p GlobalEnumTest.p EnumComparisonTest.p EnumCaseTest.p RecordFieldIndexTest.p CompileTimeBounds.p SuccEnumTest.p NestedRoutine_Suite.p NestedRoutineAccessTest.p ExitEarlyTest.p ExitFunctionReturnTest.p
+TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p StringTruncationTest.p LowHighCharTest.p GlobalEnumTest.p EnumComparisonTest.p EnumCaseTest.p RecordFieldIndexTest.p CompileTimeBounds.p SuccEnumTest.p NestedRoutine_Suite.p NestedRoutineAccessTest.p ExitEarlyTest.p ExitFunctionReturnTest.p ProgramFileList.p
 
 # SDL-specific tests
 SDL_TESTS = SDLFeaturesTest SDLRenderCopyTest.p

--- a/Tests/ProgramFileList.p
+++ b/Tests/ProgramFileList.p
@@ -1,0 +1,4 @@
+program Foo(input, output);
+begin
+end.
+

--- a/src/frontend/parser.c
+++ b/src/frontend/parser.c
@@ -786,7 +786,36 @@ AST *buildProgramAST(Parser *main_parser, BytecodeChunk* chunk) {
     AST *prog_name_node = newASTNode(AST_VARIABLE, progNameCopied);
     freeToken(progNameCopied); // newASTNode makes its own copy
 
-    DEBUG_PRINT("buildProgramAST: About to eat SEMICOLON (after prog name). Current: %s ('%s')\n", main_parser->current_token ? tokenTypeToString(main_parser->current_token->type) : "NULL_TOKEN_TYPE", main_parser->current_token && main_parser->current_token->value ? main_parser->current_token->value : "NULL_TOKEN_VALUE");
+    if (main_parser->current_token && main_parser->current_token->type == TOKEN_LPAREN) {
+        DEBUG_PRINT("buildProgramAST: About to eat LPAREN after program name. Current: %s ('%s')\n",
+                    main_parser->current_token ? tokenTypeToString(main_parser->current_token->type) : "NULL_TOKEN_TYPE",
+                    main_parser->current_token && main_parser->current_token->value ? main_parser->current_token->value : "NULL_TOKEN_VALUE");
+        eat(main_parser, TOKEN_LPAREN);
+
+        while (main_parser->current_token && main_parser->current_token->type == TOKEN_IDENTIFIER) {
+            DEBUG_PRINT("buildProgramAST: About to eat IDENTIFIER in program file list. Current: %s ('%s')\n",
+                        main_parser->current_token ? tokenTypeToString(main_parser->current_token->type) : "NULL_TOKEN_TYPE",
+                        main_parser->current_token && main_parser->current_token->value ? main_parser->current_token->value : "NULL_TOKEN_VALUE");
+            eat(main_parser, TOKEN_IDENTIFIER);
+            if (main_parser->current_token && main_parser->current_token->type == TOKEN_COMMA) {
+                DEBUG_PRINT("buildProgramAST: About to eat COMMA in program file list. Current: %s ('%s')\n",
+                            main_parser->current_token ? tokenTypeToString(main_parser->current_token->type) : "NULL_TOKEN_TYPE",
+                            main_parser->current_token && main_parser->current_token->value ? main_parser->current_token->value : "NULL_TOKEN_VALUE");
+                eat(main_parser, TOKEN_COMMA);
+            } else {
+                break;
+            }
+        }
+
+        DEBUG_PRINT("buildProgramAST: About to eat RPAREN after program file list. Current: %s ('%s')\n",
+                    main_parser->current_token ? tokenTypeToString(main_parser->current_token->type) : "NULL_TOKEN_TYPE",
+                    main_parser->current_token && main_parser->current_token->value ? main_parser->current_token->value : "NULL_TOKEN_VALUE");
+        eat(main_parser, TOKEN_RPAREN);
+    }
+
+    DEBUG_PRINT("buildProgramAST: About to eat SEMICOLON (after prog name). Current: %s ('%s')\n",
+                main_parser->current_token ? tokenTypeToString(main_parser->current_token->type) : "NULL_TOKEN_TYPE",
+                main_parser->current_token && main_parser->current_token->value ? main_parser->current_token->value : "NULL_TOKEN_VALUE");
     eat(main_parser, TOKEN_SEMICOLON);
 
     AST *uses_clause = NULL;


### PR DESCRIPTION
## Summary
- allow optional parenthesized identifier list after program name in `buildProgramAST`
- add regression test for legacy `program Foo(input, output);` syntax

## Testing
- `make -C Tests test`
- `build/bin/pscal Tests/ProgramFileList.p`


------
https://chatgpt.com/codex/tasks/task_e_6898308b616c832aa9501d3d5f70650c