### PR TITLE
Fix type inference for low/high built-ins

### DIFF
--- a/src/frontend/ast.c
+++ b/src/frontend/ast.c
@@ -514,6 +514,17 @@ void annotateTypes(AST *node, AST *currentScopeNode, AST *globalProgramNode) {
                         if (resolved) {
                             node->var_type = resolved->var_type;
                             node->type_def = resolved;
+                        } else if (arg->token && arg->token->value) {
+                            const char* tn = arg->token->value;
+                            if      (strcasecmp(tn, "integer") == 0) node->var_type = TYPE_INTEGER;
+                            else if (strcasecmp(tn, "char")    == 0) node->var_type = TYPE_CHAR;
+                            else if (strcasecmp(tn, "boolean") == 0) node->var_type = TYPE_BOOLEAN;
+                            else if (strcasecmp(tn, "byte")    == 0) node->var_type = TYPE_BYTE;
+                            else if (strcasecmp(tn, "word")    == 0) node->var_type = TYPE_WORD;
+                            else {
+                                node->var_type = arg->var_type;
+                                node->type_def = arg->type_def;
+                            }
                         } else {
                             node->var_type = arg->var_type;
                             node->type_def = arg->type_def;


### PR DESCRIPTION
## Summary
- Ensure `low` and `high` built-ins infer return types for basic type identifiers when no type definition is resolved

## Testing
- `./build/bin/pscal --dump-bytecode Tests/TypeTestSuite` *(fails: Segmentation fault)*
- `./build/bin/pscal --dump-bytecode Tests/LowHighCharTest.p`
- `./build/bin/pscal --dump-bytecode /tmp/byteword.p`


------
https://chatgpt.com/codex/tasks/task_e_689a61f56340832ab8061baea824b336