### PR TITLE
Fix byte/word printing to display numeric values

### DIFF
--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -1613,11 +1613,11 @@ void printValueToStream(Value v, FILE *stream) {
             }
             break;
         case TYPE_BYTE:
-             fprintf(stream, "BYTE(%lld)", v.i_val & 0xFF);
-             break;
+            fprintf(stream, "%lld", v.i_val & 0xFF);
+            break;
         case TYPE_WORD:
-             fprintf(stream, "WORD(%lld)", v.i_val & 0xFFFF);
-             break;
+            fprintf(stream, "%lld", v.i_val & 0xFFFF);
+            break;
         case TYPE_VOID:
             fprintf(stream, "<VOID_TYPE>");
             break;


### PR DESCRIPTION
## Summary
- Show numeric output for BYTE and WORD values in `printValueToStream`
- Prevent DOS example from printing `WORD(...)` wrappers

## Testing
- `build/bin/pscal Examples/DosExample.p`
- `./Tests/run_tests.sh` *(fails: Bus error and segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_689b48b9ff98832a84360a137e9dbe5f