### PR TITLE
Implement custom real parsing for weather example

### DIFF
--- a/Examples/weather
+++ b/Examples/weather
@@ -20,7 +20,7 @@ var
   currentZipCode : string;
   apiKeyFromFile : string; // Variable for API Key
   tempC, tempF : real;      // Temperatures in Celsius and Fahrenheit
-  valCode : integer;        // Error code for Val
+  valCode : integer;        // Error code for StrToReal
 
 // --- Function to read API key from file ---
 function ReadApiKeyFromFile(filename: string): string;
@@ -139,6 +139,69 @@ begin
   end;
 end;
 
+// --- Convert string to real ---
+// Parses a simple decimal string like "123.45" into a real value.
+// Returns position of error (1-based) in code, or 0 on success.
+function StrToReal(s: string; var code: integer): real;
+var
+  i: integer;
+  negative: boolean;
+  intPart, fracPart: real;
+  divisor: real;
+begin
+  code := 0;
+  i := 1;
+  negative := False;
+  intPart := 0;
+  fracPart := 0;
+  divisor := 1;
+
+  if length(s) = 0 then
+  begin
+    code := 1;
+    StrToReal := 0;
+    exit;
+  end;
+
+  if s[i] = '-' then
+  begin
+    negative := True;
+    inc(i);
+  end
+  else if s[i] = '+' then
+    inc(i);
+
+  // Parse integer part
+  while (i <= length(s)) and (s[i] >= '0') and (s[i] <= '9') do
+  begin
+    intPart := intPart * 10 + (Ord(s[i]) - Ord('0'));
+    inc(i);
+  end;
+
+  // Parse fractional part
+  if (i <= length(s)) and (s[i] = '.') then
+  begin
+    inc(i);
+    while (i <= length(s)) and (s[i] >= '0') and (s[i] <= '9') do
+    begin
+      fracPart := fracPart * 10 + (Ord(s[i]) - Ord('0'));
+      divisor := divisor * 10;
+      inc(i);
+    end;
+  end;
+
+  // If there are leftover characters, report position of error
+  if i <= length(s) then
+    code := i
+  else
+    code := 0;
+
+  if negative then
+    StrToReal := -(intPart + fracPart / divisor)
+  else
+    StrToReal := intPart + fracPart / divisor;
+end;
+
 // --- Main Program ---
 begin
 
@@ -195,7 +258,7 @@ begin
   if searchPos > 0 then tempStr := ExtractNumericValueStr(response, 'temp', searchPos);
   if tempStr <> '' then
   begin
-    Val(tempStr, tempC, valCode);
+    tempC := StrToReal(tempStr, valCode);
     if valCode = 0 then
     begin
       tempF := tempC * 9 / 5 + 32;


### PR DESCRIPTION
## Summary
- add a `StrToReal` helper to parse decimal temperature strings
- replace `Val` call with `StrToReal` to avoid integer-only error

## Testing
- `build/bin/pscal Examples/weather 98672`
- `ctest --output-on-failure` *(fails: pscal_tests)*

------
https://chatgpt.com/codex/tasks/task_e_689f8e91d82c832aa35779d1154fffbf