### PR TITLE
Allow open array parameters to match any bounds

### DIFF
--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -8,12 +8,13 @@ TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p 
 BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p \
 StringTruncationTest.p LowHighCharTest.p Global EnumTest.p EnumComparisonTest.p EnumCaseTest.p RecordFieldIndexTest.p \
 CompileTimeBounds.p SuccEnumTest.p NestedRoutine_Suite.p NestedRoutineAccessTest.p NestedVarArray.p ExitEarlyTest.p ExitFunctionReturnTest.p \
-ProgramFileList.p EofDefaultInput.p
+ProgramFileList.p EofDefaultInput.p OpenArrayParam.p
 
 # Tests that are expected to fail compilation
 FAIL_TESTS = ArgumentOrderMismatch.p \
              ArgumentTypeMismatch.p \
-             ArrayArgumentMismatch.p
+             ArrayArgumentMismatch.p \
+             OpenArrayBaseTypeMismatch.p
 
 # SDL-specific tests
 SDL_TESTS = SDLFeaturesTest SDLRenderCopyTest.p

--- a/Tests/OpenArrayBaseTypeMismatch.p
+++ b/Tests/OpenArrayBaseTypeMismatch.p
@@ -1,0 +1,11 @@
+program OpenArrayBaseTypeMismatch;
+
+procedure Proc(var a: array of integer);
+begin
+end;
+
+var
+  arr: array[1..5] of real;
+begin
+  Proc(arr);
+end.

--- a/Tests/OpenArrayParam.p
+++ b/Tests/OpenArrayParam.p
@@ -1,0 +1,14 @@
+program OpenArrayParam;
+
+procedure Proc(var a: array of integer);
+begin
+end;
+
+const
+  N = 5;
+
+var
+  arr: array[1..N] of integer;
+begin
+  Proc(arr);
+end.


### PR DESCRIPTION
## Summary
- Skip bound comparison in `compareTypeNodes` when a parameter array has unspecified bounds
- Route array parameters through `compareTypeNodes` in `typesMatch`
- Parse `array of <type>` syntax for open array parameters
- Add regression tests for open array parameter matching and base type mismatch

## Testing
- `make test` (fails expected negative tests)
- `bin/pscal ../Tests/OpenArrayParam.p`
- `bin/pscal ../Tests/OpenArrayBaseTypeMismatch.p` (fails)


------
https://chatgpt.com/codex/tasks/task_e_6898d6e6f5c0832aa178fd84a49e33b7