### PR TITLE
Persist procedure metadata in bytecode cache

### DIFF
--- a/src/core/cache.h
+++ b/src/core/cache.h
@@ -3,8 +3,9 @@
 
 #include <stdbool.h>
 #include "compiler/bytecode.h"
+#include "symbol/symbol.h"
 
-bool loadBytecodeFromCache(const char* source_path, BytecodeChunk* chunk);
-void saveBytecodeToCache(const char* source_path, const BytecodeChunk* chunk);
+bool loadBytecodeFromCache(const char* source_path, BytecodeChunk* chunk, HashTable* procedure_table);
+void saveBytecodeToCache(const char* source_path, const BytecodeChunk* chunk, HashTable* procedure_table);
 
 #endif // PSCAL_CACHE_H


### PR DESCRIPTION
## Summary
- extend bytecode cache to serialize and deserialize procedure tables alongside bytecode
- attempt to load cached bytecode on startup and fall back to recompilation, saving cache when successful

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./Misc/tall`


------
https://chatgpt.com/codex/tasks/task_e_689ca26284fc832a982e43a4e8191a97