### PR TITLE
Add tinycc wrapper with verbose diagnostics

### DIFF
--- a/tools/tinycc
+++ b/tools/tinycc
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Wrapper around tinycc compiler with debugging output
+
+set -euo pipefail
+
+VERBOSE=0
+# check if -v flag present
+if [[ ${1:-} == "-v" ]]; then
+  VERBOSE=1
+  shift
+fi
+# env var TINYCC_VERBOSE enables verbose
+if [[ -n ${TINYCC_VERBOSE:-} ]]; then
+  VERBOSE=1
+fi
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 [-v] <input.c> <output>" >&2
+  exit 1
+fi
+
+INPUT="$1"
+OUTPUT="$2"
+
+TCC_BIN=${TINYCC_BINARY:-tinycc}
+
+if ! command -v "$TCC_BIN" >/dev/null 2>&1; then
+  echo "Error: $TCC_BIN not found" >&2
+  exit 1
+fi
+
+# Invoke compiler
+"$TCC_BIN" "$INPUT" -o "$OUTPUT"
+
+if [[ ! -f "$OUTPUT" ]]; then
+  echo "Error: compilation failed, output $OUTPUT not created" >&2
+  exit 1
+fi
+
+SIZE=$(stat -c%s "$OUTPUT")
+echo "Generated $OUTPUT (${SIZE} bytes)"
+
+if (( SIZE < 8 )); then
+  echo "Warning: output size looks too small" >&2
+fi
+
+if (( VERBOSE )); then
+  echo "Parsed header fields:"
+  python3 - "$OUTPUT" <<'PY'
+import struct, sys, os
+path = sys.argv[1]
+try:
+    with open(path, 'rb') as f:
+        data = f.read()
+except OSError as e:
+    print(f"  failed to read output: {e}")
+    sys.exit(0)
+
+if len(data) < 16:
+    print("  output too small to contain header")
+else:
+    magic, ver, code_len, consts = struct.unpack('<4I', data[:16])
+    print(f"  magic   : 0x{magic:08x}")
+    print(f"  version : {ver}")
+    print(f"  code len: {code_len}")
+    print(f"  consts  : {consts}")
+    expected_magic = 0x50534243
+    if magic != expected_magic:
+        print(f"  warning : magic mismatch (expected 0x{expected_magic:08x})")
+    expected_min = 16 + code_len * 5
+    if len(data) < expected_min:
+        print(f"  warning : file shorter than expected minimum {expected_min} bytes")
+PY
+  echo "Dumping first 64 bytes:"
+  hexdump -C "$OUTPUT" | head -n 4
+fi
+
+TINY_C_SCRIPT="$(dirname "$0")/tinyc"
+if [[ -x "$TINY_C_SCRIPT" ]]; then
+  REF_OUT=$(mktemp)
+  "$TINY_C_SCRIPT" "$INPUT" "$REF_OUT"
+  REF_SIZE=$(stat -c%s "$REF_OUT")
+  echo "Reference tinyc output: ${REF_SIZE} bytes"
+  if (( VERBOSE )); then
+    echo "tinyc header:"
+    python3 - "$REF_OUT" <<'PY'
+import struct, sys
+with open(sys.argv[1], 'rb') as f:
+    data = f.read()
+if len(data) >= 16:
+    magic, ver, code_len, consts = struct.unpack('<4I', data[:16])
+    print(f"  magic=0x{magic:08x} version={ver} code_len={code_len} consts={consts}")
+PY
+    hexdump -C "$REF_OUT" | head -n 4
+  fi
+  rm -f "$REF_OUT"
+fi


### PR DESCRIPTION
## Summary
- add wrapper script for tinycc that reports output file size, warns on tiny outputs, and optionally dumps headers
- decode bytecode header fields and, when available, compare against tinyc's output for easier debugging

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure` *(fails: pscal_tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a12dea147c832a848ea64abdf53026