### PR TITLE
Handle var array upvalues

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -797,10 +797,13 @@ static void compileLValue(AST* node, BytecodeChunk* chunk, int current_line_appr
                     if (base_local == -1) {
                         int base_up = resolveUpvalue(current_function_compiler, base_name);
                         if (base_up != -1) {
-                            // Drop any temporary left behind when accessing the upvalue
-                            // so only the index and the array pointer remain.
-                            writeBytecodeChunk(chunk, OP_SWAP, line);
-                            writeBytecodeChunk(chunk, OP_POP, line);
+                            bool up_is_ref = current_function_compiler->upvalues[base_up].is_ref;
+                            if (!up_is_ref) {
+                                // Drop any temporary left behind when accessing the upvalue
+                                // so only the index and the array pointer remain.
+                                writeBytecodeChunk(chunk, OP_SWAP, line);
+                                writeBytecodeChunk(chunk, OP_POP, line);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Preserve index when accessing upvalue-based arrays by skipping swap/pop for by-reference captures

## Testing
- `cmake .. && make`
- `./bin/pscal --dump-bytecode /tmp/split.p`


------
https://chatgpt.com/codex/tasks/task_e_68996b193140832aa0abe8b66c719ed6