### PR TITLE
fix: ignore curly-brace comments in tinyc lexer

### DIFF
--- a/tools/tinyc.py
+++ b/tools/tinyc.py
@@ -81,6 +81,11 @@ class Token:
 
 
 def tokenize(source: str) -> List[Token]:
+    # Remove comments enclosed in curly braces. Comments do not nest and may
+    # span multiple lines, so we simply strip everything between a ``{`` and
+    # the next ``}``.
+    source = re.sub(r"\{[^}]*\}", " ", source)
+
     tokens: List[Token] = []
     for match in TOKEN_REGEX.finditer(source):
         if match.group("id"):


### PR DESCRIPTION
## Summary
- Strip `{ ... }` comments before tokenizing TINY source

## Testing
- `python tools/tinyc.py /tmp/tiny.t tiny.pbc`
- `pytest -q`
- `cd Tests && ./run_tests.sh >/tmp/test.log && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_68a105e8febc832a98a054d3981bbcdd