### PR TITLE
Fix TinyC lexer and parser to fully implement grammar

### DIFF
--- a/src/tinyc/lexer.c
+++ b/src/tinyc/lexer.c
@@ -85,10 +85,22 @@ TinyCToken tinyc_nextToken(TinyCLexer *lexer) {
             case '}': return makeToken(lexer, TINYCTOKEN_RBRACE, start, 1);
             case '[': return makeToken(lexer, TINYCTOKEN_LBRACKET, start, 1);
             case ']': return makeToken(lexer, TINYCTOKEN_RBRACKET, start, 1);
-            case '!': return makeToken(lexer, match(lexer,'=')?TINYCTOKEN_BANG_EQUAL:TINYCTOKEN_BANG, start, match(lexer,'=')?2:1);
-            case '=': return makeToken(lexer, match(lexer,'=')?TINYCTOKEN_EQUAL_EQUAL:TINYCTOKEN_EQUAL, start, match(lexer,'=')?2:1);
-            case '<': return makeToken(lexer, match(lexer,'=')?TINYCTOKEN_LESS_EQUAL:TINYCTOKEN_LESS, start, match(lexer,'=')?2:1);
-            case '>': return makeToken(lexer, match(lexer,'=')?TINYCTOKEN_GREATER_EQUAL:TINYCTOKEN_GREATER, start, match(lexer,'=')?2:1);
+            case '!': {
+                bool hasEq = match(lexer, '=');
+                return makeToken(lexer, hasEq ? TINYCTOKEN_BANG_EQUAL : TINYCTOKEN_BANG, start, hasEq ? 2 : 1);
+            }
+            case '=': {
+                bool hasEq = match(lexer, '=');
+                return makeToken(lexer, hasEq ? TINYCTOKEN_EQUAL_EQUAL : TINYCTOKEN_EQUAL, start, hasEq ? 2 : 1);
+            }
+            case '<': {
+                bool hasEq = match(lexer, '=');
+                return makeToken(lexer, hasEq ? TINYCTOKEN_LESS_EQUAL : TINYCTOKEN_LESS, start, hasEq ? 2 : 1);
+            }
+            case '>': {
+                bool hasEq = match(lexer, '=');
+                return makeToken(lexer, hasEq ? TINYCTOKEN_GREATER_EQUAL : TINYCTOKEN_GREATER, start, hasEq ? 2 : 1);
+            }
             case '&': if (match(lexer,'&')) return makeToken(lexer, TINYCTOKEN_AND_AND, start, 2); break;
             case '|': if (match(lexer,'|')) return makeToken(lexer, TINYCTOKEN_OR_OR, start, 2); break;
         }

--- a/src/tinyc/parser.c
+++ b/src/tinyc/parser.c
@@ -91,7 +91,9 @@ static ASTNodeTinyC* funDeclaration(ParserTinyC *p, TinyCToken type_token, TinyC
 }
 
 static ASTNodeTinyC* params(ParserTinyC *p) {
+    /* allow both "void" and empty parameter lists */
     if (p->current.type == TINYCTOKEN_VOID) { advanceParser(p); return NULL; }
+    if (p->current.type == TINYCTOKEN_RPAREN) { return NULL; }
     ASTNodeTinyC *paramList = newASTNodeTinyC(TCAST_PARAM, p->current);
     ASTNodeTinyC *first = param(p);
     addChildTinyC(paramList, first);


### PR DESCRIPTION
## Summary
- Correct TinyC lexer matching for `!=`, `==`, `<=`, and `>=` by storing lookahead results once
- Allow empty parameter lists in TinyC function declarations

## Testing
- `cmake --build . --target tinyc`
- `./bin/tinyc ../Examples/tinycc/hello.c`
- `./bin/tinyc /tmp/test_ops.c`


------
https://chatgpt.com/codex/tasks/task_e_68a14a9af5f4832a85d04c3eae84b747