### PR TITLE
Add offline weather parsing test

### DIFF
--- a/Tests/WeatherOfflineTest.p
+++ b/Tests/WeatherOfflineTest.p
@@ -1,0 +1,13 @@
+program WeatherOfflineTest;
+
+var
+  response: string;
+
+begin
+  response := api_receive(api_send('file:///workspace/pscal/Tests/weather_sample.json', ''));
+  if pos('"name":"Mountain View"', response) = 0 then halt(1);
+  if pos('"description":"clear sky"', response) = 0 then halt(1);
+  if pos('"temp":282.55', response) = 0 then halt(1);
+  if pos('"humidity":100', response) = 0 then halt(1);
+  if pos('"speed":1.5', response) = 0 then halt(1);
+end.

--- a/Tests/weather_sample.json
+++ b/Tests/weather_sample.json
@@ -1,0 +1,1 @@
+{"name":"Mountain View","weather":[{"description":"clear sky"}],"main":{"temp":282.55,"humidity":100},"wind":{"speed":1.5}}


### PR DESCRIPTION
## Summary
- exercise api_send/api_receive by fetching local weather_sample.json
- verify key fields to mirror weather example without requiring API key

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure` *(fails: 0% tests passed, 1 tests failed out of 1)*

------
https://chatgpt.com/codex/tasks/task_e_689f66806cf0832aa4c140e4bd8afe56