### PR TITLE
Handle invalid constant indices and remove OP_CALL byte limit

### DIFF
--- a/src/compiler/bytecode.h
+++ b/src/compiler/bytecode.h
@@ -81,7 +81,7 @@ typedef enum {
 
     // For now, built-ins might be handled specially, or we can add a generic call
     OP_CALL_BUILTIN,  // Placeholder for calling built-in functions
-                      // Needs: index of builtin, argument count
+                      // Operands: 2-byte name index, 1-byte argument count
     
     OP_CALL_BUILTIN_PROC, // For void built-in procedures. Operand1: builtin_id, Operand2: arg_count
     OP_CALL_USER_PROC,    // For user-defined procedures/functions. Operand1: name_const_idx, Operand2: arg_count
@@ -93,7 +93,7 @@ typedef enum {
 
     OP_POP,           // Pop the top value from the stack (e.g., after an expression statement)
     OP_CALL,          // For user-defined procedure/function calls.
-                      // Operands: 1-byte name_idx, 2-byte address, 1-byte arg count
+                      // Operands: 2-byte name_idx, 2-byte address, 1-byte arg count
     OP_HALT,          // Stop the VM (though OP_RETURN from main might suffice)
     OP_EXIT,          // Early exit from the current function without halting the VM
     OP_FORMAT_VALUE   // Format the value on top of the stack. Operands: width (byte), precision (byte)

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -2135,7 +2135,7 @@ comparison_error_label:
                 break;
             }
             case OP_CALL_BUILTIN: {
-                uint8_t name_const_idx = READ_BYTE();
+                uint16_t name_const_idx = READ_SHORT(vm);
                 uint8_t arg_count = READ_BYTE();
 
                 if (vm->stackTop - vm->stack < arg_count) {
@@ -2195,8 +2195,8 @@ comparison_error_label:
                     return INTERPRET_RUNTIME_ERROR;
                 }
 
-                // Operands: name_idx (1 byte), target_address (2 bytes), declared_arity (1 byte)
-                uint8_t name_idx_ignored = READ_BYTE(); // Read and discard the name index
+                // Operands: name_idx (2 bytes), target_address (2 bytes), declared_arity (1 byte)
+                uint16_t name_idx_ignored = READ_SHORT(vm); // Read and discard the name index
                 (void)name_idx_ignored; // Suppress unused variable warning
                 uint16_t target_address = READ_SHORT(vm);
                 uint8_t declared_arity = READ_BYTE();


### PR DESCRIPTION
## Summary
- Expand `OP_CALL` and `OP_CALL_BUILTIN` to use 16-bit constant indices so procedure and builtin names are no longer truncated
- Update compiler, VM, and disassembler to read and emit the wider operands and drop constant preloading

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `Tests/run_tests.sh` *(fails: ArgumentTypeMismatch.p; FileTests.p, FileTests2.p, ReadlnString.p, TestSuite7.p unexpectedly succeeded)*

------
https://chatgpt.com/codex/tasks/task_e_689bcbabdb58832a84840f9d9fe8b2d1