### PR TITLE
Allow integer constants for BYTE parameters

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -230,6 +230,12 @@ static bool typesMatch(AST* param_type, AST* arg_node, bool allow_coercion) {
                 (param_actual->var_type == TYPE_CHAR   && arg_vt == TYPE_STRING)) {
                 return true;
             }
+            // Allow implicit narrowing from wider ordinal types to BYTE.
+            if (param_actual->var_type == TYPE_BYTE &&
+                (arg_vt == TYPE_INTEGER || arg_vt == TYPE_WORD ||
+                 arg_vt == TYPE_ENUM    || arg_vt == TYPE_CHAR)) {
+                return true;
+            }
             return false;
         }
     } else if (!arg_actual) {


### PR DESCRIPTION
## Summary
- revert CRT demo helper procedures to take BYTE color arguments
- allow implicit integer-to-byte argument conversion in the compiler

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `build/bin/pscal Examples/crtd`
- `cd Tests && ./run_tests.sh` *(fails: ApiSendReceiveTest.p, ArgumentTypeMismatch.p, DosUnitTest.p, MathLibTest.p, FileTests.p, FileTests2.p, ReadlnString.p, TestSuite7.p)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dfc9cd54832ab843fe9d50d81ad3