### PR TITLE
Allow char-string compatibility

### DIFF
--- a/src/backend_ast/interpreter.c
+++ b/src/backend_ast/interpreter.c
@@ -1107,6 +1107,9 @@ Value eval(AST *node) {
 #ifdef DEBUG
     DEBUG_PRINT("[DEBUG] eval AST_STRING: token value='%s'\n", node->token->value);
 #endif
+            if (node->var_type == TYPE_CHAR) {
+                return makeChar(node->token && node->token->value ? node->token->value[0] : '\0');
+            }
             return makeString(node->token->value);
         case AST_VARIABLE: {
             if (node->token && node->token->value && strcasecmp(node->token->value, "break_requested") == 0) {

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -242,8 +242,9 @@ static bool typesMatch(AST* param_type, AST* arg_node) {
                 if (arg_vt != TYPE_POINTER && arg_vt != TYPE_NIL) return false;
                 // If the parameter specifies no referenced subtype, accept any pointer.
                 return param_actual->right == NULL;
-            case TYPE_BOOLEAN:
             case TYPE_STRING:
+                return arg_vt == TYPE_STRING || arg_vt == TYPE_CHAR;
+            case TYPE_BOOLEAN:
             case TYPE_BYTE:
             case TYPE_WORD:
             case TYPE_ENUM:
@@ -311,6 +312,10 @@ static bool typesMatch(AST* param_type, AST* arg_node) {
             break;
         case TYPE_CHAR:
             if (arg_vt == TYPE_BYTE || arg_vt == TYPE_WORD)
+                return true;
+            break;
+        case TYPE_STRING:
+            if (arg_vt == TYPE_CHAR)
                 return true;
             break;
         default:


### PR DESCRIPTION
## Summary
- Allow TYPE_CHAR when TYPE_STRING parameters are expected, including promotion rules
- Return makeChar for AST_STRING nodes typed as TYPE_CHAR during interpretation

## Testing
- `build/bin/pscal Tests/Hello`
- `Tests/run_tests.sh` *(hangs after some tests; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_689a52510bf0832ab7ecc8afe370e85c