### PR TITLE
Remove unused dumpSymbolTable declaration

### DIFF
--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -1157,9 +1157,6 @@ void dumpSymbol(Symbol *sym) {
     printf("\n");
 }
 
-/* Dump the global and local symbol tables. */
-void dumpSymbolTable(void);
-
 /*
  * debug_ast - A simple wrapper that begins dumping at the root with zero indent.
  */


### PR DESCRIPTION
## Summary
- drop dead dumpSymbolTable forward declaration from `utils.c`

## Testing
- `ctest --output-on-failure` *(fails: 1 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_689fbda58b44832a919d9efa8cd7a158