### PR TITLE
Add scientific notation support in lexer

### DIFF
--- a/Tests/RealExponentTest.p
+++ b/Tests/RealExponentTest.p
@@ -1,0 +1,6 @@
+program RealExponentTest;
+var r: real;
+begin
+  r := 1e-6;
+  writeln(r);
+end.


### PR DESCRIPTION
## Summary
- extend numeric literal lexer to recognize `e` or `E` exponents
- add regression test for real literals with scientific notation

## Testing
- `bin/pscal --dump-bytecode ../Tests/RealExponentTest.p`
- `../Tests/run_tests.sh` *(failed: hangs after EofDefaultInput.p)*

------
https://chatgpt.com/codex/tasks/task_e_689a85922228832a9c7b194eb47cf540