### PR TITLE
Infer abs return type from argument

### DIFF
--- a/src/frontend/ast.c
+++ b/src/frontend/ast.c
@@ -541,6 +541,10 @@ void annotateTypes(AST *node, AST *currentScopeNode, AST *globalProgramNode) {
                             node->var_type = arg->var_type;
                             node->type_def = arg->type_def;
                         }
+                    } else if (strcasecmp(builtin_name, "abs") == 0) {
+                        AST* arg = node->children[0];
+                        node->var_type = arg->var_type;
+                        node->type_def = arg->type_def;
                     }
                 }
                 break;
@@ -694,8 +698,12 @@ VarType getBuiltinReturnType(const char* name) {
     }
 
     /* Math routines returning INTEGER */
-    if (strcasecmp(name, "abs")       == 0 ||
-        strcasecmp(name, "round")     == 0 ||
+    /*
+     * `abs` is intentionally omitted here because it returns the same
+     * type as its argument.  Its return type is inferred during AST
+     * annotation based on the provided parameter.
+     */
+    if (strcasecmp(name, "round")     == 0 ||
         strcasecmp(name, "trunc")     == 0 ||
         strcasecmp(name, "random")    == 0 ||
         strcasecmp(name, "ioresult")  == 0 ||


### PR DESCRIPTION
## Summary
- infer `abs`'s return type from its argument instead of defaulting to integer
- restore MathSuite01 to call `abs` directly in real comparisons

## Testing
- `mkdir -p build && cd build && cmake -DSDL=OFF .. && make`
- `bin/pscal ../Tests/MathSuite01.p`


------
https://chatgpt.com/codex/tasks/task_e_689b8053b548832aa4b7eb9498389de1