### PR TITLE
Add AST and bytecode dump options to clike

### DIFF
--- a/src/clike/ast.h
+++ b/src/clike/ast.h
@@ -2,6 +2,7 @@
 #define CLIKE_AST_H
 
 #include "clike/lexer.h"
+#include <stdio.h>
 
 typedef enum {
     TCAST_PROGRAM,
@@ -35,5 +36,6 @@ typedef struct ASTNodeClike {
 ASTNodeClike *newASTNodeClike(ASTNodeTypeClike type, ClikeToken token);
 void addChildClike(ASTNodeClike *parent, ASTNodeClike *child);
 void freeASTClike(ASTNodeClike *node);
+void dumpASTClikeJSON(ASTNodeClike *node, FILE *out);
 
 #endif

--- a/src/clike/main.c
+++ b/src/clike/main.c
@@ -19,12 +19,43 @@ static void initSymbolSystemClike(void) {
     current_procedure_table = procedure_table;
 }
 
+static const char *CLIKE_USAGE =
+    "Usage: clike <options> <source.c> [program_parameters...]\n"
+    "   Options:\n"
+    "     --dump-ast-json             Dump AST to JSON and exit.\n"
+    "     --dump-bytecode             Dump compiled bytecode before execution.\n";
+
 int main(int argc, char **argv) {
-    if (argc < 2) {
-        fprintf(stderr, "Usage: clike <source.c>\n");
+    int dump_ast_json_flag = 0;
+    int dump_bytecode_flag = 0;
+    const char *path = NULL;
+    int clike_params_start = 0;
+
+    if (argc == 1) {
+        fprintf(stderr, "%s\n", CLIKE_USAGE);
         return 1;
     }
-    const char *path = argv[1];
+
+    for (int i = 1; i < argc; ++i) {
+        if (strcmp(argv[i], "--dump-ast-json") == 0) {
+            dump_ast_json_flag = 1;
+        } else if (strcmp(argv[i], "--dump-bytecode") == 0) {
+            dump_bytecode_flag = 1;
+        } else if (argv[i][0] == '-') {
+            fprintf(stderr, "Unknown option: %s\n%s\n", argv[i], CLIKE_USAGE);
+            return 1;
+        } else {
+            path = argv[i];
+            clike_params_start = i + 1;
+            break;
+        }
+    }
+
+    if (!path) {
+        fprintf(stderr, "Error: No source file specified.\n%s\n", CLIKE_USAGE);
+        return 1;
+    }
+
     FILE *f = fopen(path, "rb");
     if (!f) { perror("open"); return 1; }
     fseek(f, 0, SEEK_END); long len = ftell(f); rewind(f);
@@ -33,10 +64,30 @@ int main(int argc, char **argv) {
     ParserClike parser; initParserClike(&parser, src);
     ASTNodeClike *prog = parseProgramClike(&parser);
 
+    if (dump_ast_json_flag) {
+        fprintf(stderr, "--- Dumping AST to JSON (stdout) ---\n");
+        dumpASTClikeJSON(prog, stdout);
+        fprintf(stderr, "\n--- AST JSON Dump Complete (stderr print)---\n");
+        freeASTClike(prog);
+        free(src);
+        return 0;
+    }
+
+    if (clike_params_start < argc) {
+        gParamCount = argc - clike_params_start;
+        gParamValues = &argv[clike_params_start];
+    }
+
     initSymbolSystemClike();
     clike_register_builtins();
 
     BytecodeChunk chunk; clike_compile(prog, &chunk);
+    if (dump_bytecode_flag) {
+        fprintf(stderr, "--- Compiling Main Program AST to Bytecode ---\n");
+        disassembleBytecodeChunk(&chunk, path ? path : "CompiledChunk", procedure_table);
+        fprintf(stderr, "\n--- Executing Program with VM ---\n");
+    }
+
     VM vm; initVM(&vm);
     InterpretResult result = interpretBytecode(&vm, &chunk, globalSymbols, procedure_table);
     freeVM(&vm);
@@ -47,3 +98,4 @@ int main(int argc, char **argv) {
     if (procedure_table) freeHashTable(procedure_table);
     return result == INTERPRET_OK ? 0 : 1;
 }
+


### PR DESCRIPTION
## Summary
- implement `dumpASTClikeJSON` to serialize clike ASTs
- extend `clike` driver with `--dump-ast-json` and `--dump-bytecode` flags
- show usage text and support passing through program args

## Testing
- `cmake ..`
- `make -j4`
- `Tests/run_clike_tests.sh`
- `build/bin/clike --dump-ast-json Tests/clike/printf.c`
- `build/bin/clike --dump-bytecode Tests/clike/printf.c`


------
https://chatgpt.com/codex/tasks/task_e_68a216656274832a97e1b5772d8dd2af