### PR TITLE
Ensure SDL window opens for Multi Bouncing Balls

### DIFF
--- a/Examples/SDLMultiBouncingBalls
+++ b/Examples/SDLMultiBouncingBalls
@@ -183,6 +183,9 @@ END;
 
 BEGIN // Main Program
   InitGraph(WindowWidth, WindowHeight, WindowTitle);
+  { Pump the event loop once so the window becomes visible on all platforms }
+  UpdateScreen;
+  GraphLoop(0);
   Randomize;
   MaxX := GetMaxX; MaxY := GetMaxY;
 


### PR DESCRIPTION
## Summary
- Pump the SDL event loop immediately after initializing graphics in the SDLMultiBouncingBalls example so the window appears reliably.

## Testing
- `Tests/run_tests.sh` *(fails: pscal binary not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a9b285a0832aa120e0dc3cb79392