### PR TITLE
Log cache directory path for bytecode caching

### DIFF
--- a/src/core/cache.c
+++ b/src/core/cache.c
@@ -62,6 +62,12 @@ char* ensureCacheDir(void) {
     }
     snprintf(dir, dir_len, "%s/%s", home, CACHE_DIR);
 
+    static bool printed = false;
+    if (!printed) {
+        fprintf(stderr, "Using cache directory: %s\n", dir);
+        printed = true;
+    }
+
     struct stat st;
     if (stat(dir, &st) != 0) {
         if (errno != ENOENT) {
@@ -386,6 +392,7 @@ void saveBytecodeToCache(const char* source_path, const BytecodeChunk* chunk, Ha
         fprintf(stderr, "Error: Could not determine cache path for '%s'.\n", source_path);
         exit(EXIT_FAILURE);
     }
+    fprintf(stderr, "Saving bytecode cache to %s\n", cache_path);
     int fd = open(cache_path, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
     if (fd < 0) {
         fprintf(stderr, "Error: Could not write cache file '%s': %s\n", cache_path, strerror(errno));


### PR DESCRIPTION
## Summary
- Print the resolved cache directory path used for storing compiled bytecode
- Log the full file path when saving bytecode caches

## Testing
- `cmake --build build`
- `Tests/run_tests.sh` *(fails: ArgumentTypeMismatch.p, EnumCaseTest.p, EnumComparisonTest.p, GlobalEnumTest.p, LowHighCharTest.p, NestedVarArray.p, RecordFieldIndexTest.p, RecordsArray.p, SuccEnumTest.p, tid.p, FileTests.p, ReadlnString.p)*

------
https://chatgpt.com/codex/tasks/task_e_689e5545d814832abf79e5908a37c243