### PR TITLE
Handle width truncation for string formatting

### DIFF
--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -2281,7 +2281,9 @@ comparison_error_label:
                     snprintf(buf, sizeof(buf), "%*lld", width, raw_val.i_val);
                 } else if (raw_val.type == TYPE_STRING) {
                     const char* source_str = raw_val.s_val ? raw_val.s_val : "";
-                    snprintf(buf, sizeof(buf), "%*.*s", width, (int)strlen(source_str), source_str);
+                    size_t len = strlen(source_str);
+                    int prec = (width > 0 && (size_t)width < len) ? width : (int)len;
+                    snprintf(buf, sizeof(buf), "%*.*s", width, prec, source_str);
                 } else if (raw_val.type == TYPE_BOOLEAN) {
                     const char* bool_str = raw_val.i_val ? "TRUE" : "FALSE";
                     snprintf(buf, sizeof(buf), "%*s", width, bool_str);


### PR DESCRIPTION
## Summary
- ensure `:width` formatting truncates strings longer than the field width

## Testing
- `build/bin/pscal Tests/FormattingTestSuite`
- `bash Tests/run_tests.sh` *(fails: ArgumentTypeMismatch.p, DosUnitTest.p, MathLibTest.p, bus errors)*

------
https://chatgpt.com/codex/tasks/task_e_689b8754dcf0832a95ddac2a62f50eff