### PR TITLE
Handle single-character string literals as char

### DIFF
--- a/src/frontend/ast.c
+++ b/src/frontend/ast.c
@@ -566,7 +566,12 @@ void annotateTypes(AST *node, AST *currentScopeNode, AST *globalProgramNode) {
                 node->var_type = (node->token && node->token->type == TOKEN_REAL_CONST) ? TYPE_REAL : TYPE_INTEGER;
                 break;
             case AST_STRING:
-                node->var_type = TYPE_STRING;
+                if (node->token && node->token->value && strlen(node->token->value) == 1) {
+                    node->var_type = TYPE_CHAR;
+                    node->type_def = lookupType("char");
+                } else {
+                    node->var_type = TYPE_STRING;
+                }
                 break;
             case AST_BOOLEAN:
                 node->var_type = TYPE_BOOLEAN;


### PR DESCRIPTION
## Summary
- Annotate AST string literals of length 1 as char type
- Leave longer literals as strings

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_6899fbe652c0832ab93d4ed1ecb80c16