### PR TITLE
Link tinyc target with SDL include and link paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,6 +270,42 @@ else()
     target_link_libraries(tinyc PRIVATE ${CURL_LIBRARIES} m)
 endif()
 
+# When SDL support is enabled, tinyc needs the same SDL include paths,
+# library directories, and libraries as the other executables to compile
+# headers that reference SDL types.
+if(SDL)
+    target_include_directories(tinyc PRIVATE
+        ${SDL2_INCLUDE_DIRS}
+        ${PC_SDL2_IMAGE_INCLUDE_DIRS}
+        ${PC_SDL2_MIXER_INCLUDE_DIRS}
+        ${PC_SDL2_TTF_INCLUDE_DIRS}
+    )
+
+    target_link_directories(tinyc PRIVATE
+        ${PC_SDL2_IMAGE_LIBRARY_DIRS}
+        ${PC_SDL2_MIXER_LIBRARY_DIRS}
+        ${PC_SDL2_TTF_LIBRARY_DIRS}
+    )
+
+    set(TINYC_SDL_LIBS "")
+    if(TARGET SDL2::SDL2)
+        list(APPEND TINYC_SDL_LIBS SDL2::SDL2)
+    else()
+        list(APPEND TINYC_SDL_LIBS ${SDL2_LIBRARIES})
+    endif()
+    list(APPEND TINYC_SDL_LIBS
+        ${PC_SDL2_IMAGE_LIBRARIES}
+        ${PC_SDL2_MIXER_LIBRARIES}
+        ${PC_SDL2_TTF_LIBRARIES}
+        ${PC_SDL2_IMAGE_LDFLAGS_OTHER}
+        ${PC_SDL2_MIXER_LDFLAGS_OTHER}
+        ${PC_SDL2_TTF_LDFLAGS_OTHER}
+    )
+    list(REMOVE_DUPLICATES TINYC_SDL_LIBS)
+    target_link_libraries(tinyc PRIVATE ${TINYC_SDL_LIBS})
+    target_compile_definitions(tinyc PRIVATE SDL)
+endif()
+
 # ---- Examples ----
 add_subdirectory(Examples)
 


### PR DESCRIPTION
## Summary
- Propagate SDL include directories, library search paths, and link flags to the tinyc executable when SDL support is enabled.

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest` *(fails: pscal_tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a13cc88a74832a88b48af8b7de8b9a