### PR TITLE
Use c_val for character values

### DIFF
--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -1719,6 +1719,8 @@ Value makeCopyOfValue(const Value *src) {
             break;
         }
         case TYPE_CHAR:
+            v.c_val = src->c_val;
+            v.max_length = 1;
             break;
         case TYPE_SET:
             v.set_val.set_values = NULL;


### PR DESCRIPTION
## Summary
- Handle single-character strings in ordinal evaluation
- Read characters directly with `fgetc` in READLN/READ
- Support assigning and copying characters via `c_val` in helpers

## Testing
- `cmake ..`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_689a5a187f30832aa2bac85f23c6355f