### PR TITLE
Implement SetLength builtin and fix global string constant handling

### DIFF
--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -43,6 +43,7 @@ Value vmBuiltinSucc(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinUpcase(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinPos(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinCopy(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinSetlength(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinRealtostr(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinParamcount(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinParamstr(struct VM_s* vm, int arg_count, Value* args);


### PR DESCRIPTION
## Summary
- Implement `SetLength` as VM builtin and expose through dispatch table
- Avoid clobbering string constants when accessing globals
- Recognize new builtin via updated classification logic

## Testing
- `build/bin/pscal Examples/weather 98672` *(fails: missing API key)*
- `build/bin/pscal /tmp/desc_test.p`
- `cd Tests && ./run_tests.sh` *(fails: various environment-dependent tests)*

------
https://chatgpt.com/codex/tasks/task_e_689f84d4b5c0832a9e7c4d953c55f471