### PR TITLE
Allow 'write' without expression in tiny compiler

### DIFF
--- a/tools/tinyc
+++ b/tools/tinyc
@@ -126,7 +126,7 @@ class Read(Node):
 
 @dataclass
 class Write(Node):
-    expr: Node
+    expr: Optional[Node] = None
 
 @dataclass
 class If(Node):
@@ -196,6 +196,8 @@ class Parser:
             return Read(name)
         if tok.type == "write":
             self.consume("write")
+            if self.current().type in {";", "until", "end", "else", "EOF"}:
+                return Write(None)
             expr = self.expression()
             return Write(expr)
         if tok.type == "IDENT":
@@ -370,9 +372,13 @@ class TinyCompiler:
             self.builder.emit_short(self.read_idx)
             self.builder.emit(1)  # argument count
         elif isinstance(stmt, Write):
-            self.compile_expression(stmt.expr)
-            self.builder.emit(self.opcodes["OP_WRITE"])
-            self.builder.emit(1)
+            if stmt.expr is None:
+                self.builder.emit(self.opcodes["OP_WRITE_LN"])
+                self.builder.emit(0)
+            else:
+                self.compile_expression(stmt.expr)
+                self.builder.emit(self.opcodes["OP_WRITE"])
+                self.builder.emit(1)
         elif isinstance(stmt, If):
             self.compile_expression(stmt.cond)
             self.builder.emit(self.opcodes["OP_JUMP_IF_FALSE"])


### PR DESCRIPTION
## Summary
- Permit `write` statements without an expression in the tiny language
- Emit newline output via `OP_WRITE_LN` when no argument is provided

## Testing
- `python tools/tinyc /tmp/test_write.tiny /tmp/test_write.pbc`
- `cmake -S . -B build`
- `cmake --build build --target pscalvm`
- `./build/bin/pscalvm /tmp/test_write.pbc <<EOF
3
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68a1194768fc832ab89236cd480bd57e