### PR TITLE
Dereference pointer operands in string concatenation

### DIFF
--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -567,6 +567,16 @@ InterpretResult interpretBytecode(VM* vm, BytecodeChunk* chunk, HashTable* globa
         \
         /* String/char concatenation for OP_ADD */ \
         if (current_instruction_code == OP_ADD) { \
+            while (a_val_popped.type == TYPE_POINTER && a_val_popped.ptr_val) { \
+                Value tmp = makeCopyOfValue(a_val_popped.ptr_val); \
+                freeValue(&a_val_popped); \
+                a_val_popped = tmp; \
+            } \
+            while (b_val_popped.type == TYPE_POINTER && b_val_popped.ptr_val) { \
+                Value tmp = makeCopyOfValue(b_val_popped.ptr_val); \
+                freeValue(&b_val_popped); \
+                b_val_popped = tmp; \
+            } \
             if ((IS_STRING(a_val_popped) || IS_CHAR(a_val_popped)) && \
                 (IS_STRING(b_val_popped) || IS_CHAR(b_val_popped))) { \
                 char a_buffer[2] = {0}; \


### PR DESCRIPTION
## Summary
- Restore weather example to its original Pascal source
- Dereference pointer operands before string/char '+' to avoid runtime type errors

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure` *(fails: pscal_tests)*

------
https://chatgpt.com/codex/tasks/task_e_689f812d7afc832a9c92c1857f7f587d