### PR TITLE
Improve bytecode cache handling and execution setup

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -237,115 +237,74 @@ int runProgram(const char *source, const char *programName, int dump_ast_json_fl
     bool overall_success_status = false;
     bool used_cache = false;
 
-    if (!dump_ast_json_flag && !use_ast_interpreter_flag) {
-        used_cache = loadBytecodeFromCache(programName, &chunk);
-    }
+    Lexer lexer;
+    initLexer(&lexer, source);
+    Parser parser;
+    parser.lexer = &lexer;
+    parser.current_token = getNextToken(&lexer);
+    GlobalAST = buildProgramAST(&parser, &chunk);
+    if (parser.current_token) { freeToken(parser.current_token); parser.current_token = NULL; }
 
-    if (!used_cache) {
-        Lexer lexer;
-        initLexer(&lexer, source);
-
-#ifdef DEBUG
-        fprintf(stderr, "\n--- Build AST Before Execution START (stderr print)---\n");
-#endif
-
-        Parser parser;
-        parser.lexer = &lexer;
-        parser.current_token = getNextToken(&lexer);
-
-        GlobalAST = buildProgramAST(&parser, &chunk);
-
-        if (parser.current_token) {
-            freeToken(parser.current_token);
-            parser.current_token = NULL;
-        }
-
-        if (GlobalAST && GlobalAST->type == AST_PROGRAM) {
-            annotateTypes(GlobalAST, NULL, GlobalAST);
-
-#ifdef DEBUG
-            fprintf(stderr, "--- Verifying AST Links ---\n");
-            if (verifyASTLinks(GlobalAST, NULL)) {
-                fprintf(stderr, "--- AST Link Verification Passed ---\n");
-            } else {
-                fprintf(stderr, "--- AST Link Verification FAILED ---\n");
+    if (GlobalAST && GlobalAST->type == AST_PROGRAM) {
+        annotateTypes(GlobalAST, NULL, GlobalAST);
+        if (dump_ast_json_flag) {
+            fprintf(stderr, "--- Dumping AST to JSON (stdout) ---\n");
+            dumpASTJSON(GlobalAST, stdout);
+            fprintf(stderr, "\n--- AST JSON Dump Complete (stderr print)---\n");
+            overall_success_status = true;
+        } else if (use_ast_interpreter_flag) {
+            fprintf(stderr, "\n--- Executing Program with AST Interpreter (selected by flag) ---\n");
+            executeWithScope(GlobalAST, true);
+            overall_success_status = true;
+        } else {
+            if (!dump_ast_json_flag && !use_ast_interpreter_flag) {
+                used_cache = loadBytecodeFromCache(programName, &chunk);
             }
-            fprintf(stderr, "\n--- Build AST Before Execution END (stderr print)---\n");
-#endif
-
-            if (dump_ast_json_flag) {
-                fprintf(stderr, "--- Dumping AST to JSON (stdout) ---\n");
-                dumpASTJSON(GlobalAST, stdout);
-                fprintf(stderr, "\n--- AST JSON Dump Complete (stderr print)---\n");
-                overall_success_status = true;
-            } else if (use_ast_interpreter_flag) {
-                fprintf(stderr, "\n--- Executing Program with AST Interpreter (selected by flag) ---\n");
-#ifdef DEBUG
-                if (dumpExec) {
-                    fprintf(stderr, " ===== FINAL AST DUMP START (Textual to stderr if AST walker selected) =====\n");
-                    dumpAST(GlobalAST, 0);
-                    fprintf(stderr, " ===== FINAL AST DUMP END (Textual to stderr) =====\n");
-                    dumpSymbolTable();
-                }
-#endif
-                executeWithScope(GlobalAST, true);
-                overall_success_status = true;
-            } else {
+            bool compilation_ok_for_vm = true;
+            if (!used_cache) {
                 if (dump_bytecode_flag) {
                     fprintf(stderr, "--- Compiling Main Program AST to Bytecode ---\n");
                 }
-                bool compilation_ok_for_vm = compileASTToBytecode(GlobalAST, &chunk);
+                compilation_ok_for_vm = compileASTToBytecode(GlobalAST, &chunk);
                 if (compilation_ok_for_vm) {
                     finalizeBytecode(&chunk);
                     saveBytecodeToCache(programName, &chunk);
-                }
-                if (compilation_ok_for_vm) {
                     fprintf(stderr, "Compilation successful. Bytecode size: %d bytes, Constants: %d\n", chunk.count, chunk.constants_count);
                     if (dump_bytecode_flag) {
                         disassembleBytecodeChunk(&chunk, programName ? programName : "CompiledChunk", procedure_table);
-                    }
-                    if (dump_bytecode_flag) {
                         fprintf(stderr, "\n--- Executing Program with VM ---\n");
                     }
-                    VM vm;
-                    initVM(&vm);
-                    InterpretResult result_vm = interpretBytecode(&vm, &chunk, globalSymbols, procedure_table);
-                    freeVM(&vm);
-                    globalSymbols = NULL;
-                    if (result_vm == INTERPRET_OK) {
-                        if (dump_bytecode_flag) {
-                            fprintf(stderr, "--- VM Execution Finished Successfully ---\n");
-                        }
-                        overall_success_status = true;
-                    } else {
-                        fprintf(stderr, "--- VM Execution Failed (%s) ---\n",
-                                result_vm == INTERPRET_RUNTIME_ERROR ? "Runtime Error" : "Compile Error (VM stage)");
-                        overall_success_status = false;
-                        vm_dump_stack_info(&vm);
-                    }
-                } else {
-                    fprintf(stderr, "Compilation failed with errors.\n");
-                    overall_success_status = false;
                 }
+            } else if (dump_bytecode_flag) {
+                disassembleBytecodeChunk(&chunk, programName ? programName : "CompiledChunk", procedure_table);
+                fprintf(stderr, "\n--- Executing Program with VM (cached) ---\n");
             }
-        } else if (!dump_ast_json_flag) {
-            fprintf(stderr, "Failed to build Program AST for execution.\n");
-            overall_success_status = false;
-        } else if (dump_ast_json_flag && (!GlobalAST || GlobalAST->type != AST_PROGRAM)) {
-            fprintf(stderr, "Failed to build Program AST for JSON dump.\n");
-            overall_success_status = false;
+
+            if (compilation_ok_for_vm) {
+                VM vm;
+                initVM(&vm);
+                InterpretResult result_vm = interpretBytecode(&vm, &chunk, globalSymbols, procedure_table);
+                freeVM(&vm);
+                globalSymbols = NULL;
+                if (result_vm == INTERPRET_OK) {
+                    overall_success_status = true;
+                } else {
+                    fprintf(stderr, "--- VM Execution Failed (%s) ---\n",
+                            result_vm == INTERPRET_RUNTIME_ERROR ? "Runtime Error" : "Compile Error (VM stage)");
+                    overall_success_status = false;
+                    vm_dump_stack_info(&vm);
+                }
+            } else {
+                fprintf(stderr, "Compilation failed with errors.\n");
+                overall_success_status = false;
+            }
         }
-    } else {
-        if (dump_bytecode_flag) {
-            disassembleBytecodeChunk(&chunk, programName ? programName : "CompiledChunk", procedure_table);
-            fprintf(stderr, "\n--- Executing Program with VM (cached) ---\n");
-        }
-        VM vm;
-        initVM(&vm);
-        InterpretResult result_vm = interpretBytecode(&vm, &chunk, globalSymbols, procedure_table);
-        freeVM(&vm);
-        globalSymbols = NULL;
-        overall_success_status = (result_vm == INTERPRET_OK);
+    } else if (!dump_ast_json_flag) {
+        fprintf(stderr, "Failed to build Program AST for execution.\n");
+        overall_success_status = false;
+    } else if (dump_ast_json_flag && (!GlobalAST || GlobalAST->type != AST_PROGRAM)) {
+        fprintf(stderr, "Failed to build Program AST for JSON dump.\n");
+        overall_success_status = false;
     }
 
     freeBytecodeChunk(&chunk);


### PR DESCRIPTION
## Summary
- Serialize set constants and procedure metadata to support full bytecode cache round trips
- Always rebuild AST and type tables before loading cached bytecode and patching procedure symbols
- Harden cache loading by freeing partially read constants and resetting chunks on error

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `./build/bin/pscal Tests/TypeTestSuite`
- `./build/bin/pscal Tests/TypeTestSuite` *(cached)*
- `./Misc/tall`
- `./Misc/tall` *(cached)*

------
https://chatgpt.com/codex/tasks/task_e_689e897d1e58832a8807cadc25ef59e8