### PR TITLE
Add READ statement support in compiler and VM

### DIFF
--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -69,6 +69,7 @@ Value vmBuiltinAssign(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinReset(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinRewrite(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinClose(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinRead(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinReadln(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinEof(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinIoresult(struct VM_s* vm, int arg_count, Value* args);


### PR DESCRIPTION
## Summary
- Handle `READ` statements in the compiler by compiling them into a call to builtin `read`
- Implement VM builtin `read` for token-based input and register it in the dispatch table
- Expose `vmBuiltinRead` in the builtin header

## Testing
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)`
- `Tests/run_tests.sh` *(fails: ArgumentTypeMismatch.p, DosUnitTest.p, MathLibTest.p, NestedVarArray.p, FileTests2.p, ReadlnString.p, TestSuite7.p)*

------
https://chatgpt.com/codex/tasks/task_e_689f4df1b124832abcd15c9521ad9e04