### PR TITLE
Embed documented unit list and warn on missing libraries

### DIFF
--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -145,6 +145,7 @@ char *findUnitFile(const char *unit_name);
 void linkUnit(AST *unit_ast, int recursion_depth);
 Symbol *buildUnitSymbolTable(AST *interface_ast);
 void freeUnitSymbolTable(Symbol *symbol_table);
+bool isUnitDocumented(const char *unit_name);
 
 // General helpers
 // Helper function to map 0-15 to ANSI FG codes

--- a/src/documented_units.h
+++ b/src/documented_units.h
@@ -1,0 +1,20 @@
+// Generated from Docs/pscal_overview.md; do not edit manually.
+#ifndef DOCUMENTED_UNITS_H
+#define DOCUMENTED_UNITS_H
+
+#include <stddef.h>
+
+static const char *documented_units[] = {
+    "stringutil",
+    "base64",
+    "calculatearea",
+    "crt",
+    "crtmac",
+    "dos",
+    "mathlib",
+    "mylib",
+    "sysutils",
+};
+static const size_t documented_units_count = sizeof(documented_units) / sizeof(documented_units[0]);
+
+#endif // DOCUMENTED_UNITS_H

--- a/tools/gen_documented_units.py
+++ b/tools/gen_documented_units.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import re
+from pathlib import Path
+
+def main():
+    doc_path = Path('Docs/pscal_overview.md')
+    content = doc_path.read_text(encoding='utf-8')
+    try:
+        section = content.split('## Included Units', 1)[1]
+        section = section.split('## Summary', 1)[0]
+    except IndexError:
+        raise SystemExit('Could not find "## Included Units" section in documentation.')
+    units = re.findall(r'^###\s+(\w+)', section, flags=re.MULTILINE)
+    units_lower = [u.lower() for u in units]
+
+    header_path = Path('src/documented_units.h')
+    with header_path.open('w', encoding='utf-8') as f:
+        f.write('// Generated from Docs/pscal_overview.md; do not edit manually.\n')
+        f.write('#ifndef DOCUMENTED_UNITS_H\n#define DOCUMENTED_UNITS_H\n\n')
+        f.write('#include <stddef.h>\n\n')
+        f.write('static const char *documented_units[] = {\n')
+        for u in units_lower:
+            f.write(f'    "{u}",\n')
+        f.write('};\n')
+        f.write('static const size_t documented_units_count = sizeof(documented_units) / sizeof(documented_units[0]);\n\n')
+        f.write('#endif // DOCUMENTED_UNITS_H\n')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- Generate a `documented_units.h` header from `Docs/pscal_overview.md`
- Replace runtime doc scanning with compile-time lookup and warnings for undocumented missing units

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `Tests/run_tests.sh` *(fails: Bus error in DosUnitTest.p, segmentation fault in MathLibTest.p, additional bus errors)*

------
https://chatgpt.com/codex/tasks/task_e_689b5a678980832a98fac5050a8ff97b