### PR TITLE
Initialize AST type_def to prevent segmentation faults

### DIFF
--- a/src/frontend/ast.c
+++ b/src/frontend/ast.c
@@ -57,6 +57,7 @@ AST *newASTNode(ASTNodeType type, Token *token) {
     node->i_val = 0; // Initialize i_val
     node->symbol_table = NULL; // Initialize symbol_table
     node->unit_list = NULL; // Initialize unit_list
+    node->type_def = NULL; // Initialize type definition link
 
     return node;
 }


### PR DESCRIPTION
## Summary
- Initialize the `type_def` pointer in newly created AST nodes to NULL.
- Prevents undefined memory access when resolving type aliases during compilation.

## Testing
- `ctest --test-dir build --rerun-failed --output-on-failure` *(fails: pscal_tests)*

------
https://chatgpt.com/codex/tasks/task_e_689bca0cfa58832aa449af74169a4a28