### PR TITLE
Allow generic pointer parameters

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -3184,6 +3184,10 @@ static void configureBuiltinDummyAST(AST *dummy, const char *name) {
         AST* p1 = newASTNode(AST_VAR_DECL, NULL);
         if (strcasecmp(name, "new") == 0 || strcasecmp(name, "dispose") == 0) {
             setTypeAST(p1, TYPE_POINTER);
+            AST* ptrType = newASTNode(AST_POINTER_TYPE, NULL); // Generic pointer (no subtype)
+            setTypeAST(ptrType, TYPE_POINTER);
+            p1->type_def = ptrType;
+            setRight(p1, ptrType);
         } else {
             setTypeAST(p1, TYPE_INTEGER); // Placeholder for any ordinal
         }

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -238,6 +238,10 @@ static bool typesMatch(AST* param_type, AST* arg_node) {
             case TYPE_CHAR:
                 return arg_vt == TYPE_CHAR   || arg_vt == TYPE_INTEGER ||
                        arg_vt == TYPE_BYTE   || arg_vt == TYPE_WORD;
+            case TYPE_POINTER:
+                if (arg_vt != TYPE_POINTER && arg_vt != TYPE_NIL) return false;
+                // If the parameter specifies no referenced subtype, accept any pointer.
+                return param_actual->right == NULL;
             case TYPE_BOOLEAN:
             case TYPE_STRING:
             case TYPE_BYTE:
@@ -261,9 +265,15 @@ static bool typesMatch(AST* param_type, AST* arg_node) {
         return compareTypeNodes(param_actual, arg_actual);
     }
 
-    if (param_actual->var_type == TYPE_RECORD ||
-        param_actual->var_type == TYPE_POINTER) {
-        if (arg_vt != param_actual->var_type) return false;
+    if (param_actual->var_type == TYPE_RECORD) {
+        if (arg_vt != TYPE_RECORD) return false;
+        return compareTypeNodes(param_actual, arg_actual);
+    }
+
+    if (param_actual->var_type == TYPE_POINTER) {
+        if (arg_vt != TYPE_POINTER && arg_vt != TYPE_NIL) return false;
+        if (!param_actual->right) return true; // Generic pointer accepts any pointer
+        if (!arg_actual) return false;
         return compareTypeNodes(param_actual, arg_actual);
     }
 


### PR DESCRIPTION
## Summary
- Let pointer parameters without a subtype accept any pointer argument
- Use generic pointer parameters for builtin new/dispose

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `./Tests/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6899e0eecca8832a8bb9c5d9ca1e690c