### PR TITLE
Initialize halt and delay built-ins

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -3237,6 +3237,34 @@ static void configureBuiltinDummyAST(AST *dummy, const char *name) {
         AST* retNode = newASTNode(AST_VARIABLE, retTok); freeToken(retTok);
         setTypeAST(retNode, TYPE_INTEGER); setRight(dummy, retNode); dummy->var_type = TYPE_INTEGER;
     }
+    // --- Simple procedures (Delay, Halt, GetMouseState, etc.) ---
+    else if (strcasecmp(name, "delay") == 0) {
+        dummy->child_capacity = 1;
+        dummy->children = malloc(sizeof(AST*));
+        if (!dummy->children) { EXIT_FAILURE_HANDLER(); }
+        AST* p1 = newASTNode(AST_VAR_DECL, NULL);
+        setTypeAST(p1, TYPE_INTEGER);
+        Token* pn1 = newToken(TOKEN_IDENTIFIER, "_milliseconds", 0, 0);
+        AST* v1 = newASTNode(AST_VARIABLE, pn1); freeToken(pn1);
+        addChild(p1, v1);
+        dummy->children[0] = p1;
+        dummy->child_count = 1;
+        dummy->var_type = TYPE_VOID;
+    }
+    else if (strcasecmp(name, "halt") == 0) {
+        dummy->child_capacity = 1;
+        dummy->children = malloc(sizeof(AST*));
+        if (!dummy->children) { EXIT_FAILURE_HANDLER(); }
+        AST* p1 = newASTNode(AST_VAR_DECL, NULL);
+        setTypeAST(p1, TYPE_INTEGER);
+        Token* pn1 = newToken(TOKEN_IDENTIFIER, "_exitCode", 0, 0);
+        AST* v1 = newASTNode(AST_VARIABLE, pn1); freeToken(pn1);
+        addChild(p1, v1);
+        dummy->children[0] = p1;
+        dummy->child_count = 1; // optional argument, compiler allows 0 or 1
+        dummy->i_val = 0; // zero required parameters
+        dummy->var_type = TYPE_VOID;
+    }
     // --- Procedures with specific params (getmousestate, etc.) ---
     else if (strcasecmp(name, "getmousestate") == 0) {
         dummy->child_capacity = 3; dummy->children = malloc(sizeof(AST*) * 3); if (!dummy->children) { EXIT_FAILURE_HANDLER(); }

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -1752,9 +1752,17 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
             if (proc_symbol && proc_symbol->type_def) {
                 int expected = proc_symbol->type_def->child_count;
                 bool is_inc_dec = (strcasecmp(calleeName, "inc") == 0 || strcasecmp(calleeName, "dec") == 0);
+                bool is_halt = (strcasecmp(calleeName, "halt") == 0);
                 if (is_inc_dec) {
                     if (!(node->child_count == 1 || node->child_count == 2)) {
                         fprintf(stderr, "L%d: Compiler Error: '%s' expects 1 or 2 argument(s) but %d were provided.\n",
+                                line, calleeName, node->child_count);
+                        compiler_had_error = true;
+                        param_mismatch = true;
+                    }
+                } else if (is_halt) {
+                    if (!(node->child_count == 0 || node->child_count == 1)) {
+                        fprintf(stderr, "L%d: Compiler Error: '%s' expects 0 or 1 argument(s) but %d were provided.\n",
                                 line, calleeName, node->child_count);
                         compiler_had_error = true;
                         param_mismatch = true;


### PR DESCRIPTION
## Summary
- define delay and halt parameters when registering built-in procedures
- allow halt to accept optional exit code in compiler argument checks

## Testing
- `mkdir build && cd build && cmake -DSDL=OFF .. && make -j$(nproc)`
- `bin/pscal /tmp/test_halt_delay.p >/tmp/test_output.log && cat /tmp/test_output.log`


------
https://chatgpt.com/codex/tasks/task_e_689a73370060832ab8d33b8f9c75b55d