### PR TITLE
Link tinyc target with SDL libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,6 +270,13 @@ else()
     target_link_libraries(tinyc PRIVATE ${CURL_LIBRARIES} m)
 endif()
 
+# When SDL support is enabled, tinyc needs the same SDL include paths and
+# libraries as the main executables to successfully compile headers that
+# reference SDL types.
+if(SDL)
+    target_link_libraries(tinyc PRIVATE SDL2::SDL2 SDL2_image SDL2_mixer SDL2_ttf)
+endif()
+
 # ---- Examples ----
 add_subdirectory(Examples)
 


### PR DESCRIPTION
## Summary
- Link tinyc with SDL2 libraries when SDL support is enabled so that SDL headers are found.

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest` *(fails: pscal_tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a13cc88a74832a88b48af8b7de8b9a