### PR TITLE
Fix Base64 decode table initialization

### DIFF
--- a/lib/base64.pl
+++ b/lib/base64.pl
@@ -2,16 +2,16 @@ unit Base64;
 
 interface
 
-function EncodeStringBase64(const s: string): string;
-function DecodeStringBase64(const s: string): string;
-
-implementation
-
 const
   Base64Chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
 
 var
   DecodeTable: array[0..127] of integer; { Simple ASCII range is enough }
+
+function EncodeStringBase64(const s: string): string;
+function DecodeStringBase64(const s: string): string;
+
+implementation
 
 procedure InitializeDecodeTable;
 var
@@ -126,13 +126,27 @@ begin
      if i <= len then c3 := DecodeTable[Ord(s[i])] else c3 := -1; inc(i); // Handle end padding
      if i <= len then c4 := DecodeTable[Ord(s[i])] else c4 := -1; inc(i); // Handle end padding
 
-     { Check for invalid characters (ignore padding chars here) }
-     if (c1=-1) or (c2=-1) or (c3=-1 and (i-1 <= len-padding)) or (c4=-1 and (i <= len-padding)) then
-     begin
-        writeln('Warning: Invalid character found in Base64 input.');
-        DecodeStringBase64 := '';
-        exit;
-     end;
+      { Check for invalid characters (ignore padding chars here) }
+      if (c1 = -1) or (c2 = -1) then
+      begin
+         writeln('Warning: Invalid character found in Base64 input.');
+         DecodeStringBase64 := '';
+         exit;
+      end;
+
+      if (c3 = -1) and ((i - 1) <= (len - padding)) then
+      begin
+         writeln('Warning: Invalid character found in Base64 input.');
+         DecodeStringBase64 := '';
+         exit;
+      end;
+
+      if (c4 = -1) and (i <= (len - padding)) then
+      begin
+         writeln('Warning: Invalid character found in Base64 input.');
+         DecodeStringBase64 := '';
+         exit;
+      end;
 
      { Combine 4x6 bits into 3x8 bits }
      b1 := (c1 shl 2) or (c2 shr 4);


### PR DESCRIPTION
## Summary
- declare `Base64Chars` and `DecodeTable` in Base64 unit interface
- add explicit invalid-character checks during Base64 decoding

## Testing
- `ctest --output-on-failure` *(fails: pscal_tests)*

------
https://chatgpt.com/codex/tasks/task_e_689c028710f0832abfa35a3998d430f8