### PR TITLE
Fix missing terminator when copying memory streams

### DIFF
--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -1750,19 +1750,21 @@ Value makeCopyOfValue(const Value *src) {
                     EXIT_FAILURE_HANDLER();
                 }
                 v.mstream->size = src->mstream->size;
-                v.mstream->capacity = src->mstream->capacity;
-                if (src->mstream->buffer && src->mstream->capacity > 0) {
-                    v.mstream->buffer = malloc(src->mstream->capacity);
+                if (src->mstream->buffer && src->mstream->size >= 0) {
+                    size_t copy_size = (size_t)src->mstream->size + 1;
+                    v.mstream->capacity = copy_size;
+                    v.mstream->buffer = malloc(copy_size);
                     if (!v.mstream->buffer) {
                         free(v.mstream);
                         fprintf(stderr, "Memory allocation failed in makeCopyOfValue (mstream buffer)\n");
                         EXIT_FAILURE_HANDLER();
                     }
-                    memcpy(v.mstream->buffer, src->mstream->buffer, src->mstream->size);
+                    memcpy(v.mstream->buffer, src->mstream->buffer, copy_size);
                 } else {
                     v.mstream->buffer = NULL;
+                    v.mstream->capacity = 0;
                 }
-            }
+                }
             break;
         case TYPE_SET:
             v.set_val.set_values = NULL;


### PR DESCRIPTION
## Summary
- Ensure memory stream copies allocate room for the terminator and include it when duplicating

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `build/bin/dscal --dump-bytecode Tests/ApiSendReceiveTest.p >/tmp/program.log 2>&1`
- `grep -n 'Unexpected API response' /tmp/program.log | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689f7e467814832a9afdecf936cff26f