### PR TITLE
Add negative test for array argument mismatch

### DIFF
--- a/Tests/ArrayArgumentMismatch.p
+++ b/Tests/ArrayArgumentMismatch.p
@@ -1,0 +1,13 @@
+program ArrayArgumentMismatch;
+
+procedure Proc(var a: array[1..5] of integer; n: integer);
+begin
+end;
+
+var
+  a: array[1..5] of integer;
+  n: integer;
+begin
+  n := 3;
+  Proc(n, a);
+end.

--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -4,7 +4,14 @@
 PSCAL = ../build/bin/pscal
 
 # List of test files
-TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p StringTruncationTest.p LowHighCharTest.p GlobalEnumTest.p EnumComparisonTest.p EnumCaseTest.p RecordFieldIndexTest.p CompileTimeBounds.p SuccEnumTest.p NestedRoutine_Suite.p NestedRoutineAccessTest.p NestedVarArray.p ExitEarlyTest.p ExitFunctionReturnTest.p ProgramFileList.p EofDefaultInput.p
+TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p \
+BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p \
+StringTruncationTest.p LowHighCharTest.p Global EnumTest.p EnumComparisonTest.p EnumCaseTest.p RecordFieldIndexTest.p \
+CompileTimeBounds.p SuccEnumTest.p NestedRoutine_Suite.p NestedRoutineAccessTest.p NestedVarArray.p ExitEarlyTest.p ExitFunctionReturnTest.p \
+ProgramFileList.p EofDefaultInput.p
+
+# Tests that are expected to fail compilation
+FAIL_TESTS = ArgumentOrderMismatch.p ArgumentTypeMismatch.p ArrayArgumentMismatch.p
 
 # SDL-specific tests
 SDL_TESTS = SDLFeaturesTest SDLRenderCopyTest.p
@@ -20,6 +27,25 @@ test:
 	echo "----------------------------------------------------"; \
 	echo "Running $$t:"; \
 	$(PSCAL) $$t; \
+	echo "----------------------------------------------------"; \
+	echo ""; \
+	done
+	@echo "Running negative tests..."
+	@for t in $(FAIL_TESTS); do \
+	echo "----------------------------------------------------"; \
+	echo "Running $$t (expected failure):"; \
+	if $(PSCAL) $$t >/tmp/pscal_output 2>&1; then \
+	echo "ERROR: $$t unexpectedly succeeded"; \
+	cat /tmp/pscal_output; \
+	exit 1; \
+	else \
+	cat /tmp/pscal_output; \
+	if [ -f $${t%.p}.dbg ]; then \
+	echo "ERROR: bytecode generated for $$t"; \
+	rm -f $${t%.p}.dbg; \
+	exit 1; \
+	fi; \
+	fi; \
 	echo "----------------------------------------------------"; \
 	echo ""; \
 	done


### PR DESCRIPTION
## Summary
- add regression test for calling a procedure with integer and array arguments swapped
- extend test runner to execute negative tests and fail if unexpected bytecode is produced

## Testing
- `make -C Tests test`

------
https://chatgpt.com/codex/tasks/task_e_6898c8dc9f90832ab119239fdd4eb2fc