### PR TITLE
Ensure SDL window opens for Multi Bouncing Balls

### DIFF
--- a/src/backend_ast/sdl.c
+++ b/src/backend_ast/sdl.c
@@ -90,6 +90,7 @@ Value vmBuiltinInitgraph(VM* vm, int arg_count, Value* args) {
     SDL_SetRenderDrawColor(gSdlRenderer, 0, 0, 0, 255);
     SDL_RenderClear(gSdlRenderer);
     SDL_RenderPresent(gSdlRenderer);
+    SDL_PumpEvents(); // Process any pending events so the window becomes visible
 
     gSdlCurrentColor.r = 255; gSdlCurrentColor.g = 255; gSdlCurrentColor.b = 255; gSdlCurrentColor.a = 255;
     


### PR DESCRIPTION
## Summary
- Pump SDL event queue once during `InitGraph` so the SDL window appears without extra event-loop calls.
- Remove the `UpdateScreen`/`GraphLoop` workaround from the `SDLMultiBouncingBalls` example.

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- `Tests/run_tests.sh` *(fails: ApiSendReceiveTest.p, DosUnitTest.p, MathLibTest.p, ReadlnString.p unexpectedly succeeded)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a9b285a0832aa120e0dc3cb79392