### PR TITLE
Add Tiny language compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,23 @@ ctest --output-on-failure
 
 This executes `Tests/run_tests.sh` and exercises both positive and expected failure cases.
 
+## Tiny language compiler
+
+A minimal compiler for a small educational language, often called *Tiny*, is
+provided in `tools/tinyc.py`.  It reads source code that follows the grammar
+described in the project documentation and emits bytecode that can be executed
+by the Pscal virtual machine.
+
+Example usage:
+
+```sh
+python tools/tinyc.py program.tiny out.pbc
+./build/bin/pscalvm out.pbc
+```
+
+Only integer variables and arithmetic are supported, but this is sufficient for
+basic experiments or teaching purposes.
+
 ## Runtime library
 
 The interpreter expects access to the `etc` and `lib` directories.  When running from the repository you can create temporary symlinks:


### PR DESCRIPTION
## Summary
- add `tools/tinyc.py`, a Python compiler for a simple Tiny language that emits Pscal bytecode
- document usage of the Tiny compiler in the README

## Testing
- `ctest --output-on-failure` *(fails: 0% tests passed, 1 tests failed out of 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a100d852e4832a8f8c37d8ae096104