### PR TITLE
feat: add bytecode caching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ set(PSCAL_SOURCES
     src/backend_ast/interpreter.c src/backend_ast/builtin.c
     src/backend_ast/builtin_network_api.c
     src/compiler/bytecode.c src/compiler/compiler.c
+    src/core/cache.c
     src/vm/vm.c
 )
 

--- a/src/core/cache.c
+++ b/src/core/cache.c
@@ -1,0 +1,191 @@
+#include "core/cache.h"
+#include "core/utils.h" // for Value constructors
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdint.h>
+
+#define CACHE_DIR ".pscal_cache"
+#define CACHE_MAGIC 0x50534243 /* 'PSBC' */
+#define CACHE_VERSION 1
+
+static unsigned long hash_path(const char* path) {
+    uint32_t hash = 2166136261u;
+    for (const unsigned char* p = (const unsigned char*)path; *p; ++p) {
+        hash ^= *p;
+        hash *= 16777619u;
+    }
+    return (unsigned long)hash;
+}
+
+static char* build_cache_path(const char* source_path) {
+    const char* home = getenv("HOME");
+    if (!home) return NULL;
+    size_t dir_len = strlen(home) + 1 + strlen(CACHE_DIR) + 1;
+    char* dir = (char*)malloc(dir_len);
+    if (!dir) return NULL;
+    snprintf(dir, dir_len, "%s/%s", home, CACHE_DIR);
+    mkdir(dir, 0777); // ensure directory exists
+
+    unsigned long h = hash_path(source_path);
+    size_t path_len = dir_len + 32;
+    char* full = (char*)malloc(path_len);
+    if (!full) { free(dir); return NULL; }
+    snprintf(full, path_len, "%s/%lu.bc", dir, h);
+    free(dir);
+    return full;
+}
+
+static bool is_cache_fresh(const char* cache_path, const char* source_path) {
+    struct stat src_stat, cache_stat;
+    if (stat(source_path, &src_stat) != 0) return false;
+    if (stat(cache_path, &cache_stat) != 0) return false;
+    return difftime(cache_stat.st_mtime, src_stat.st_mtime) >= 0;
+}
+
+static bool write_value(FILE* f, const Value* v) {
+    fwrite(&v->type, sizeof(v->type), 1, f);
+    switch (v->type) {
+        case TYPE_INTEGER:
+        case TYPE_WORD:
+        case TYPE_BYTE:
+        case TYPE_BOOLEAN:
+            fwrite(&v->i_val, sizeof(v->i_val), 1, f); break;
+        case TYPE_REAL:
+            fwrite(&v->r_val, sizeof(v->r_val), 1, f); break;
+        case TYPE_CHAR:
+            fwrite(&v->c_val, sizeof(v->c_val), 1, f); break;
+        case TYPE_STRING: {
+            int len = v->s_val ? (int)strlen(v->s_val) : 0;
+            fwrite(&len, sizeof(len), 1, f);
+            if (len > 0) fwrite(v->s_val, 1, len, f);
+            break;
+        }
+        case TYPE_NIL:
+            break;
+        case TYPE_ENUM: {
+            int len = v->enum_val.enum_name ? (int)strlen(v->enum_val.enum_name) : 0;
+            fwrite(&len, sizeof(len), 1, f);
+            if (len > 0) fwrite(v->enum_val.enum_name, 1, len, f);
+            fwrite(&v->enum_val.ordinal, sizeof(v->enum_val.ordinal), 1, f);
+            break;
+        }
+        default:
+            return false;
+    }
+    return true;
+}
+
+static bool read_value(FILE* f, Value* out) {
+    if (fread(&out->type, sizeof(out->type), 1, f) != 1) return false;
+    switch (out->type) {
+        case TYPE_INTEGER:
+        case TYPE_WORD:
+        case TYPE_BYTE:
+        case TYPE_BOOLEAN:
+            if (fread(&out->i_val, sizeof(out->i_val), 1, f) != 1) return false;
+            break;
+        case TYPE_REAL:
+            if (fread(&out->r_val, sizeof(out->r_val), 1, f) != 1) return false;
+            break;
+        case TYPE_CHAR:
+            if (fread(&out->c_val, sizeof(out->c_val), 1, f) != 1) return false;
+            break;
+        case TYPE_STRING: {
+            int len = 0;
+            if (fread(&len, sizeof(len), 1, f) != 1) return false;
+            if (len > 0) {
+                out->s_val = (char*)malloc(len + 1);
+                if (!out->s_val) return false;
+                if (fread(out->s_val, 1, len, f) != (size_t)len) return false;
+                out->s_val[len] = '\0';
+            } else {
+                out->s_val = NULL;
+            }
+            break;
+        }
+        case TYPE_NIL:
+            break;
+        case TYPE_ENUM: {
+            int len = 0;
+            if (fread(&len, sizeof(len), 1, f) != 1) return false;
+            if (len > 0) {
+                out->enum_val.enum_name = (char*)malloc(len + 1);
+                if (!out->enum_val.enum_name) return false;
+                if (fread(out->enum_val.enum_name, 1, len, f) != (size_t)len) return false;
+                out->enum_val.enum_name[len] = '\0';
+            } else {
+                out->enum_val.enum_name = NULL;
+            }
+            if (fread(&out->enum_val.ordinal, sizeof(out->enum_val.ordinal), 1, f) != 1) return false;
+            break;
+        }
+        default:
+            return false;
+    }
+    return true;
+}
+
+bool loadBytecodeFromCache(const char* source_path, BytecodeChunk* chunk) {
+    char* cache_path = build_cache_path(source_path);
+    if (!cache_path) return false;
+    bool ok = false;
+    if (is_cache_fresh(cache_path, source_path)) {
+        FILE* f = fopen(cache_path, "rb");
+        if (f) {
+            uint32_t magic = 0, ver = 0;
+            if (fread(&magic, sizeof(magic), 1, f) == 1 &&
+                fread(&ver, sizeof(ver), 1, f) == 1 &&
+                magic == CACHE_MAGIC && ver == CACHE_VERSION) {
+                int count = 0, const_count = 0;
+                if (fread(&count, sizeof(count), 1, f) == 1 &&
+                    fread(&const_count, sizeof(const_count), 1, f) == 1) {
+                    chunk->code = (uint8_t*)malloc(count);
+                    chunk->lines = (int*)malloc(sizeof(int) * count);
+                    chunk->constants = (Value*)calloc(const_count, sizeof(Value));
+                    if (chunk->code && chunk->lines && chunk->constants) {
+                        chunk->count = count; chunk->capacity = count;
+                        chunk->constants_count = const_count; chunk->constants_capacity = const_count;
+                        if (fread(chunk->code, 1, count, f) == (size_t)count &&
+                            fread(chunk->lines, sizeof(int), count, f) == (size_t)count) {
+                            ok = true;
+                            for (int i = 0; i < const_count; ++i) {
+                                if (!read_value(f, &chunk->constants[i])) { ok = false; break; }
+                            }
+                        }
+                    }
+                }
+            }
+            fclose(f);
+        }
+    }
+    free(cache_path);
+    if (!ok) {
+        free(chunk->code); chunk->code = NULL; chunk->lines = NULL; chunk->constants = NULL;
+        chunk->count = chunk->capacity = 0; chunk->constants_count = chunk->constants_capacity = 0;
+    }
+    return ok;
+}
+
+void saveBytecodeToCache(const char* source_path, const BytecodeChunk* chunk) {
+    char* cache_path = build_cache_path(source_path);
+    if (!cache_path) return;
+    FILE* f = fopen(cache_path, "wb");
+    if (!f) { free(cache_path); return; }
+    uint32_t magic = CACHE_MAGIC, ver = CACHE_VERSION;
+    fwrite(&magic, sizeof(magic), 1, f);
+    fwrite(&ver, sizeof(ver), 1, f);
+    fwrite(&chunk->count, sizeof(chunk->count), 1, f);
+    fwrite(&chunk->constants_count, sizeof(chunk->constants_count), 1, f);
+    fwrite(chunk->code, 1, chunk->count, f);
+    fwrite(chunk->lines, sizeof(int), chunk->count, f);
+    for (int i = 0; i < chunk->constants_count; ++i) {
+        if (!write_value(f, &chunk->constants[i])) { break; }
+    }
+    fclose(f);
+    free(cache_path);
+}

--- a/src/core/cache.h
+++ b/src/core/cache.h
@@ -1,0 +1,10 @@
+#ifndef PSCAL_CACHE_H
+#define PSCAL_CACHE_H
+
+#include <stdbool.h>
+#include "compiler/bytecode.h"
+
+bool loadBytecodeFromCache(const char* source_path, BytecodeChunk* chunk);
+void saveBytecodeToCache(const char* source_path, const BytecodeChunk* chunk);
+
+#endif // PSCAL_CACHE_H

--- a/src/main.c
+++ b/src/main.c
@@ -9,6 +9,7 @@
 #include "backend_ast/builtin.h"
 #include "compiler/bytecode.h"
 #include "compiler/compiler.h"
+#include "core/cache.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -228,122 +229,128 @@ int runProgram(const char *source, const char *programName, int dump_ast_json_fl
     fflush(stderr);
 #endif
 
-    Lexer lexer;
-    initLexer(&lexer, source);
-
-#ifdef DEBUG
-    fprintf(stderr, "\n--- Build AST Before Execution START (stderr print)---\n");
-#endif
-
-    Parser parser;
-    parser.lexer = &lexer;
-    parser.current_token = getNextToken(&lexer);
-    
-    // --- MODIFICATION: Initialize the main bytecode chunk here ---
     BytecodeChunk chunk;
     initBytecodeChunk(&chunk);
 
-    // --- MODIFICATION: Pass the chunk to the AST builder ---
-    AST *GlobalAST = buildProgramAST(&parser, &chunk);
+    AST *GlobalAST = NULL;
+    bool overall_success_status = false;
+    bool used_cache = false;
 
-    if (parser.current_token) {
-        freeToken(parser.current_token);
-        parser.current_token = NULL;
+    if (!dump_ast_json_flag && !use_ast_interpreter_flag) {
+        used_cache = loadBytecodeFromCache(programName, &chunk);
     }
 
-    bool overall_success_status = false;
-
-    if (GlobalAST && GlobalAST->type == AST_PROGRAM) {
-        annotateTypes(GlobalAST, NULL, GlobalAST);
+    if (!used_cache) {
+        Lexer lexer;
+        initLexer(&lexer, source);
 
 #ifdef DEBUG
-        fprintf(stderr, "--- Verifying AST Links ---\n");
-        if (verifyASTLinks(GlobalAST, NULL)) {
-            fprintf(stderr, "--- AST Link Verification Passed ---\n");
-        } else {
-            fprintf(stderr, "--- AST Link Verification FAILED ---\n");
+        fprintf(stderr, "\n--- Build AST Before Execution START (stderr print)---\n");
+#endif
+
+        Parser parser;
+        parser.lexer = &lexer;
+        parser.current_token = getNextToken(&lexer);
+
+        GlobalAST = buildProgramAST(&parser, &chunk);
+
+        if (parser.current_token) {
+            freeToken(parser.current_token);
+            parser.current_token = NULL;
         }
-        fprintf(stderr, "\n--- Build AST Before Execution END (stderr print)---\n");
+
+        if (GlobalAST && GlobalAST->type == AST_PROGRAM) {
+            annotateTypes(GlobalAST, NULL, GlobalAST);
+
+#ifdef DEBUG
+            fprintf(stderr, "--- Verifying AST Links ---\n");
+            if (verifyASTLinks(GlobalAST, NULL)) {
+                fprintf(stderr, "--- AST Link Verification Passed ---\n");
+            } else {
+                fprintf(stderr, "--- AST Link Verification FAILED ---\n");
+            }
+            fprintf(stderr, "\n--- Build AST Before Execution END (stderr print)---\n");
 #endif
 
-        if (dump_ast_json_flag) {
-            fprintf(stderr, "--- Dumping AST to JSON (stdout) ---\n");
-            dumpASTJSON(GlobalAST, stdout);
-            fprintf(stderr, "\n--- AST JSON Dump Complete (stderr print)---\n");
-            overall_success_status = true;
-        } else if (use_ast_interpreter_flag) {
-            fprintf(stderr, "\n--- Executing Program with AST Interpreter (selected by flag) ---\n");
+            if (dump_ast_json_flag) {
+                fprintf(stderr, "--- Dumping AST to JSON (stdout) ---\n");
+                dumpASTJSON(GlobalAST, stdout);
+                fprintf(stderr, "\n--- AST JSON Dump Complete (stderr print)---\n");
+                overall_success_status = true;
+            } else if (use_ast_interpreter_flag) {
+                fprintf(stderr, "\n--- Executing Program with AST Interpreter (selected by flag) ---\n");
 #ifdef DEBUG
-            if (dumpExec) { // Use your dumpExec flag for AST dump if running AST walker
-                fprintf(stderr, " ===== FINAL AST DUMP START (Textual to stderr if AST walker selected) =====\n");
-                dumpAST(GlobalAST, 0);
-                fprintf(stderr, " ===== FINAL AST DUMP END (Textual to stderr) =====\n");
-                dumpSymbolTable();
-            }
+                if (dumpExec) {
+                    fprintf(stderr, " ===== FINAL AST DUMP START (Textual to stderr if AST walker selected) =====\n");
+                    dumpAST(GlobalAST, 0);
+                    fprintf(stderr, " ===== FINAL AST DUMP END (Textual to stderr) =====\n");
+                    dumpSymbolTable();
+                }
 #endif
-            executeWithScope(GlobalAST, true);
-            overall_success_status = true;
-        } else {
-            // --- DEFAULT: COMPILE TO BYTECODE AND EXECUTE WITH VM ---
-            // The chunk is already initialized and populated with unit implementations.
-            // We just need to compile the main program block now.
-            if (dump_bytecode_flag) {
-                fprintf(stderr, "--- Compiling Main Program AST to Bytecode ---\n");
-            }
-            bool compilation_ok_for_vm = compileASTToBytecode(GlobalAST, &chunk);
-            
-            if (compilation_ok_for_vm) {
-                finalizeBytecode(&chunk); // Perform the final back-patching pass
-            }
-            
-            if (compilation_ok_for_vm) {
-                fprintf(stderr, "Compilation successful. Bytecode size: %d bytes, Constants: %d\n", chunk.count, chunk.constants_count);
-                if (dump_bytecode_flag) {
-                    disassembleBytecodeChunk(&chunk, programName ? programName : "CompiledChunk", procedure_table);
-                }
-                if (dump_bytecode_flag) {
-                    fprintf(stderr, "\n--- Executing Program with VM ---\n");
-                }
-            VM vm;
-            initVM(&vm);
-            InterpretResult result_vm = interpretBytecode(&vm, &chunk, globalSymbols, procedure_table);
-            freeVM(&vm);
-            globalSymbols = NULL; // Prevent subsequent freeHashTable(globalSymbols) in main's cleanup.
-            
-            if (result_vm == INTERPRET_OK) {
-                if (dump_bytecode_flag) {
-                    fprintf(stderr, "--- VM Execution Finished Successfully ---\n");
-                }
+                executeWithScope(GlobalAST, true);
                 overall_success_status = true;
             } else {
-                fprintf(stderr, "--- VM Execution Failed (%s) ---\n",
-                        result_vm == INTERPRET_RUNTIME_ERROR ? "Runtime Error" : "Compile Error (VM stage)");
-                    overall_success_status = false;
-                vm_dump_stack_info(&vm);
+                if (dump_bytecode_flag) {
+                    fprintf(stderr, "--- Compiling Main Program AST to Bytecode ---\n");
                 }
-            } else {
-                fprintf(stderr, "Compilation failed with errors.\n");
-                overall_success_status = false;
+                bool compilation_ok_for_vm = compileASTToBytecode(GlobalAST, &chunk);
+                if (compilation_ok_for_vm) {
+                    finalizeBytecode(&chunk);
+                    saveBytecodeToCache(programName, &chunk);
+                }
+                if (compilation_ok_for_vm) {
+                    fprintf(stderr, "Compilation successful. Bytecode size: %d bytes, Constants: %d\n", chunk.count, chunk.constants_count);
+                    if (dump_bytecode_flag) {
+                        disassembleBytecodeChunk(&chunk, programName ? programName : "CompiledChunk", procedure_table);
+                    }
+                    if (dump_bytecode_flag) {
+                        fprintf(stderr, "\n--- Executing Program with VM ---\n");
+                    }
+                    VM vm;
+                    initVM(&vm);
+                    InterpretResult result_vm = interpretBytecode(&vm, &chunk, globalSymbols, procedure_table);
+                    freeVM(&vm);
+                    globalSymbols = NULL;
+                    if (result_vm == INTERPRET_OK) {
+                        if (dump_bytecode_flag) {
+                            fprintf(stderr, "--- VM Execution Finished Successfully ---\n");
+                        }
+                        overall_success_status = true;
+                    } else {
+                        fprintf(stderr, "--- VM Execution Failed (%s) ---\n",
+                                result_vm == INTERPRET_RUNTIME_ERROR ? "Runtime Error" : "Compile Error (VM stage)");
+                        overall_success_status = false;
+                        vm_dump_stack_info(&vm);
+                    }
+                } else {
+                    fprintf(stderr, "Compilation failed with errors.\n");
+                    overall_success_status = false;
+                }
             }
-            
-            // This is already done below
-            // freeBytecodeChunk(&chunk);
+        } else if (!dump_ast_json_flag) {
+            fprintf(stderr, "Failed to build Program AST for execution.\n");
+            overall_success_status = false;
+        } else if (dump_ast_json_flag && (!GlobalAST || GlobalAST->type != AST_PROGRAM)) {
+            fprintf(stderr, "Failed to build Program AST for JSON dump.\n");
+            overall_success_status = false;
         }
-    } else if (!dump_ast_json_flag) {
-        fprintf(stderr, "Failed to build Program AST for execution.\n");
-        overall_success_status = false;
-    } else if (dump_ast_json_flag && (!GlobalAST || GlobalAST->type != AST_PROGRAM)) {
-        fprintf(stderr, "Failed to build Program AST for JSON dump.\n");
-        overall_success_status = false;
+    } else {
+        if (dump_bytecode_flag) {
+            disassembleBytecodeChunk(&chunk, programName ? programName : "CompiledChunk", procedure_table);
+            fprintf(stderr, "\n--- Executing Program with VM (cached) ---\n");
+        }
+        VM vm;
+        initVM(&vm);
+        InterpretResult result_vm = interpretBytecode(&vm, &chunk, globalSymbols, procedure_table);
+        freeVM(&vm);
+        globalSymbols = NULL;
+        overall_success_status = (result_vm == INTERPRET_OK);
     }
 
-    // --- Cleanup ---
-    freeBytecodeChunk(&chunk); // Free chunk resources after use
+    freeBytecodeChunk(&chunk);
     freeProcedureTable();
     freeTypeTableASTNodes();
     freeTypeTable();
-
-    // --- FIX START: Move global symbol table cleanup here ---
     if (globalSymbols) {
         freeHashTable(globalSymbols);
         globalSymbols = NULL;
@@ -354,8 +361,6 @@ int runProgram(const char *source, const char *programName, int dump_ast_json_fl
         inserted_global_names = NULL;
     }
 #endif
-    // --- FIX END ---
-
     if (GlobalAST) {
         freeAST(GlobalAST);
         GlobalAST = NULL;
@@ -363,8 +368,6 @@ int runProgram(const char *source, const char *programName, int dump_ast_json_fl
 #ifdef SDL
     SdlCleanupAtExit();
 #endif
-    // The block that was here has been moved up.
-
     return overall_success_status ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 


### PR DESCRIPTION
## Summary
- cache compiled bytecode under `~/.pscal_cache`
- load cached chunks when up-to-date to skip compilation
- wire cache module into build system

## Testing
- `cmake -B build`
- `cmake --build build`
- `Tests/run_tests.sh` *(failing: FileTests.p unexpectedly succeeded, FileTests2.p unexpectedly succeeded, ReadlnString.p unexpectedly succeeded, TestSuite7.p unexpectedly succeeded)*

------
https://chatgpt.com/codex/tasks/task_e_689c9a8440b8832aa2ce9a53ac461acd