### PR TITLE
Add PollKey builtin

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -122,6 +122,7 @@ static const VmBuiltinMapping vmBuiltinDispatchTable[] = {
     {"paramstr", vmBuiltinParamstr},
 #ifdef SDL
     {"playsound", vmBuiltinPlaysound},
+    {"pollkey", vmBuiltinPollkey},
 #endif
     {"pos", vmBuiltinPos},
 #ifdef SDL
@@ -1614,6 +1615,7 @@ static const BuiltinMapping builtin_dispatch_table[] = {
     {"paramstr",  executeBuiltinParamstr},
 #ifdef SDL
     {"playsound", executeBuiltinPlaySound},
+    {"pollkey", executeBuiltinPollKey},
 #endif
     {"pos",       executeBuiltinPos},
 #ifdef SDL
@@ -3173,7 +3175,11 @@ static void configureBuiltinDummyAST(AST *dummy, const char *name) {
              strcasecmp(name, "wherex") == 0 ||
              strcasecmp(name, "wherey") == 0 ||
              strcasecmp(name, "createtexture") == 0 ||
-             strcasecmp(name, "loadsound") == 0 ) {
+             strcasecmp(name, "loadsound") == 0
+#ifdef SDL
+             || strcasecmp(name, "pollkey") == 0
+#endif
+             ) {
 
         if (strcasecmp(name, "ord") == 0 || strcasecmp(name, "round") == 0 || strcasecmp(name, "trunc") == 0 || strcasecmp(name, "length") == 0 || strcasecmp(name, "loadsound") == 0) {
             dummy->child_capacity = 1;

--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -165,6 +165,7 @@ Value executeBuiltinGraphLoop(AST *node);
 Value executeBuiltinUpdateScreen(AST *node);
 Value executeBuiltinClearDevice(AST *node);
 Value executeBuiltinWaitKeyEvent(AST *node);
+Value executeBuiltinPollKey(AST *node);
 Value executeBuiltinGetMaxX(AST *node);
 Value executeBuiltinGetMaxY(AST *node);
 Value executeBuiltinGetTicks(AST *node);
@@ -196,6 +197,7 @@ Value executeBuiltinLoadImageToTexture(AST *node);
 Value executeBuiltinRenderTextToTexture(AST *node);
 Value executeBuiltinSetAlphaBlend(AST *node);
 Value vmBuiltinLoadimagetotexture(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinPollkey(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinWaitkeyevent(struct VM_s* vm, int arg_count, Value* args);
 
 // Prototypes from audio.c (via audio.h)

--- a/src/backend_ast/sdl.h
+++ b/src/backend_ast/sdl.h
@@ -45,6 +45,7 @@ Value executeBuiltinGraphLoop(AST *node);
 Value executeBuiltinUpdateScreen(AST *node);
 Value executeBuiltinClearDevice(AST *node);
 Value executeBuiltinWaitKeyEvent(AST *node);
+Value executeBuiltinPollKey(AST *node);
 Value executeBuiltinGetMaxX(AST *node);
 Value executeBuiltinGetMaxY(AST *node);
 Value executeBuiltinGetTicks(AST *node);
@@ -110,6 +111,7 @@ Value vmBuiltinRendercopyex(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinSetcolor(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinSetrendertarget(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinUpdatetexture(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinPollkey(struct VM_s* vm, int arg_count, Value* args);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- support PollKey builtin with integer return type
- implement SDL runtime handlers for PollKey
- wire PollKey into builtin dispatch tables

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest` *(fails: pscal_tests)*

------
https://chatgpt.com/codex/tasks/task_e_689cbecc79bc832a892e33f1bfe6a1ae