### PR TITLE
Handle realloc failure in addBreakJump

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -313,8 +313,14 @@ static void addBreakJump(BytecodeChunk* chunk, int line) {
     }
     Loop* current_loop = &loop_stack[loop_depth];
     current_loop->break_count++;
-    current_loop->break_jumps = realloc(current_loop->break_jumps, sizeof(int) * current_loop->break_count);
-    
+    int* temp = realloc(current_loop->break_jumps, sizeof(int) * current_loop->break_count);
+    if (!temp) {
+        fprintf(stderr, "L%d: Compiler error: memory allocation failed for break jumps.\\n", line);
+        compiler_had_error = true;
+        return;
+    }
+    current_loop->break_jumps = temp;
+
     writeBytecodeChunk(chunk, OP_JUMP, line);
     current_loop->break_jumps[current_loop->break_count - 1] = chunk->count; // Store offset of the operand
     emitShort(chunk, 0xFFFF, line); // Placeholder


### PR DESCRIPTION
## Summary
- Safely reallocate break jump array in `addBreakJump` by checking `realloc` result and emitting a compiler error on failure.

## Testing
- `cmake -DSDL=OFF ..`
- `make -j$(nproc)`
- `make -C Tests test` *(fails: `Makefile:11: *** missing separator. Stop.`)*
- `./build/bin/pscal Tests/BoolTest1.p`


------
https://chatgpt.com/codex/tasks/task_e_6898fcb96d60832aa0799907218b9d15