### PR TITLE
Handle nil comparisons in VM equality operator

### DIFF
--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1012,8 +1012,20 @@ InterpretResult interpretBytecode(VM* vm, BytecodeChunk* chunk, HashTable* globa
                 Value result_val;
                 bool comparison_succeeded = false;
 
+                // Handle NIL comparisons explicitly. Only '=' and '<>' are allowed.
+                if (a_val.type == TYPE_NIL || b_val.type == TYPE_NIL) {
+                    if (instruction_val == OP_EQUAL) {
+                        result_val = makeBoolean(a_val.type == TYPE_NIL && b_val.type == TYPE_NIL);
+                        comparison_succeeded = true;
+                    } else if (instruction_val == OP_NOT_EQUAL) {
+                        result_val = makeBoolean(a_val.type != TYPE_NIL || b_val.type != TYPE_NIL);
+                        comparison_succeeded = true;
+                    } else {
+                        goto comparison_error_label;
+                    }
+                }
                 // Numeric comparison (Integers and Reals)
-                if (IS_NUMERIC(a_val) && IS_NUMERIC(b_val)) {
+                else if (IS_NUMERIC(a_val) && IS_NUMERIC(b_val)) {
                     if (a_val.type == TYPE_REAL || b_val.type == TYPE_REAL) {
                         double fa = as_f64(a_val);
                         double fb = as_f64(b_val);


### PR DESCRIPTION
## Summary
- Treat NIL operands gracefully in comparison opcodes, returning appropriate boolean results for '=' and '<>'
- Leave other comparison operators unchanged and still report an error for unsupported NIL comparisons

## Testing
- `ctest --output-on-failure` *(fails: Tests not passing in current environment)*
- `../Tests/run_tests.sh` *(fails: ArgumentTypeMismatch.p, DosUnitTest.p, MathLibTest.p, NestedVarArray.p, FileTests.p, FileTests2.p, ReadlnString.p, TestSuite7.p)*

------
https://chatgpt.com/codex/tasks/task_e_689f5cd01f74832aa612d6f9cea30155