### PR TITLE
Handle READ statements in compiler and VM

### DIFF
--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -63,6 +63,7 @@ Value vmBuiltinAssign(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinReset(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinRewrite(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinClose(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinRead(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinReadln(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinEof(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinIoresult(struct VM_s* vm, int arg_count, Value* args);

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -1526,9 +1526,29 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
             endLoop(); // <<< MODIFIED
             break;
         }
+        case AST_READ: {
+            int line = getLine(node);
+
+            int var_start_index = 0;
+            if (node->child_count > 0 && node->children[0]->var_type == TYPE_FILE) {
+                compileRValue(node->children[0], chunk, getLine(node->children[0]));
+                var_start_index = 1;
+            }
+
+            for (int i = var_start_index; i < node->child_count; i++) {
+                AST* arg_node = node->children[i];
+                compileLValue(arg_node, chunk, getLine(arg_node));
+            }
+
+            int nameIndex = addStringConstant(chunk, "read");
+            writeBytecodeChunk(chunk, OP_CALL_BUILTIN, line);
+            emitShort(chunk, (uint16_t)nameIndex, line);
+            writeBytecodeChunk(chunk, (uint8_t)node->child_count, line);
+            break;
+        }
         case AST_READLN: {
             int line = getLine(node);
-            
+
             int var_start_index = 0;
             // Check if the first argument is a file variable. We can guess based on its type,
             // which the annotation pass should have set on the AST node.


### PR DESCRIPTION
## Summary
- Compile Pascal `read` statements to bytecode
- Implement `read` as a VM builtin and register it

## Testing
- `cmake --build build`
- `../build/bin/pscal --dump-bytecode FileTests2.p`

------
https://chatgpt.com/codex/tasks/task_e_689ccbcadcd8832ab38895940447c3d7