### PR TITLE
Add stubs for SDL graphics builtins

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -32,6 +32,23 @@ static DIR* dos_dir = NULL; // Used by dos_findfirst/findnext
 // Terminal cursor helper
 static int getCursorPosition(int *row, int *col);
 
+#ifndef SDL
+// Stubbed graphics state for non-SDL builds
+static int gStubGraphWidth = 0;
+static int gStubGraphHeight = 0;
+
+// Forward declarations for stubbed graphics built-ins
+static Value vmBuiltinInitgraph(struct VM_s* vm, int arg_count, Value* args);
+static Value vmBuiltinClosegraph(struct VM_s* vm, int arg_count, Value* args);
+static Value vmBuiltinCleardevice(struct VM_s* vm, int arg_count, Value* args);
+static Value vmBuiltinFillcircle(struct VM_s* vm, int arg_count, Value* args);
+static Value vmBuiltinGetmaxx(struct VM_s* vm, int arg_count, Value* args);
+static Value vmBuiltinGetmaxy(struct VM_s* vm, int arg_count, Value* args);
+static Value vmBuiltinGraphloop(struct VM_s* vm, int arg_count, Value* args);
+static Value vmBuiltinSetrgbcolor(struct VM_s* vm, int arg_count, Value* args);
+static Value vmBuiltinUpdatescreen(struct VM_s* vm, int arg_count, Value* args);
+#endif
+
 // The new dispatch table for the VM - MUST be defined before the function that uses it
 // This list MUST BE SORTED ALPHABETICALLY BY NAME (lowercase).
 static const VmBuiltinMapping vmBuiltinDispatchTable[] = {
@@ -50,14 +67,10 @@ static const VmBuiltinMapping vmBuiltinDispatchTable[] = {
     {"blinktext", vmBuiltinBlinktext},
     {"boldtext", vmBuiltinBoldtext},
     {"chr", vmBuiltinChr},
-#ifdef SDL
     {"cleardevice", vmBuiltinCleardevice},
-#endif
     {"clrscr", vmBuiltinClrscr},
     {"close", vmBuiltinClose},
-#ifdef SDL
     {"closegraph", vmBuiltinClosegraph},
-#endif
     {"copy", vmBuiltinCopy},
     {"cos", vmBuiltinCos},
 #ifdef SDL
@@ -88,26 +101,26 @@ static const VmBuiltinMapping vmBuiltinDispatchTable[] = {
     {"eof", vmBuiltinEof},
     {"exit", vmBuiltinExit},
     {"exp", vmBuiltinExp},
-#ifdef SDL
     {"fillcircle", vmBuiltinFillcircle},
+#ifdef SDL
     {"fillrect", vmBuiltinFillrect},
 #endif
     {"getenv", vmBuiltinGetenv},
-#ifdef SDL
     {"getmaxx", vmBuiltinGetmaxx},
     {"getmaxy", vmBuiltinGetmaxy},
+#ifdef SDL
     {"getmousestate", vmBuiltinGetmousestate},
     {"getpixelcolor", vmBuiltinGetpixelcolor}, // Moved
     {"gettextsize", vmBuiltinGettextsize},
     {"getticks", vmBuiltinGetticks},
-    {"graphloop", vmBuiltinGraphloop},
 #endif
+    {"graphloop", vmBuiltinGraphloop},
     {"gotoxy", vmBuiltinGotoxy},
     {"halt", vmBuiltinHalt},
     {"high", vmBuiltinHigh},
     {"inc", vmBuiltinInc},
-#ifdef SDL
     {"initgraph", vmBuiltinInitgraph},
+#ifdef SDL
     {"initsoundsystem", vmBuiltinInitsoundsystem},
     {"inittextsystem", vmBuiltinInittextsystem},
 #endif
@@ -173,8 +186,8 @@ static const VmBuiltinMapping vmBuiltinDispatchTable[] = {
     {"setalphablend", vmBuiltinSetalphablend},
     {"setcolor", vmBuiltinSetcolor}, // Moved
     {"setrendertarget", vmBuiltinSetrendertarget}, // Moved
-    {"setrgbcolor", vmBuiltinSetrgbcolor},
 #endif
+    {"setrgbcolor", vmBuiltinSetrgbcolor},
     {"sin", vmBuiltinSin},
     {"sqr", vmBuiltinSqr},
     {"sqrt", vmBuiltinSqrt},
@@ -187,8 +200,8 @@ static const VmBuiltinMapping vmBuiltinDispatchTable[] = {
     {"trunc", vmBuiltinTrunc},
     {"underlinetext", vmBuiltinUnderlinetext},
     {"upcase", vmBuiltinUpcase},
-#ifdef SDL
     {"updatescreen", vmBuiltinUpdatescreen},
+#ifdef SDL
     {"updatetexture", vmBuiltinUpdatetexture},
 #endif
     {"val", vmBuiltinVal},
@@ -2060,4 +2073,63 @@ BuiltinRoutineType getBuiltinType(const char *name) {
     }
     return BUILTIN_TYPE_NONE;
 }
+
+#ifndef SDL
+// ---------------------------------------------------------------------------
+// Stub implementations for graphics-related built-ins when SDL support is
+// not available. These provide no-op behavior so programs can still run on
+// platforms without the SDL dependency.
+
+static Value vmBuiltinInitgraph(struct VM_s* vm, int arg_count, Value* args) {
+    if (arg_count == 3 && args[0].type == TYPE_INTEGER && args[1].type == TYPE_INTEGER) {
+        gStubGraphWidth  = (int)args[0].i_val;
+        gStubGraphHeight = (int)args[1].i_val;
+    } else {
+        runtimeError(vm, "initgraph expects (Integer, Integer, String)");
+    }
+    return makeVoid();
+}
+
+static Value vmBuiltinClosegraph(struct VM_s* vm, int arg_count, Value* args) {
+    (void)vm; (void)arg_count; (void)args;
+    return makeVoid();
+}
+
+static Value vmBuiltinCleardevice(struct VM_s* vm, int arg_count, Value* args) {
+    (void)vm; (void)arg_count; (void)args;
+    return makeVoid();
+}
+
+static Value vmBuiltinFillcircle(struct VM_s* vm, int arg_count, Value* args) {
+    (void)vm; (void)arg_count; (void)args;
+    return makeVoid();
+}
+
+static Value vmBuiltinSetrgbcolor(struct VM_s* vm, int arg_count, Value* args) {
+    (void)vm; (void)arg_count; (void)args;
+    return makeVoid();
+}
+
+static Value vmBuiltinUpdatescreen(struct VM_s* vm, int arg_count, Value* args) {
+    (void)vm; (void)arg_count; (void)args;
+    return makeVoid();
+}
+
+static Value vmBuiltinGraphloop(struct VM_s* vm, int arg_count, Value* args) {
+    if (arg_count == 1 && args[0].type == TYPE_INTEGER) {
+        usleep((useconds_t)args[0].i_val * 1000);
+    }
+    return makeVoid();
+}
+
+static Value vmBuiltinGetmaxx(struct VM_s* vm, int arg_count, Value* args) {
+    (void)vm; (void)arg_count; (void)args;
+    return makeInt(gStubGraphWidth > 0 ? gStubGraphWidth - 1 : 0);
+}
+
+static Value vmBuiltinGetmaxy(struct VM_s* vm, int arg_count, Value* args) {
+    (void)vm; (void)arg_count; (void)args;
+    return makeInt(gStubGraphHeight > 0 ? gStubGraphHeight - 1 : 0);
+}
+#endif
 

--- a/src/main.c
+++ b/src/main.c
@@ -68,10 +68,19 @@ int runProgram(const char *source, const char *programName, int dump_ast_json_fl
         EXIT_FAILURE_HANDLER();
     }
     
-#ifdef SDL
-    // --- SDL GRAPHICS AND SOUND BUILT-INS ---
+    // --- Graphics stubs (usable even without SDL) ---
     registerBuiltinFunction("ClearDevice", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("CloseGraph", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("FillCircle", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("GetMaxX", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("GetMaxY", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("GraphLoop", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("InitGraph", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("SetRGBColor", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("UpdateScreen", AST_PROCEDURE_DECL, NULL);
+
+#ifdef SDL
+    // --- Additional SDL graphics and sound built-ins ---
     registerBuiltinFunction("CreateTargetTexture", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("CreateTexture", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("DestroyTexture", AST_PROCEDURE_DECL, NULL);
@@ -79,16 +88,11 @@ int runProgram(const char *source, const char *programName, int dump_ast_json_fl
     registerBuiltinFunction("DrawLine", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("DrawPolygon", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("DrawRect", AST_PROCEDURE_DECL, NULL);
-    registerBuiltinFunction("FillCircle", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("FillRect", AST_PROCEDURE_DECL, NULL);
-    registerBuiltinFunction("GetMaxX", AST_FUNCTION_DECL, NULL);
-    registerBuiltinFunction("GetMaxY", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("GetMouseState", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("GetPixelColor", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("GetTextSize", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("GetTicks", AST_FUNCTION_DECL, NULL);
-    registerBuiltinFunction("GraphLoop", AST_PROCEDURE_DECL, NULL);
-    registerBuiltinFunction("InitGraph", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("InitSoundSystem", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("InitTextSystem", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("IsSoundPlaying", AST_FUNCTION_DECL, NULL);
@@ -107,8 +111,6 @@ int runProgram(const char *source, const char *programName, int dump_ast_json_fl
     registerBuiltinFunction("SetAlphaBlend", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("SetColor", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("SetRenderTarget", AST_PROCEDURE_DECL, NULL);
-    registerBuiltinFunction("SetRGBColor", AST_PROCEDURE_DECL, NULL);
-    registerBuiltinFunction("UpdateScreen", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("UpdateTexture", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("WaitKeyEvent", AST_PROCEDURE_DECL, NULL);
 #endif


### PR DESCRIPTION
## Summary
- implement no-op versions of SDL graphics routines for builds without SDL
- always register core graphics builtins so examples compile without SDL

## Testing
- `ctest` *(failed: VM execution runtime error)*
- `./bin/pscal --dump-bytecode ../Examples/SDLMultiBouncingBalls`

------
https://chatgpt.com/codex/tasks/task_e_68a098560294832abdffcffaab306746