### PR TITLE
Allow CHAR arguments for STRING parameters

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -224,6 +224,12 @@ static bool typesMatch(AST* param_type, AST* arg_node, bool allow_coercion) {
             if (param_actual->var_type == TYPE_POINTER && arg_vt == TYPE_NIL) {
                 return true;
             }
+            // Treat CHAR and STRING as interchangeable without requiring
+            // coercion.  A CHAR is effectively a single-character STRING.
+            if ((param_actual->var_type == TYPE_STRING && arg_vt == TYPE_CHAR) ||
+                (param_actual->var_type == TYPE_CHAR   && arg_vt == TYPE_STRING)) {
+                return true;
+            }
             return false;
         }
     } else if (!arg_actual) {


### PR DESCRIPTION
## Summary
- Treat CHAR and STRING types as interchangeable when matching procedure arguments

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `../build/bin/pscal TestSuite7.p` *(fails: Bus error)*

------
https://chatgpt.com/codex/tasks/task_e_689b8573c50c832ab095d67540817f94