### PR TITLE
Allow SetColor VM builtin to accept byte values

### DIFF
--- a/src/backend_ast/sdl.c
+++ b/src/backend_ast/sdl.c
@@ -2808,7 +2808,10 @@ Value vmBuiltinRendercopyex(VM* vm, int arg_count, Value* args) {
 }
 
 Value vmBuiltinSetcolor(VM* vm, int arg_count, Value* args) {
-    if (arg_count != 1 || args[0].type != TYPE_INTEGER) { runtimeError(vm, "SetColor expects 1 argument (color index 0-255)."); return makeVoid(); }
+    if (arg_count != 1 || (args[0].type != TYPE_INTEGER && args[0].type != TYPE_BYTE)) {
+        runtimeError(vm, "SetColor expects 1 argument (color index 0-255).");
+        return makeVoid();
+    }
     if (!gSdlInitialized || !gSdlRenderer) { runtimeError(vm, "Graphics mode not initialized before SetColor."); return makeVoid(); }
 
     long long colorCode = args[0].i_val;


### PR DESCRIPTION
## Summary
- permit byte type as valid argument for VM SetColor

## Testing
- `ctest --output-on-failure` *(fails: ArgumentTypeMismatch.p reports compile-time error)*

------
https://chatgpt.com/codex/tasks/task_e_689f51f6298c832a8f38e6004c39029b