### PR TITLE
Add basic type checking to clike

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,7 @@ set(CLIKE_SOURCES
     src/clike/parser.c
     src/clike/ast.c
     src/clike/builtins.c
+    src/clike/semantics.c
     src/clike/codegen.c
     src/globals.c
     src/core/utils.c src/core/types.c src/core/list.c src/core/cache.c

--- a/src/clike/ast.c
+++ b/src/clike/ast.c
@@ -8,6 +8,7 @@ ASTNodeClike *newASTNodeClike(ASTNodeTypeClike type, ClikeToken token) {
     if (!node) return NULL;
     node->type = type;
     node->token = token;
+    node->var_type = TYPE_UNKNOWN;
     node->left = node->right = node->third = NULL;
     node->children = NULL;
     node->child_count = 0;

--- a/src/clike/ast.h
+++ b/src/clike/ast.h
@@ -2,6 +2,7 @@
 #define CLIKE_AST_H
 
 #include "clike/lexer.h"
+#include "core/types.h"
 #include <stdio.h>
 
 typedef enum {
@@ -26,6 +27,7 @@ typedef enum {
 typedef struct ASTNodeClike {
     ASTNodeTypeClike type;
     ClikeToken token; // For identifier or operator token
+    VarType var_type; // Inferred or declared type
     struct ASTNodeClike *left;
     struct ASTNodeClike *right;
     struct ASTNodeClike *third; // else branch or additional pointer

--- a/src/clike/codegen.c
+++ b/src/clike/codegen.c
@@ -51,12 +51,7 @@ static void collectLocals(ASTNodeClike* node, FuncContext* ctx) {
     if (!node) return;
     if (node->type == TCAST_VAR_DECL) {
         char* name = tokenToCString(node->token);
-        VarType type = TYPE_INTEGER;
-        if (node->right) {
-            if (node->right->token.type == CLIKE_TOKEN_FLOAT) type = TYPE_REAL;
-            else if (node->right->token.type == CLIKE_TOKEN_STR) type = TYPE_STRING;
-        }
-        addLocal(ctx, name, type);
+        addLocal(ctx, name, node->var_type);
         free(name);
         return;
     }
@@ -286,12 +281,7 @@ static void compileFunction(ASTNodeClike *func, BytecodeChunk *chunk) {
         for (int i = 0; i < func->left->child_count; i++) {
             ASTNodeClike* p = func->left->children[i];
             char* name = tokenToCString(p->token);
-            VarType type = TYPE_INTEGER;
-            if (p->left) {
-                if (p->left->token.type == CLIKE_TOKEN_FLOAT) type = TYPE_REAL;
-                else if (p->left->token.type == CLIKE_TOKEN_STR) type = TYPE_STRING;
-            }
-            addLocal(&ctx, name, type);
+            addLocal(&ctx, name, p->var_type);
             free(name);
             ctx.paramCount++;
         }
@@ -308,7 +298,7 @@ static void compileFunction(ASTNodeClike *func, BytecodeChunk *chunk) {
     sym->bytecode_address = address;
     sym->arity = (uint8_t)ctx.paramCount;
     sym->locals_count = (uint8_t)(ctx.localCount - ctx.paramCount);
-    sym->type = TYPE_INTEGER;
+    sym->type = func->var_type;
     sym->is_defined = true;
     hashTableInsert(procedure_table, sym);
 

--- a/src/clike/main.c
+++ b/src/clike/main.c
@@ -4,6 +4,7 @@
 #include "clike/parser.h"
 #include "clike/codegen.h"
 #include "clike/builtins.h"
+#include "clike/semantics.h"
 #include "vm/vm.h"
 #include "core/cache.h"
 #include "core/utils.h"
@@ -80,6 +81,7 @@ int main(int argc, char **argv) {
 
     initSymbolSystemClike();
     clike_register_builtins();
+    analyzeSemanticsClike(prog);
 
     BytecodeChunk chunk; clike_compile(prog, &chunk);
     if (dump_bytecode_flag) {

--- a/src/clike/semantics.c
+++ b/src/clike/semantics.c
@@ -1,0 +1,196 @@
+#include "clike/semantics.h"
+#include "core/utils.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+    char *name;
+    VarType type;
+} VarEntry;
+
+typedef struct {
+    VarEntry entries[256];
+    int count;
+} VarTable;
+
+static void vt_add(VarTable *t, const char *name, VarType type) {
+    t->entries[t->count].name = strdup(name);
+    t->entries[t->count].type = type;
+    t->count++;
+}
+
+static VarType vt_get(VarTable *t, const char *name) {
+    for (int i = 0; i < t->count; ++i) {
+        if (strcmp(t->entries[i].name, name) == 0) {
+            return t->entries[i].type;
+        }
+    }
+    return TYPE_UNKNOWN;
+}
+
+static void vt_free(VarTable *t) {
+    for (int i = 0; i < t->count; ++i) free(t->entries[i].name);
+}
+
+typedef struct {
+    char *name;
+    VarType type;
+} FuncEntry;
+
+static FuncEntry functions[256];
+static int functionCount = 0;
+
+static VarType getFunctionType(const char *name) {
+    for (int i = 0; i < functionCount; ++i) {
+        if (strcmp(functions[i].name, name) == 0) return functions[i].type;
+    }
+    return TYPE_UNKNOWN;
+}
+
+static char *tokenToCString(ClikeToken t) {
+    char *s = (char *)malloc(t.length + 1);
+    memcpy(s, t.lexeme, t.length);
+    s[t.length] = '\0';
+    return s;
+}
+
+static VarType analyzeExpr(ASTNodeClike *node, VarTable *vt);
+
+static VarType analyzeExpr(ASTNodeClike *node, VarTable *vt) {
+    if (!node) return TYPE_UNKNOWN;
+    switch (node->type) {
+        case TCAST_NUMBER:
+        case TCAST_STRING:
+            return node->var_type;
+        case TCAST_IDENTIFIER: {
+            char *name = tokenToCString(node->token);
+            VarType t = vt_get(vt, name);
+            node->var_type = t;
+            free(name);
+            return t;
+        }
+        case TCAST_BINOP: {
+            VarType lt = analyzeExpr(node->left, vt);
+            VarType rt = analyzeExpr(node->right, vt);
+            if (lt == TYPE_REAL || rt == TYPE_REAL) node->var_type = TYPE_REAL;
+            else if (lt == TYPE_STRING || rt == TYPE_STRING) node->var_type = TYPE_STRING;
+            else node->var_type = lt != TYPE_UNKNOWN ? lt : rt;
+            return node->var_type;
+        }
+        case TCAST_UNOP:
+            node->var_type = analyzeExpr(node->left, vt);
+            return node->var_type;
+        case TCAST_ASSIGN: {
+            VarType lt = analyzeExpr(node->left, vt);
+            VarType rt = analyzeExpr(node->right, vt);
+            if (lt != TYPE_UNKNOWN && rt != TYPE_UNKNOWN && lt != rt) {
+                fprintf(stderr, "Type error: cannot assign %s to %s at line %d\n",
+                        varTypeToString(rt), varTypeToString(lt), node->token.line);
+            }
+            node->var_type = lt;
+            return lt;
+        }
+        case TCAST_CALL: {
+            char *name = tokenToCString(node->token);
+            VarType t = getFunctionType(name);
+            free(name);
+            node->var_type = t;
+            return t;
+        }
+        default:
+            return TYPE_UNKNOWN;
+    }
+}
+
+static void analyzeStmt(ASTNodeClike *node, VarTable *vt, VarType retType) {
+    if (!node) return;
+    switch (node->type) {
+        case TCAST_COMPOUND:
+            for (int i = 0; i < node->child_count; ++i) {
+                analyzeStmt(node->children[i], vt, retType);
+            }
+            break;
+        case TCAST_IF:
+            analyzeExpr(node->left, vt);
+            analyzeStmt(node->right, vt, retType);
+            analyzeStmt(node->third, vt, retType);
+            break;
+        case TCAST_WHILE:
+            analyzeExpr(node->left, vt);
+            analyzeStmt(node->right, vt, retType);
+            break;
+        case TCAST_RETURN: {
+            VarType t = TYPE_VOID;
+            if (node->left) t = analyzeExpr(node->left, vt);
+            if (retType == TYPE_VOID) {
+                if (t != TYPE_VOID && t != TYPE_UNKNOWN) {
+                    fprintf(stderr, "Type error: returning value from void function at line %d\n", node->token.line);
+                }
+            } else if (t != TYPE_UNKNOWN && t != retType) {
+                fprintf(stderr, "Type error: return type %s does not match %s at line %d\n",
+                        varTypeToString(t), varTypeToString(retType), node->token.line);
+            }
+            break;
+        }
+        case TCAST_EXPR_STMT:
+            if (node->left) analyzeExpr(node->left, vt);
+            break;
+        default:
+            if (node->type == TCAST_ASSIGN) {
+                analyzeExpr(node, vt);
+            }
+            break;
+    }
+}
+
+static void gatherDecls(ASTNodeClike *node, VarTable *vt) {
+    if (!node) return;
+    if (node->type == TCAST_VAR_DECL) {
+        char *name = tokenToCString(node->token);
+        vt_add(vt, name, node->var_type);
+        free(name);
+        return;
+    }
+    if (node->left) gatherDecls(node->left, vt);
+    if (node->right) gatherDecls(node->right, vt);
+    if (node->third) gatherDecls(node->third, vt);
+    for (int i = 0; i < node->child_count; ++i) {
+        gatherDecls(node->children[i], vt);
+    }
+}
+
+static void analyzeFunction(ASTNodeClike *func) {
+    VarTable vt = {0};
+    // parameters
+    if (func->left) {
+        for (int i = 0; i < func->left->child_count; ++i) {
+            ASTNodeClike *p = func->left->children[i];
+            char *name = tokenToCString(p->token);
+            vt_add(&vt, name, p->var_type);
+            free(name);
+        }
+    }
+    gatherDecls(func->right, &vt);
+    analyzeStmt(func->right, &vt, func->var_type);
+    vt_free(&vt);
+}
+
+void analyzeSemanticsClike(ASTNodeClike *program) {
+    if (!program) return;
+    functionCount = 0;
+    for (int i = 0; i < program->child_count; ++i) {
+        ASTNodeClike *decl = program->children[i];
+        if (decl->type == TCAST_FUN_DECL) {
+            char *name = tokenToCString(decl->token);
+            functions[functionCount].name = name;
+            functions[functionCount].type = decl->var_type;
+            functionCount++;
+        }
+    }
+    for (int i = 0; i < program->child_count; ++i) {
+        ASTNodeClike *decl = program->children[i];
+        if (decl->type == TCAST_FUN_DECL) analyzeFunction(decl);
+    }
+    for (int i = 0; i < functionCount; ++i) free(functions[i].name);
+}

--- a/src/clike/semantics.h
+++ b/src/clike/semantics.h
@@ -1,0 +1,8 @@
+#ifndef CLIKE_SEMANTICS_H
+#define CLIKE_SEMANTICS_H
+
+#include "clike/ast.h"
+
+void analyzeSemanticsClike(ASTNodeClike *program);
+
+#endif


### PR DESCRIPTION
## Summary
- track declared and inferred types on C-like AST nodes
- validate assignment and return types in new semantics pass
- respect function return types during code generation

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest` *(fails: pscal_tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a2446cecbc832a8caf8dddc71c27ea