### PR TITLE
Fix array pointer handling for nested VAR arrays

### DIFF
--- a/Tests/NestedVarArray.p
+++ b/Tests/NestedVarArray.p
@@ -1,12 +1,16 @@
 program NestedVarArray;
 
-procedure Outer(var arr: array[1..3] of integer);
-  procedure Inner;
+procedure Level1(var arr: array[1..3] of integer);
+  procedure Level2(var arr2: array[1..3] of integer);
+    procedure Level3;
+    begin
+      arr2[3] := 99;
+    end;
   begin
-    arr[2] := 42;
+    Level3;
   end;
 begin
-  Inner;
+  Level2(arr);
 end;
 
 var myArr: array[1..3] of integer;
@@ -15,9 +19,9 @@ var i: integer;
 begin
   for i := 1 to 3 do
     myArr[i] := i;
-  Outer(myArr);
-  if myArr[2] = 42 then
-    writeln('PASS: VAR array accessed in nested procedure')
+  Level1(myArr);
+  if myArr[3] = 99 then
+    writeln('PASS: VAR array accessed through multiple nested procedures')
   else
-    writeln('FAIL: VAR array accessed in nested procedure');
+    writeln('FAIL: VAR array accessed through multiple nested procedures');
 end.


### PR DESCRIPTION
## Summary
- Handle pointers referencing the first element of an array in `OP_GET_ELEMENT_ADDRESS` by building a temporary array wrapper from AST bounds
- Prevent erroneous "Expected a pointer to an array" errors when nested routines index into VAR arrays
- Add regression test covering multi-level VAR array passing

## Testing
- `cmake --build build`
- `./build/bin/pscal Tests/NestedVarArray.p`

------
https://chatgpt.com/codex/tasks/task_e_68988f4863c4832ab257ad0e72d78d73