### PR TITLE
Fix EOF file parameter handling

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -2377,6 +2377,9 @@ static void compileRValue(AST* node, BytecodeChunk* chunk, int current_line_appr
                         if (param_node && param_node->by_ref) {
                             is_var_param = true;
                         }
+                    } else if (functionName && i == 0 && strcasecmp(functionName, "eof") == 0) {
+                        // Built-in EOF takes its file parameter by reference
+                        is_var_param = true;
                     }
 
                     if (is_var_param) {


### PR DESCRIPTION
## Summary
- Ensure EOF builtin receives a VAR file parameter even in expression contexts

## Testing
- `build/bin/pscal Examples/hangman5`
- `(cd Tests && ./run_tests.sh)` *(fails: ApiSendReceiveTest.p, ArgumentTypeMismatch.p, DosUnitTest.p, MathLibTest.p, FileTests.p, FileTests2.p, ReadlnString.p, TestSuite7.p)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ccc45704832aa7314ec83bcb9e7e