### PR TITLE
Validate procedure call arguments

### DIFF
--- a/Tests/ArgumentOrderMismatch.p
+++ b/Tests/ArgumentOrderMismatch.p
@@ -1,0 +1,14 @@
+program ArgumentOrderMismatch;
+
+procedure Mix(i: integer; r: real);
+begin
+end;
+
+var
+  x: integer;
+  y: real;
+begin
+  x := 5;
+  y := 3.14;
+  Mix(y, x); { wrong argument order }
+end.

--- a/Tests/ArgumentTypeMismatch.p
+++ b/Tests/ArgumentTypeMismatch.p
@@ -1,0 +1,12 @@
+program ArgumentTypeMismatch;
+
+procedure Foo(i: integer; r: real);
+begin
+end;
+
+var
+  x: integer;
+begin
+  x := 5;
+  Foo(x, x); { wrong type for second argument }
+end.


### PR DESCRIPTION
## Summary
- verify procedure call argument counts and types, checking VAR parameters
- add regression tests for mismatched argument order and types

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `build/bin/pscal Tests/ArgumentOrderMismatch.p` *(fails: expects INTEGER but got REAL)*
- `build/bin/pscal Tests/ArgumentTypeMismatch.p` *(fails: expects REAL but got INTEGER)*
- `build/bin/pscal Tests/pass-by-reference.p`


------
https://chatgpt.com/codex/tasks/task_e_6898c318c510832abf9144de6d88b220