### PR TITLE
Allow integer to word coercion for delay built-in

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -263,12 +263,15 @@ static bool typesMatch(AST* param_type, AST* arg_node, bool allow_coercion) {
                 return arg_vt == TYPE_STRING || arg_vt == TYPE_CHAR;
             case TYPE_BOOLEAN:
             case TYPE_BYTE:
-            case TYPE_WORD:
             case TYPE_ENUM:
             case TYPE_FILE:
             case TYPE_MEMORYSTREAM:
             case TYPE_NIL:
                 return param_actual->var_type == arg_vt;
+            case TYPE_WORD:
+                return arg_vt == TYPE_WORD || arg_vt == TYPE_INTEGER ||
+                       arg_vt == TYPE_BYTE  || arg_vt == TYPE_ENUM   ||
+                       arg_vt == TYPE_CHAR;
             default:
                 return false; // Need structural info for arrays/records/etc.
         }


### PR DESCRIPTION
## Summary
- permit integers when passing parameters of type `word`
- revert hangman example to use literal delay value

## Testing
- `build/bin/pscal Examples/hangman5`
- `Tests/run_tests.sh` *(fails: ApiSendReceiveTest.p, ArgumentTypeMismatch.p, DosUnitTest.p, MathLibTest.p, ReadlnString.p, TestSuite7.p)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c56268d8832ab7c40048d6e3f89d