### PR TITLE
Propagate reference flag for captured variables

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -1153,6 +1153,7 @@ static void compileDefinedFunction(AST* func_decl_node, BytecodeChunk* chunk, in
         for (int i = 0; i < fc.upvalue_count; i++) {
             proc_symbol->upvalues[i].index = fc.upvalues[i].index;
             proc_symbol->upvalues[i].isLocal = fc.upvalues[i].isLocal;
+            proc_symbol->upvalues[i].is_ref = fc.upvalues[i].is_ref;
         }
     }
 

--- a/src/symbol/symbol.h
+++ b/src/symbol/symbol.h
@@ -37,6 +37,7 @@ struct Symbol_s {
     struct {
         uint8_t index;
         bool isLocal;
+        bool is_ref;          // Indicates whether the captured variable is a reference (VAR param)
     } upvalues[256];
 };
 


### PR DESCRIPTION
## Summary
- Preserve reference semantics for variables captured by nested routines by tracking an `is_ref` flag in upvalue metadata
- Export the flag in compiler symbols so deeper routines know when captured values are references

## Testing
- `make test` *(fails: ../build/bin/pscal: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898ba85310c832aaa535030f8216e7c