### PR TITLE
Handle single-character string literals as char

### DIFF
--- a/src/frontend/parser.c
+++ b/src/frontend/parser.c
@@ -2615,10 +2615,11 @@ AST *factor(Parser *parser) {
         return node; // <<< RETURN IMMEDIATELY
 
     } else if (initialTokenType == TOKEN_STRING_CONST) {
+        int isChar = (initialToken->value && initialToken->value[1] == '\0');
         Token* c = copyToken(initialToken);
         eat(parser, initialTokenType); // Eat the string token
         node = newASTNode(AST_STRING, c); freeToken(c);
-        setTypeAST(node, TYPE_STRING);
+        setTypeAST(node, isChar ? TYPE_CHAR : TYPE_STRING);
         return node; // <<< RETURN IMMEDIATELY
 
     } else if (initialTokenType == TOKEN_IDENTIFIER) {


### PR DESCRIPTION
## Summary
- Treat string constants of length 1 as `TYPE_CHAR` during parsing

## Testing
- `cmake -DSDL=OFF ..`
- `make -j$(nproc)`
- `Tests/run_tests.sh` *(interrupted after running some tests)*

------
https://chatgpt.com/codex/tasks/task_e_689a1b1f2fd4832abfcdc8da67a3daf6