### PR TITLE
Remove unused interpreter exit flag

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -4078,10 +4078,7 @@ Value executeBuiltinExit(AST *node) {
         EXIT_FAILURE_HANDLER();
     }
     // In the AST interpreter we simply note the exit; the interpreter loop
-    // is responsible for observing this flag and unwinding appropriately.
-    // A dedicated flag is kept static within this module for simplicity.
-    static bool interpreter_exit_requested = false;
-    interpreter_exit_requested = true;
+    // is responsible for unwinding appropriately.
     return makeVoid();
 }
 


### PR DESCRIPTION
## Summary
- Remove unused interpreter_exit_requested flag from executeBuiltinExit
- Clarify comment about unwinding

## Testing
- `cmake --build . > /tmp/build.log 2>&1`
- `rg interpreter_exit_requested /tmp/build.log`
- `ctest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_6898b8747f88832a90ffa46a8cc86097