### PR TITLE
Allow optional step argument for inc/dec builtins

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -3185,10 +3185,9 @@ static void configureBuiltinDummyAST(AST *dummy, const char *name) {
             AST* v2 = newASTNode(AST_VARIABLE, pn2); freeToken(pn2);
             addChild(p2, v2);
             dummy->children[1] = p2;
-            dummy->child_count = 2;
-        } else {
-            dummy->child_count = 1;
         }
+        // Only the first parameter is required; the second is optional.
+        dummy->child_count = 1;
         dummy->var_type = TYPE_VOID;
     }
     // --- Ordinal functions (Low, High, Succ) ---


### PR DESCRIPTION
## Summary
- Support optional second parameter for `inc`/`dec` by building dummy AST nodes with a single required child and extra capacity
- Permit calling `inc`/`dec` with one or two arguments by relaxing argument-count checks in compiler

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd Tests && ./run_tests.sh` *(fails: segmentation fault in FileTests.p, FileTests2.p, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6899755af8d8832a8ef729bb5f76466a