### PR TITLE
Handle inline arrays in OP_GET_ELEMENT_ADDRESS

### DIFF
--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -4,7 +4,7 @@
 PSCAL = ../build/bin/pscal
 
 # List of test files
-TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p StringTruncationTest.p LowHighCharTest.p GlobalEnumTest.p EnumComparisonTest.p EnumCaseTest.p RecordFieldIndexTest.p CompileTimeBounds.p SuccEnumTest.p NestedRoutine_Suite.p NestedRoutineAccessTest.p ExitEarlyTest.p ExitFunctionReturnTest.p ProgramFileList.p EofDefaultInput.p
+TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p StringTruncationTest.p LowHighCharTest.p GlobalEnumTest.p EnumComparisonTest.p EnumCaseTest.p RecordFieldIndexTest.p CompileTimeBounds.p SuccEnumTest.p NestedRoutine_Suite.p NestedRoutineAccessTest.p NestedVarArray.p ExitEarlyTest.p ExitFunctionReturnTest.p ProgramFileList.p EofDefaultInput.p
 
 # SDL-specific tests
 SDL_TESTS = SDLFeaturesTest SDLRenderCopyTest.p

--- a/Tests/NestedVarArray.p
+++ b/Tests/NestedVarArray.p
@@ -1,0 +1,23 @@
+program NestedVarArray;
+
+procedure Outer(var arr: array[1..3] of integer);
+  procedure Inner;
+  begin
+    arr[2] := 42;
+  end;
+begin
+  Inner;
+end;
+
+var myArr: array[1..3] of integer;
+var i: integer;
+
+begin
+  for i := 1 to 3 do
+    myArr[i] := i;
+  Outer(myArr);
+  if myArr[2] = 42 then
+    writeln('PASS: VAR array accessed in nested procedure')
+  else
+    writeln('FAIL: VAR array accessed in nested procedure');
+end.


### PR DESCRIPTION
## Summary
- Allow `OP_GET_ELEMENT_ADDRESS` to accept direct `TYPE_ARRAY` values in addition to pointers, freeing temporary stack values appropriately.
- Add regression test for nested procedures indexing into a `VAR` array parameter.

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd Tests && make test`

------
https://chatgpt.com/codex/tasks/task_e_689880f489e8832abbe8f4538dd17843