### PR TITLE
Add api_send/api_receive test

### DIFF
--- a/Tests/ApiSendReceiveTest.p
+++ b/Tests/ApiSendReceiveTest.p
@@ -1,0 +1,17 @@
+program ApiSendReceiveTest;
+
+var
+  ms: mstream;
+  response: string;
+  url: string;
+begin
+  url := 'http://example.com/';
+  ms := api_send(url, '');
+  response := api_receive(ms);
+  if pos('Example Domain', response) = 0 then
+  begin
+    writeln('Unexpected API response');
+    halt(1);
+  end;
+  writeln('API send/receive test passed');
+end.


### PR DESCRIPTION
## Summary
- add ApiSendReceiveTest using mstream with api_send and api_receive

## Testing
- `Tests/run_tests.sh` *(fails: api_send: curl_easy_perform() failed; other tests also failing)*

------
https://chatgpt.com/codex/tasks/task_e_689f6bc08530832aa1c8e4e59770fcda