### PR TITLE
Add example program using DOS unit

### DIFF
--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -8,6 +8,7 @@ set(PSCAL_BIN ${CMAKE_BINARY_DIR}/bin/pscal)
 add_custom_target(run_basic_examples
     COMMAND ${CMAKE_COMMAND} -E echo "Running basic examples..."
     COMMAND ${PSCAL_BIN} ${CMAKE_CURRENT_SOURCE_DIR}/AreaCalculation.p
+    COMMAND ${PSCAL_BIN} ${CMAKE_CURRENT_SOURCE_DIR}/DosExample.p
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 

--- a/Examples/DosExample.p
+++ b/Examples/DosExample.p
@@ -1,0 +1,13 @@
+#!/usr/bin/env pscal
+program DosExample;
+uses dos;
+var
+  Year, Month, Day, DayOfWeek : Word;
+  Hour, Min, Sec, Sec100 : Word;
+begin
+  GetDate(Year, Month, Day, DayOfWeek);
+  GetTime(Hour, Min, Sec, Sec100);
+  writeln('Today is: ', Month, '/', Day, '/', Year);
+  writeln('Current time: ', Hour, ':', Min, ':', Sec);
+  writeln('PATH environment variable: ', GetEnv('PATH'));
+end.


### PR DESCRIPTION
## Summary
- add `DosExample.p` to show date, time and PATH usage with the `dos` unit
- run DosExample via `run_basic_examples` target

## Testing
- `cmake -DSDL=OFF ..`
- `make -j$(nproc)`
- `make run_basic_examples` *(fails: Parser error at line 1, column 1: Expected token UNIT, got EOF)*

------
https://chatgpt.com/codex/tasks/task_e_689b46733584832abd8ba079707b7213