### PR TITLE
Add array argument mismatch negative test

### DIFF
--- a/Tests/ArrayArgumentMismatch.p
+++ b/Tests/ArrayArgumentMismatch.p
@@ -1,11 +1,11 @@
 program ArrayArgumentMismatch;
 
-procedure Proc(var a: array[1..5] of integer; n: integer);
+procedure Proc(var a: array[1..10] of integer; n: integer);
 begin
 end;
 
 var
-  a: array[1..5] of integer;
+  a: array[1..10] of integer;
   n: integer;
 begin
   n := 3;

--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -11,7 +11,9 @@ CompileTimeBounds.p SuccEnumTest.p NestedRoutine_Suite.p NestedRoutineAccessTest
 ProgramFileList.p EofDefaultInput.p
 
 # Tests that are expected to fail compilation
-FAIL_TESTS = ArgumentOrderMismatch.p ArgumentTypeMismatch.p ArrayArgumentMismatch.p
+FAIL_TESTS = ArgumentOrderMismatch.p \
+             ArgumentTypeMismatch.p \
+             ArrayArgumentMismatch.p
 
 # SDL-specific tests
 SDL_TESTS = SDLFeaturesTest SDLRenderCopyTest.p


### PR DESCRIPTION
## Summary
- add ArrayArgumentMismatch.p to verify passing arguments in wrong order triggers compile error
- register the test in Tests/Makefile as a negative test

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6898d29cbc9c832abd73116bc607038a