### PR TITLE
chore: drop obsolete SDL include

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -6,10 +6,6 @@
 #include <stdlib.h> // For exit, EXIT_FAILURE
 
 #include "types.h" // Provides TypeEntry, Value, List, AST forward decl etc.
-#ifdef SDL
-#include "backend_ast/sdl.h"   // For SDL related externs or types if any directly in globals.h
-                   // (It's better if specific SDL globals are in sdl.h and sdl.c)
-#endif
 
 // --- EXIT_FAILURE_HANDLER Macro ---
 #ifdef SUPPRESS_EXIT


### PR DESCRIPTION
## Summary
- remove leftover `backend_ast/sdl.h` include from globals after AST backend removal

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd Tests && ./run_tests.sh` *(fails: undefined builtins and runtime errors)*

------
https://chatgpt.com/codex/tasks/task_e_689fb8e00370832aa3f85506b1a80ab4