### PR TITLE
Echo typed replay character in hangman5 example

### DIFF
--- a/Examples/hangman5
+++ b/Examples/hangman5
@@ -412,7 +412,12 @@ begin
     padding := (effectiveWidth - length(promptMsg)) div 2; if padding < 0 then padding := 0;
     GotoXY(borderLeft + 1 + padding, vMsgRow + 3);
     write(promptMsg);
-    repeat replay := ReadKey; if replay = #0 then Delay(10); until (replay <> #0);
+    repeat
+      replay := ReadKey;
+      if replay = #0 then Delay(10);
+    until (replay <> #0);
+    if not (replay in [#10, #13]) then
+      write(replay);
 
   until not ( (UpCase(replay) = 'Y') or (replay = #10) or (replay = #13) );
 


### PR DESCRIPTION
## Summary
- Echo the key pressed at the replay prompt in `Examples/hangman5`.

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure` *(fails: pscal_tests)*
- `./bin/pscal ../Examples/hangman5` *(fails: Compiler Error: argument 1 to 'textcolor' expects type INTEGER but got VOID)*

------
https://chatgpt.com/codex/tasks/task_e_689f8e2425c4832a9f65795a7202a3c1