### PR TITLE
Improve bytecode caching robustness

### DIFF
--- a/src/core/cache.h
+++ b/src/core/cache.h
@@ -7,5 +7,6 @@
 
 bool loadBytecodeFromCache(const char* source_path, BytecodeChunk* chunk, HashTable* procedure_table);
 void saveBytecodeToCache(const char* source_path, const BytecodeChunk* chunk, HashTable* procedure_table);
+char* ensureCacheDir(void);
 
 #endif // PSCAL_CACHE_H

--- a/src/main.c
+++ b/src/main.c
@@ -224,7 +224,7 @@ int runProgram(const char *source_code, const char *source_path, const char *pro
     registerBuiltinFunction("UpCase", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("WhereX", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("WhereY", AST_FUNCTION_DECL, NULL);
-    
+
 #ifdef DEBUG
     fprintf(stderr, "Completed all built-in registrations. About to init lexer.\n");
     fflush(stderr);
@@ -235,6 +235,9 @@ int runProgram(const char *source_code, const char *source_path, const char *pro
 
     AST *GlobalAST = NULL;
     bool overall_success_status = false;
+
+    char* cache_dir_check = ensureCacheDir();
+    free(cache_dir_check);
 
     if (loadBytecodeFromCache(source_path, &chunk, procedure_table)) {
         if (dump_bytecode_flag) {


### PR DESCRIPTION
## Summary
- ensure `~/.pscal_cache` is created with user-only permissions and abort if it can't be accessed
- guard cache reads and writes with explicit error handling and version/mtime checks
- verify cache directory at startup so execution fails fast when caching isn't available

## Testing
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)`
- `Tests/run_tests.sh` *(fails: ArgumentTypeMismatch.p, FileTests.p, FileTests2.p, ReadlnString.p, TestSuite7.p)*

------
https://chatgpt.com/codex/tasks/task_e_689e470ad6b4832a8c3a385dbd34d97e