### PR TITLE
Improve VM console formatting support

### DIFF
--- a/lib/crt.pl
+++ b/lib/crt.pl
@@ -84,7 +84,7 @@ begin
   case OSKind of
     osLinux, osMac:
       begin
-        Write(ESC, '[2J');
+        BIClrScr;
         GotoXY(WinLeft, WinTop);
       end;
   else
@@ -235,17 +235,17 @@ end;
 
 procedure BoldText;
 begin
-  Write(ESC, '[1m');
+  BIBoldText;
 end;
 
 procedure UnderlineText;
 begin
-  Write(ESC, '[4m');
+  BIUnderlineText;
 end;
 
 procedure BlinkText;
 begin
-  Write(ESC, '[5m');
+  BIBlinkText;
 end;
 
 function WhereX: integer;
@@ -275,21 +275,19 @@ end;
 { Sets text attribute to high intensity (bold) }
 procedure HighVideo;
 begin
-  Write(ESC, '[1m');
+  BIBoldText;
 end;
 
 { Sets text attribute to low intensity (often dark gray foreground) }
 procedure LowVideo;
 begin
-  TextColor(DarkGray);
-  // Alternatively, could use faint code if supported: Write(ESC, '[2m');
+  BILowVideo;
 end;
 
 { Sets text attribute to the default/normal intensity and colors }
 procedure NormVideo;
 begin
-  NormalColors; // Reuse existing NormalColors procedure
-  // Alternatively, directly: Write(ESC, '[0m');
+  BINormVideo;
 end;
 
 { Defines a text window on the screen }

--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -55,6 +55,12 @@ Value vmBuiltinTextcolor(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinTextbackground(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinTextcolore(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinTextbackgrounde(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinBoldtext(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinUnderlinetext(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinBlinktext(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinNormvideo(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinLowvideo(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinClrscr(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinQuitrequested(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinReal(struct VM_s* vm, int arg_count, Value* args); // ADDED
 
@@ -154,6 +160,12 @@ Value executeBuiltinTextColorE(AST *node);
 Value executeBuiltinTextBackgroundE(AST *node);
 Value executeBuiltinTextColor(AST *node);
 Value executeBuiltinTextBackground(AST *node);
+Value executeBuiltinBoldText(AST *node);
+Value executeBuiltinUnderlineText(AST *node);
+Value executeBuiltinBlinkText(AST *node);
+Value executeBuiltinNormVideo(AST *node);
+Value executeBuiltinLowVideo(AST *node);
+Value executeBuiltinClrScr(AST *node);
 Value executeBuiltinNew(AST *node);
 Value executeBuiltinDispose(AST *node);
 Value executeBuiltinRealToStr(AST *node);

--- a/src/globals.c
+++ b/src/globals.c
@@ -38,6 +38,8 @@ int gCurrentTextBackground = 0;       // Default background color (Black in 16-c
 bool gCurrentTextBold      = false;   // Default text boldness state.
 bool gCurrentColorIsExt    = false;   // Flag for extended 256-color foreground mode.
 bool gCurrentBgIsExt       = false;   // Flag for extended 256-color background mode.
+bool gCurrentTextUnderline = false;   // Default underline state.
+bool gCurrentTextBlink     = false;   // Default blink state.
 // --- End CRT State Variables ---
 
 // Flag used by builtins like GraphLoop to signal a quit request from the user.

--- a/src/globals.h
+++ b/src/globals.h
@@ -50,6 +50,8 @@ extern int gCurrentTextBackground;
 extern bool gCurrentTextBold;
 extern bool gCurrentColorIsExt;
 extern bool gCurrentBgIsExt;
+extern bool gCurrentTextUnderline;
+extern bool gCurrentTextBlink;
 
 // --- Other Globals ---
 #define MAX_RECURSION_DEPTH 10

--- a/src/main.c
+++ b/src/main.c
@@ -217,6 +217,12 @@ int runProgram(const char *source, const char *programName, int dump_ast_json_fl
     registerBuiltinFunction("Succ", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("Tan", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("GotoXY", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("BoldText", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("BlinkText", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("UnderlineText", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("LowVideo", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("NormVideo", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("ClrScr", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("TextBackground", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("TextBackgroundE", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("TextColor", AST_PROCEDURE_DECL, NULL);

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -2070,21 +2070,34 @@ comparison_error_label:
                 if (output_stream == stdout) {
                     // Check if the current color settings are the default ones.
                     bool is_default_state = (gCurrentTextColor == 7 && gCurrentTextBackground == 0 &&
-                                             !gCurrentTextBold && !gCurrentColorIsExt && !gCurrentBgIsExt);
+                                             !gCurrentTextBold && !gCurrentTextUnderline && !gCurrentTextBlink &&
+                                             !gCurrentColorIsExt && !gCurrentBgIsExt);
 
                     if (!is_default_state) {
                         color_was_applied = true; // Mark that we're applying custom colors.
                         char escape_sequence[64] = "\x1B[";
                         char code_str[64];
                         bool first_attr = true;
+                        if (gCurrentTextBold) { strcat(escape_sequence, "1"); first_attr = false; }
+                        if (gCurrentTextUnderline) {
+                            if (!first_attr) strcat(escape_sequence, ";");
+                            strcat(escape_sequence, "4");
+                            first_attr = false;
+                        }
+                        if (gCurrentTextBlink) {
+                            if (!first_attr) strcat(escape_sequence, ";");
+                            strcat(escape_sequence, "5");
+                            first_attr = false;
+                        }
                         if (gCurrentColorIsExt) {
+                            if (!first_attr) strcat(escape_sequence, ";");
                             snprintf(code_str, sizeof(code_str), "38;5;%d", gCurrentTextColor);
                         } else {
-                            if (gCurrentTextBold) { strcat(escape_sequence, "1"); first_attr = false; }
+                            if (!first_attr) strcat(escape_sequence, ";");
                             snprintf(code_str, sizeof(code_str), "%d", map16FgColorToAnsi(gCurrentTextColor, gCurrentTextBold));
                         }
-                        if (!first_attr) strcat(escape_sequence, ";");
                         strcat(escape_sequence, code_str);
+                        first_attr = false;
                         strcat(escape_sequence, ";");
                         if (gCurrentBgIsExt) {
                             snprintf(code_str, sizeof(code_str), "48;5;%d", gCurrentTextBackground);


### PR DESCRIPTION
## Summary
- track underline and blink state for console output
- add built-in procedures for BoldText, UnderlineText, BlinkText, LowVideo, NormVideo and ClrScr
- apply new attributes in VM write operations and CRT unit

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest --output-on-failure` *(fails: VM runtime errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_689ec13812f0832aa9ab74852eb4c9af