### PR TITLE
Support EOF builtin without explicit file

### DIFF
--- a/Tests/EofDefaultInput.p
+++ b/Tests/EofDefaultInput.p
@@ -1,0 +1,11 @@
+program EofDefaultInput;
+var
+  input: text;
+  x: integer;
+begin
+  assign(input, 'empty.txt');
+  reset(input);
+  while not eof do
+    readln(x);
+  close(input);
+end.

--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -4,7 +4,7 @@
 PSCAL = ../build/bin/pscal
 
 # List of test files
-TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p StringTruncationTest.p LowHighCharTest.p GlobalEnumTest.p EnumComparisonTest.p EnumCaseTest.p RecordFieldIndexTest.p CompileTimeBounds.p SuccEnumTest.p NestedRoutine_Suite.p NestedRoutineAccessTest.p ExitEarlyTest.p ExitFunctionReturnTest.p ProgramFileList.p
+TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p StringTruncationTest.p LowHighCharTest.p GlobalEnumTest.p EnumComparisonTest.p EnumCaseTest.p RecordFieldIndexTest.p CompileTimeBounds.p SuccEnumTest.p NestedRoutine_Suite.p NestedRoutineAccessTest.p ExitEarlyTest.p ExitFunctionReturnTest.p ProgramFileList.p EofDefaultInput.p
 
 # SDL-specific tests
 SDL_TESTS = SDLFeaturesTest SDLRenderCopyTest.p


### PR DESCRIPTION
## Summary
- Allow `eof` builtin to accept 0 or 1 argument in VM and AST interpreter
- Treat `eof` file parameter as optional during builtin registration
- Add regression test covering `eof` with default input

## Testing
- `./build/bin/pscal Tests/FileTests.p`
- `./build/bin/pscal Tests/FileTests2.p`
- `./build/bin/pscal Tests/EofDefaultInput.p`


------
https://chatgpt.com/codex/tasks/task_e_68983336fed4832a9ba16ba033f3d627