### PR TITLE
Fix primitive argument type comparison

### DIFF
--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -8,7 +8,7 @@ TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p 
 BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p \
 StringTruncationTest.p LowHighCharTest.p Global EnumTest.p EnumComparisonTest.p EnumCaseTest.p RecordFieldIndexTest.p \
 CompileTimeBounds.p SuccEnumTest.p NestedRoutine_Suite.p NestedRoutineAccessTest.p NestedVarArray.p ExitEarlyTest.p ExitFunctionReturnTest.p \
-ProgramFileList.p EofDefaultInput.p
+ProgramFileList.p EofDefaultInput.p PrimitiveArgCall.p
 
 # Tests that are expected to fail compilation
 FAIL_TESTS = ArgumentOrderMismatch.p \

--- a/Tests/PrimitiveArgCall.p
+++ b/Tests/PrimitiveArgCall.p
@@ -1,0 +1,14 @@
+program PrimitiveArgCall;
+
+procedure Foo(var i: integer; var b: boolean);
+begin
+end;
+
+var
+  x: integer;
+  y: boolean;
+begin
+  x := 10;
+  y := false;
+  Foo(x, y);
+end.

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -203,14 +203,19 @@ static bool typesMatch(AST* param_type, AST* arg_node) {
     if (!param_type || !arg_node) return false;
 
     AST* param_actual = resolveTypeAlias(param_type);
-    AST* arg_actual   = resolveTypeAlias(arg_node->type_def);
-    if (!param_actual || !arg_actual) return false;
+    if (!param_actual) return false;
 
-    if (param_actual->var_type != arg_actual->var_type) return false;
+    AST* arg_actual = NULL;
+    if (arg_node->type_def) {
+        arg_actual = resolveTypeAlias(arg_node->type_def);
+    }
 
-    if (param_actual->var_type == TYPE_ARRAY ||
-        param_actual->var_type == TYPE_RECORD ||
-        param_actual->var_type == TYPE_POINTER) {
+    VarType arg_vartype = arg_actual ? arg_actual->var_type : arg_node->var_type;
+    if (param_actual->var_type != arg_vartype) return false;
+
+    if (arg_actual && (param_actual->var_type == TYPE_ARRAY ||
+                       param_actual->var_type == TYPE_RECORD ||
+                       param_actual->var_type == TYPE_POINTER)) {
         return compareTypeNodes(param_actual, arg_actual);
     }
 
@@ -1621,7 +1626,7 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
 
                         // VAR parameters preserve their full TYPE_ARRAY node so that
                         // structural comparisons (like array bounds) remain possible.
-                        AST* param_type = param_node->type_def;
+                        AST* param_type = param_node->type_def ? param_node->type_def : param_node;
                         bool match = typesMatch(param_type, arg_node);
                         if (!match) {
                             AST* param_actual = resolveTypeAlias(param_type);


### PR DESCRIPTION
## Summary
- allow `typesMatch` to fall back on an argument's `var_type` when no `type_def` is present
- guard structural type comparisons on both sides being fully resolved
- add regression test exercising primitive VAR arguments

## Testing
- `./build/bin/pscal Tests/PrimitiveArgCall.p`
- `./build/bin/pscal Tests/BoolTest1.p`
- `./build/bin/pscal Tests/ArgumentTypeMismatch.p`

------
https://chatgpt.com/codex/tasks/task_e_6898d6e5bff4832aa454f54affaeaa21