### PR TITLE
Fix memory stream ownership in VM assignments

### DIFF
--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1594,7 +1594,14 @@ comparison_error_label:
                     }
                     else {
                         freeValue(target_lvalue_ptr);
-                        *target_lvalue_ptr = makeCopyOfValue(&value_to_set);
+                        if (value_to_set.type == TYPE_MEMORYSTREAM) {
+                            /* Transfer ownership of the MStream pointer without freeing it
+                             * when the temporary value is cleaned up below. */
+                            *target_lvalue_ptr = value_to_set;
+                            value_to_set.mstream = NULL;
+                        } else {
+                            *target_lvalue_ptr = makeCopyOfValue(&value_to_set);
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary
- prevent double-free when assigning MStream values by transferring ownership during `OP_SET_INDIRECT`

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `Tests/run_tests.sh` *(fails: curl_easy_perform HTTP error; several negative tests unexpectedly succeeded)*

------
https://chatgpt.com/codex/tasks/task_e_689f7a67f864832abbbd38009b30a595