### PR TITLE
Fix AST initialization and string constant handling

### DIFF
--- a/src/frontend/ast.c
+++ b/src/frontend/ast.c
@@ -57,6 +57,7 @@ AST *newASTNode(ASTNodeType type, Token *token) {
     node->i_val = 0; // Initialize i_val
     node->symbol_table = NULL; // Initialize symbol_table
     node->unit_list = NULL; // Initialize unit_list
+    node->type_def = NULL; // Ensure type definition pointer is initialized
 
     return node;
 }

--- a/src/frontend/parser.c
+++ b/src/frontend/parser.c
@@ -12,6 +12,7 @@
 #include "symbol/symbol.h"
 #include <stdbool.h>
 #include <stdio.h>
+#include <string.h>
 
 // Define the helper function *only* when DEBUG is enabled
 // No 'static inline' needed here as it's defined only once in this file.
@@ -2646,7 +2647,9 @@ AST *factor(Parser *parser) {
         return node; // <<< RETURN IMMEDIATELY
 
     } else if (initialTokenType == TOKEN_STRING_CONST) {
-        int isChar = (initialToken->value && initialToken->value[1] == '\0');
+        /* Treat zero-length strings as TYPE_STRING and single-character strings as TYPE_CHAR */
+        size_t len = (initialToken->value ? strlen(initialToken->value) : 0);
+        int isChar = (len == 1);
         Token* c = copyToken(initialToken);
         eat(parser, initialTokenType); // Eat the string token
         node = newASTNode(AST_STRING, c); freeToken(c);


### PR DESCRIPTION
## Summary
- Treat empty string constants safely and classify single-character strings as chars
- Initialize AST node `type_def` to prevent dangling pointer usage

## Testing
- `./Tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_689b60f01ec8832a85052c2a81595b47