### PR TITLE
Correct ReadKey return type

### DIFF
--- a/src/frontend/ast.c
+++ b/src/frontend/ast.c
@@ -724,13 +724,15 @@ VarType getBuiltinReturnType(const char* name) {
     if (strcasecmp(name, "inttostr")  == 0 ||
         strcasecmp(name, "realtostr") == 0 ||
         strcasecmp(name, "paramstr")  == 0 ||
-        strcasecmp(name, "readkey")   == 0 ||
         strcasecmp(name, "copy")      == 0) {
         return TYPE_STRING;
     }
 
-    /* UpCase returns a single character */
-    if (strcasecmp(name, "upcase") == 0) return TYPE_CHAR;
+    /* ReadKey and UpCase return a single character */
+    if (strcasecmp(name, "readkey") == 0 ||
+        strcasecmp(name, "upcase")  == 0) {
+        return TYPE_CHAR;
+    }
 
     return TYPE_VOID;
 }


### PR DESCRIPTION
## Summary
- Treat `ReadKey` as a char-returning builtin rather than a string
- Group `ReadKey` with `UpCase` so char operations compile correctly

## Testing
- `cmake --build build -j$(nproc)`
- `ctest --output-on-failure` *(fails: pscal_tests)*

------
https://chatgpt.com/codex/tasks/task_e_689f595c2c94832aa6624625c18c8df7