### PR TITLE
Persist global constants in bytecode cache

### DIFF
--- a/src/core/cache.c
+++ b/src/core/cache.c
@@ -13,7 +13,7 @@
 
 #define CACHE_DIR ".pscal_cache"
 #define CACHE_MAGIC 0x50534243 /* 'PSBC' */
-#define CACHE_VERSION 1
+#define CACHE_VERSION 2
 
 static unsigned long hash_path(const char* path) {
     uint32_t hash = 2166136261u;
@@ -205,6 +205,37 @@ bool loadBytecodeFromCache(const char* source_path, BytecodeChunk* chunk) {
                                         }
                                         free(name);
                                     }
+
+                                    if (ok) {
+                                        int const_sym_count = 0;
+                                        if (fread(&const_sym_count, sizeof(const_sym_count), 1, f) == 1) {
+                                            for (int i = 0; i < const_sym_count; ++i) {
+                                                int name_len = 0;
+                                                if (fread(&name_len, sizeof(name_len), 1, f) != 1) { ok = false; break; }
+                                                char* name = (char*)malloc(name_len + 1);
+                                                if (!name) { ok = false; break; }
+                                                if (fread(name, 1, name_len, f) != (size_t)name_len) {
+                                                    free(name); ok = false; break; }
+                                                name[name_len] = '\0';
+                                                VarType type;
+                                                if (fread(&type, sizeof(type), 1, f) != 1) { free(name); ok = false; break; }
+                                                Value val;
+                                                if (!read_value(f, &val)) { free(name); ok = false; break; }
+                                                insertGlobalSymbol(name, type, NULL);
+                                                Symbol* sym = lookupGlobalSymbol(name);
+                                                if (sym && sym->value) {
+                                                    freeValue(sym->value);
+                                                    *(sym->value) = val;
+                                                    sym->is_const = true;
+                                                } else {
+                                                    freeValue(&val);
+                                                }
+                                                free(name);
+                                            }
+                                        } else {
+                                            ok = false;
+                                        }
+                                    }
                                 } else {
                                     ok = false;
                                 }
@@ -264,6 +295,34 @@ void saveBytecodeToCache(const char* source_path, const BytecodeChunk* chunk) {
                 fwrite(&sym->bytecode_address, sizeof(sym->bytecode_address), 1, f);
                 fwrite(&sym->locals_count, sizeof(sym->locals_count), 1, f);
                 fwrite(&sym->upvalue_count, sizeof(sym->upvalue_count), 1, f);
+            }
+        }
+    }
+
+    int const_sym_count = 0;
+    if (globalSymbols) {
+        for (int i = 0; i < HASHTABLE_SIZE; i++) {
+            for (Symbol* sym = globalSymbols->buckets[i]; sym; sym = sym->next) {
+                if (sym->is_alias || !sym->is_const) continue;
+                const_sym_count++;
+            }
+        }
+    }
+    fwrite(&const_sym_count, sizeof(const_sym_count), 1, f);
+    if (globalSymbols) {
+        for (int i = 0; i < HASHTABLE_SIZE; i++) {
+            for (Symbol* sym = globalSymbols->buckets[i]; sym; sym = sym->next) {
+                if (sym->is_alias || !sym->is_const) continue;
+                int name_len = (int)strlen(sym->name);
+                fwrite(&name_len, sizeof(name_len), 1, f);
+                fwrite(sym->name, 1, name_len, f);
+                fwrite(&sym->type, sizeof(sym->type), 1, f);
+                if (sym->value) {
+                    write_value(f, sym->value);
+                } else {
+                    Value tmp = makeVoid();
+                    write_value(f, &tmp);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- save global constant symbols in bytecode cache and restore them on load
- bump cache format version to account for new data

## Testing
- `cmake -DSDL=OFF ..`
- `make -j$(nproc)`
- `ctest --output-on-failure` *(fails: pscal_tests)*

------
https://chatgpt.com/codex/tasks/task_e_689ea990b700832a860ec4af67a0983f