### PR TITLE
Fix Tests Makefile separator issue

### DIFF
--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -5,10 +5,9 @@ PSCAL = ../build/bin/pscal
 
 # List of test files
 TESTS = test1.p test2.p test3.p test4.p test5.p test6.p test7.p test8.p test9.p \
-BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p \
-StringTruncationTest.p LowHighCharTest.p Global EnumTest.p EnumComparisonTest.p EnumCaseTest.p RecordFieldIndexTest.p \
-
-ProgramFileList.p EofDefaultInput.p OpenArrayParam.p PrimitiveArgCall.p  SwapArrayElements.p
+        BoolTest1.p BoolTest2.p BoolTest3.p BoolTest4.p TestSuite.p math.p FileTests.p FileTests2.p TestCase.p inc.p pass-by-reference.p \
+        StringTruncationTest.p LowHighCharTest.p GlobalEnumTest.p EnumComparisonTest.p EnumCaseTest.p RecordFieldIndexTest.p \
+        ProgramFileList.p EofDefaultInput.p OpenArrayParam.p PrimitiveArgCall.p SwapArrayElements.p
 
 
 # Tests that are expected to fail compilation


### PR DESCRIPTION
## Summary
- fix typo and line continuations in Tests/Makefile

## Testing
- `cd Tests && make test` *(fails: `/bin/sh: 4: ../build/bin/pscal: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_689a71ab1ed0832a8f2a88e6b1edce92