### PR TITLE
Fix pointer and nil comparison in VM

### DIFF
--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1007,17 +1007,17 @@ InterpretResult interpretBytecode(VM* vm, BytecodeChunk* chunk, HashTable* globa
                 Value result_val;
                 bool comparison_succeeded = false;
 
-                // Handle NIL comparisons explicitly. Only '=' and '<>' are allowed.
-                if (a_val.type == TYPE_NIL || b_val.type == TYPE_NIL) {
+                // Handle explicit NIL-to-NIL comparisons first.  Pointer/NIL
+                // comparisons are handled in the pointer block below.
+                if (a_val.type == TYPE_NIL && b_val.type == TYPE_NIL) {
                     if (instruction_val == OP_EQUAL) {
-                        result_val = makeBoolean(a_val.type == TYPE_NIL && b_val.type == TYPE_NIL);
-                        comparison_succeeded = true;
+                        result_val = makeBoolean(true);
                     } else if (instruction_val == OP_NOT_EQUAL) {
-                        result_val = makeBoolean(a_val.type != TYPE_NIL || b_val.type != TYPE_NIL);
-                        comparison_succeeded = true;
+                        result_val = makeBoolean(false);
                     } else {
                         goto comparison_error_label;
                     }
+                    comparison_succeeded = true;
                 }
                 // Numeric comparison (Integers and Reals)
                 else if (IS_NUMERIC(a_val) && IS_NUMERIC(b_val)) {


### PR DESCRIPTION
## Summary
- Correct VM equality logic to treat pointer–nil comparisons as intended
- Allow nil-to-nil comparisons while deferring mixed pointer/nil cases to pointer block

## Testing
- `./build/bin/pscal Tests/PointerTortureTest`

------
https://chatgpt.com/codex/tasks/task_e_689f89dddf9c832a93b6b9ccc7c22372