### PR TITLE
Fix return type for BIWhereX/BIWhereY builtins

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -3329,6 +3329,8 @@ static void configureBuiltinDummyAST(AST *dummy, const char *name) {
              strcasecmp(name, "length") == 0 ||
              strcasecmp(name, "wherex") == 0 ||
              strcasecmp(name, "wherey") == 0 ||
+             strcasecmp(name, "biwherex") == 0 ||
+             strcasecmp(name, "biwherey") == 0 ||
              strcasecmp(name, "createtexture") == 0 ||
              strcasecmp(name, "loadsound") == 0 ||
              strcasecmp(name, "pollkey") == 0 ) {


### PR DESCRIPTION
## Summary
- ensure BIWhereX and BIWhereY builtins are recognized as integer functions, preventing spurious return type warnings

## Testing
- `build/bin/pscal Tests/FormattingTestSuite`
- `ctest --output-on-failure` *(fails: pscal_tests)*

------
https://chatgpt.com/codex/tasks/task_e_689f4c1cb418832abe5d9da271d839b8