### PR TITLE
Implement getenv and val builtins

### DIFF
--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -85,9 +85,11 @@ Value vmBuiltinTrunc(struct VM_s* vm, int arg_count, Value* args);
 // --- VM-NATIVE RANDOM FUNCTIONS ---
 Value vmBuiltinRandomize(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinRandom(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinVal(struct VM_s* vm, int arg_count, Value* args);
 
 // --- VM-NATIVE DOS/OS FUNCTIONS ---
 Value vmBuiltinDosGetenv(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinGetenv(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinDosExec(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinDosMkdir(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinDosRmdir(struct VM_s* vm, int arg_count, Value* args);

--- a/src/main.c
+++ b/src/main.c
@@ -181,6 +181,7 @@ int runProgram(const char *source, const char *programName, int dump_ast_json_fl
     registerBuiltinFunction("EOF", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("Exit", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("Exp", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("GetEnv", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("Halt", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("High", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("Inc", AST_PROCEDURE_DECL, NULL);
@@ -222,6 +223,7 @@ int runProgram(const char *source, const char *programName, int dump_ast_json_fl
     registerBuiltinFunction("TextColorE", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("Trunc", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("UpCase", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("Val", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("WhereX", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("WhereY", AST_FUNCTION_DECL, NULL);
     


### PR DESCRIPTION
## Summary
- add VM implementations for `getenv` and `val`
- expose new builtins in dispatch tables and registration
- register builtin prototypes for parser

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `./build/bin/pscal Examples/hangman5`

------
https://chatgpt.com/codex/tasks/task_e_689ebd4bf34c832ab1e7ab53a16bd251