### PR TITLE
Serialize type definitions for VM runtime

### DIFF
--- a/src/core/cache.c
+++ b/src/core/cache.c
@@ -2,6 +2,8 @@
 #include "core/utils.h" // for Value constructors
 #include "globals.h"
 #include "symbol/symbol.h"
+#include "frontend/parser.h"
+#include "frontend/ast.h"
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <stdlib.h>
@@ -49,6 +51,94 @@ static bool is_cache_fresh(const char* cache_path, const char* source_path) {
     if (stat(cache_path, &cache_stat) != 0) return false;
     return difftime(cache_stat.st_mtime, src_stat.st_mtime) >= 0;
 }
+
+// ----- AST serialization helpers -----
+static bool write_token(FILE* f, const Token* tok) {
+    int has = (tok != NULL);
+    fwrite(&has, sizeof(has), 1, f);
+    if (!has) return true;
+    fwrite(&tok->type, sizeof(tok->type), 1, f);
+    int len = tok->value ? (int)strlen(tok->value) : 0;
+    fwrite(&len, sizeof(len), 1, f);
+    if (len > 0) fwrite(tok->value, 1, len, f);
+    return true;
+}
+
+static Token* read_token(FILE* f) {
+    int has = 0;
+    if (fread(&has, sizeof(has), 1, f) != 1) return NULL;
+    if (!has) return NULL;
+    TokenType type;
+    if (fread(&type, sizeof(type), 1, f) != 1) return NULL;
+    int len = 0;
+    if (fread(&len, sizeof(len), 1, f) != 1) return NULL;
+    char* buf = NULL;
+    if (len > 0) {
+        buf = (char*)malloc(len + 1);
+        if (!buf) return NULL;
+        if (fread(buf, 1, len, f) != (size_t)len) { free(buf); return NULL; }
+        buf[len] = '\0';
+    } else {
+        buf = strdup("");
+        if (!buf) return NULL;
+    }
+    Token* tok = newToken(type, buf, 0, 0);
+    free(buf);
+    return tok;
+}
+
+static bool write_ast(FILE* f, const AST* node) {
+    int has = (node != NULL);
+    fwrite(&has, sizeof(has), 1, f);
+    if (!has) return true;
+    fwrite(&node->type, sizeof(node->type), 1, f);
+    fwrite(&node->var_type, sizeof(node->var_type), 1, f);
+    write_token(f, node->token);
+    fwrite(&node->i_val, sizeof(node->i_val), 1, f);
+    write_ast(f, node->left);
+    write_ast(f, node->right);
+    write_ast(f, node->extra);
+    fwrite(&node->child_count, sizeof(node->child_count), 1, f);
+    for (int i = 0; i < node->child_count; i++) {
+        write_ast(f, node->children[i]);
+    }
+    return true;
+}
+
+static AST* read_ast(FILE* f) {
+    int has = 0;
+    if (fread(&has, sizeof(has), 1, f) != 1) return NULL;
+    if (!has) return NULL;
+    ASTNodeType t;
+    VarType vt;
+    if (fread(&t, sizeof(t), 1, f) != 1) return NULL;
+    if (fread(&vt, sizeof(vt), 1, f) != 1) return NULL;
+    Token* tok = read_token(f);
+    int i_val = 0;
+    if (fread(&i_val, sizeof(i_val), 1, f) != 1) { if (tok) freeToken(tok); return NULL; }
+    AST* node = newASTNode(t, tok);
+    if (node) {
+        setTypeAST(node, vt);
+        node->i_val = i_val;
+        node->left = read_ast(f); if (node->left) node->left->parent = node;
+        node->right = read_ast(f); if (node->right) node->right->parent = node;
+        node->extra = read_ast(f); if (node->extra) node->extra->parent = node;
+        int child_count = 0;
+        if (fread(&child_count, sizeof(child_count), 1, f) != 1) { freeAST(node); return NULL; }
+        if (child_count > 0) {
+            node->children = (AST**)malloc(sizeof(AST*) * child_count);
+            if (!node->children) { freeAST(node); return NULL; }
+            node->child_count = child_count;
+            node->child_capacity = child_count;
+            for (int i = 0; i < child_count; i++) {
+                node->children[i] = read_ast(f);
+                if (node->children[i]) node->children[i]->parent = node;
+            }
+        }
+    }
+    return node;
+}
+
 
 static bool write_value(FILE* f, const Value* v) {
     fwrite(&v->type, sizeof(v->type), 1, f);
@@ -401,6 +491,26 @@ bool loadBytecodeFromFile(const char* file_path, BytecodeChunk* chunk) {
                                         ok = false;
                                     }
                                 }
+                                if (ok) {
+                                    int type_count = 0;
+                                    if (fread(&type_count, sizeof(type_count), 1, f) == 1) {
+                                        for (int i = 0; i < type_count; ++i) {
+                                            int name_len = 0;
+                                            if (fread(&name_len, sizeof(name_len), 1, f) != 1) { ok = false; break; }
+                                            char* name = (char*)malloc(name_len + 1);
+                                            if (!name) { ok = false; break; }
+                                            if (fread(name, 1, name_len, f) != (size_t)name_len) { free(name); ok = false; break; }
+                                            name[name_len] = '\0';
+                                            AST* type_ast = read_ast(f);
+                                            if (!type_ast) { free(name); ok = false; break; }
+                                            insertType(name, type_ast);
+                                            freeAST(type_ast);
+                                            free(name);
+                                        }
+                                    } else {
+                                        ok = false;
+                                    }
+                                }
                             } else {
                                 ok = false;
                             }
@@ -489,6 +599,16 @@ void saveBytecodeToCache(const char* source_path, const BytecodeChunk* chunk) {
                 }
             }
         }
+    }
+
+    int type_count = 0;
+    for (TypeEntry* entry = type_table; entry; entry = entry->next) type_count++;
+    fwrite(&type_count, sizeof(type_count), 1, f);
+    for (TypeEntry* entry = type_table; entry; entry = entry->next) {
+        int name_len = (int)strlen(entry->name);
+        fwrite(&name_len, sizeof(name_len), 1, f);
+        fwrite(entry->name, 1, name_len, f);
+        write_ast(f, entry->typeAST);
     }
     fclose(f);
     free(cache_path);


### PR DESCRIPTION
## Summary
- serialize AST-based type information into cached bytecode
- restore type table when loading bytecode so pointer allocations know their base type

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest` *(fails: Errors while running CTest)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d9b62258832aa0852166c09301ce