### PR TITLE
Fix EOF built-in handling for file values

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -1022,19 +1022,26 @@ Value vmBuiltinEof(VM* vm, int arg_count, Value* args) {
             }
         }
     } else if (arg_count == 1) {
-        if (args[0].type != TYPE_POINTER || !args[0].ptr_val) {
-            runtimeError(vm, "Eof: Argument must be a VAR file parameter.");
+        if (args[0].type == TYPE_POINTER && args[0].ptr_val) {
+            Value* fileVarLValue = (Value*)args[0].ptr_val; // Dereference the pointer
+            if (fileVarLValue->type != TYPE_FILE) {
+                runtimeError(vm, "Argument to Eof must be a file variable.");
+                return makeBoolean(true);
+            }
+            if (!fileVarLValue->f_val) {
+                return makeBoolean(true); // Closed file is treated as EOF
+            }
+            stream = fileVarLValue->f_val;
+        } else if (args[0].type == TYPE_FILE) {
+            if (!args[0].f_val) {
+                return makeBoolean(true); // Closed file is treated as EOF
+            }
+            stream = args[0].f_val;
+            args[0].f_val = NULL; // Prevent freeValue from closing the stream
+        } else {
+            runtimeError(vm, "Eof: Argument must be a file or VAR file parameter.");
             return makeBoolean(true);
         }
-        Value* fileVarLValue = (Value*)args[0].ptr_val; // Dereference the pointer
-        if (fileVarLValue->type != TYPE_FILE) {
-            runtimeError(vm, "Argument to Eof must be a file variable.");
-            return makeBoolean(true);
-        }
-        if (!fileVarLValue->f_val) {
-            return makeBoolean(true); // Closed file is treated as EOF
-        }
-        stream = fileVarLValue->f_val;
     } else {
         runtimeError(vm, "Eof expects 0 or 1 arguments.");
         return makeBoolean(true);

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -1737,6 +1737,7 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
                 int expected = proc_symbol->type_def->child_count;
                 bool is_inc_dec = (strcasecmp(calleeName, "inc") == 0 || strcasecmp(calleeName, "dec") == 0);
                 bool is_halt = (strcasecmp(calleeName, "halt") == 0);
+                bool is_eof  = (strcasecmp(calleeName, "eof") == 0);
                 if (is_inc_dec) {
                     if (!(node->child_count == 1 || node->child_count == 2)) {
                         fprintf(stderr, "L%d: Compiler Error: '%s' expects 1 or 2 argument(s) but %d were provided.\n",
@@ -1745,6 +1746,13 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
                         param_mismatch = true;
                     }
                 } else if (is_halt) {
+                    if (!(node->child_count == 0 || node->child_count == 1)) {
+                        fprintf(stderr, "L%d: Compiler Error: '%s' expects 0 or 1 argument(s) but %d were provided.\n",
+                                line, calleeName, node->child_count);
+                        compiler_had_error = true;
+                        param_mismatch = true;
+                    }
+                } else if (is_eof) {
                     if (!(node->child_count == 0 || node->child_count == 1)) {
                         fprintf(stderr, "L%d: Compiler Error: '%s' expects 0 or 1 argument(s) but %d were provided.\n",
                                 line, calleeName, node->child_count);
@@ -1832,7 +1840,7 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
                     is_var_param = true;
                 }
                 else if (calleeName && (
-                    (i == 0 && (strcasecmp(calleeName, "new") == 0 || strcasecmp(calleeName, "dispose") == 0 || strcasecmp(calleeName, "assign") == 0 || strcasecmp(calleeName, "reset") == 0 || strcasecmp(calleeName, "rewrite") == 0 || strcasecmp(calleeName, "close") == 0 || strcasecmp(calleeName, "inc") == 0 || strcasecmp(calleeName, "dec") == 0 || strcasecmp(calleeName, "mstreamloadfromfile") == 0 || strcasecmp(calleeName, "mstreamsavetofile") == 0 || strcasecmp(calleeName, "mstreamfree") == 0)) ||
+                    (i == 0 && (strcasecmp(calleeName, "new") == 0 || strcasecmp(calleeName, "dispose") == 0 || strcasecmp(calleeName, "assign") == 0 || strcasecmp(calleeName, "reset") == 0 || strcasecmp(calleeName, "rewrite") == 0 || strcasecmp(calleeName, "close") == 0 || strcasecmp(calleeName, "inc") == 0 || strcasecmp(calleeName, "dec") == 0 || strcasecmp(calleeName, "mstreamloadfromfile") == 0 || strcasecmp(calleeName, "mstreamsavetofile") == 0 || strcasecmp(calleeName, "mstreamfree") == 0 || strcasecmp(calleeName, "eof") == 0)) ||
                     (strcasecmp(calleeName, "readln") == 0 && (i > 0 || (i == 0 && arg_node->var_type != TYPE_FILE))) ||
                     (strcasecmp(calleeName, "getmousestate") == 0) || // All params are VAR
                     (strcasecmp(calleeName, "gettextsize") == 0 && i > 0) // Width and Height are VAR


### PR DESCRIPTION
## Summary
- Allow `eof` to accept zero or one arguments and treat first argument as VAR when compiling
- Permit `eof` VM builtin to handle file values without crashing and avoid closing streams implicitly

## Testing
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)`
- `PSCAL_LIB_DIR=lib build/bin/pscal Tests/FileTests.p`
- `PSCAL_LIB_DIR=lib build/bin/pscal Tests/EofDefaultInput.p` *(hangs awaiting input)*

------
https://chatgpt.com/codex/tasks/task_e_689cb70222bc832a9053faeedb64ce9c