### PR TITLE
Add optimizer, formatter, and REPL for Clike front-end

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,6 +256,7 @@ set(CLIKE_SOURCES
     src/clike/builtins.c
     src/clike/semantics.c
     src/clike/codegen.c
+    src/clike/opt.c
     src/globals.c
     src/core/utils.c src/core/types.c src/core/list.c src/core/cache.c
     src/compiler/bytecode.c
@@ -280,6 +281,16 @@ if(TARGET CURL::libcurl)
     target_link_libraries(clike PRIVATE CURL::libcurl m)
 else()
     target_link_libraries(clike PRIVATE ${CURL_LIBRARIES} m)
+endif()
+
+set(CLIKE_REPL_SOURCES ${CLIKE_SOURCES})
+list(REMOVE_ITEM CLIKE_REPL_SOURCES src/clike/main.c)
+list(APPEND CLIKE_REPL_SOURCES src/clike/repl.c)
+add_executable(clike-repl ${CLIKE_REPL_SOURCES})
+if(TARGET CURL::libcurl)
+    target_link_libraries(clike-repl PRIVATE CURL::libcurl m)
+else()
+    target_link_libraries(clike-repl PRIVATE ${CURL_LIBRARIES} m)
 endif()
 
 # When SDL support is enabled, clike needs the same SDL include paths,
@@ -316,6 +327,22 @@ if(SDL)
     list(REMOVE_DUPLICATES CLIKE_SDL_LIBS)
     target_link_libraries(clike PRIVATE ${CLIKE_SDL_LIBS})
     target_compile_definitions(clike PRIVATE SDL)
+
+    target_include_directories(clike-repl PRIVATE
+        ${SDL2_INCLUDE_DIRS}
+        ${PC_SDL2_IMAGE_INCLUDE_DIRS}
+        ${PC_SDL2_MIXER_INCLUDE_DIRS}
+        ${PC_SDL2_TTF_INCLUDE_DIRS}
+    )
+
+    target_link_directories(clike-repl PRIVATE
+        ${PC_SDL2_IMAGE_LIBRARY_DIRS}
+        ${PC_SDL2_MIXER_LIBRARY_DIRS}
+        ${PC_SDL2_TTF_LIBRARY_DIRS}
+    )
+
+    target_link_libraries(clike-repl PRIVATE ${CLIKE_SDL_LIBS})
+    target_compile_definitions(clike-repl PRIVATE SDL)
 
 endif()
 

--- a/src/clike/main.c
+++ b/src/clike/main.c
@@ -6,6 +6,7 @@
 #include "clike/builtins.h"
 #include "clike/semantics.h"
 #include "clike/errors.h"
+#include "clike/opt.h"
 #include "vm/vm.h"
 #include "core/cache.h"
 #include "core/utils.h"
@@ -98,6 +99,7 @@ int main(int argc, char **argv) {
         if (procedure_table) freeHashTable(procedure_table);
         return clike_error_count > 255 ? 255 : clike_error_count;
     }
+    prog = optimizeClikeAST(prog);
 
     BytecodeChunk chunk; clike_compile(prog, &chunk);
     if (dump_bytecode_flag) {

--- a/src/clike/opt.c
+++ b/src/clike/opt.c
@@ -1,0 +1,117 @@
+#include "clike/opt.h"
+#include "clike/lexer.h"
+#include "core/types.h"
+#include <stdlib.h>
+
+static int isConst(ASTNodeClike* n, double* out, int* is_float) {
+    if (!n || n->type != TCAST_NUMBER) return 0;
+    if (n->var_type == TYPE_REAL) {
+        if (out) *out = n->token.float_val;
+        if (is_float) *is_float = 1;
+    } else {
+        if (out) *out = (double)n->token.int_val;
+        if (is_float) *is_float = 0;
+    }
+    return 1;
+}
+
+static ASTNodeClike* foldBinary(ASTNodeClike* node) {
+    double lv, rv; int lf, rf;
+    if (!isConst(node->left, &lv, &lf) || !isConst(node->right, &rv, &rf))
+        return node;
+    int result_is_float = lf || rf;
+    double res = 0;
+    switch (node->token.type) {
+        case CLIKE_TOKEN_PLUS: res = lv + rv; break;
+        case CLIKE_TOKEN_MINUS: res = lv - rv; break;
+        case CLIKE_TOKEN_STAR: res = lv * rv; break;
+        case CLIKE_TOKEN_SLASH: res = lv / rv; result_is_float = 1; break;
+        case CLIKE_TOKEN_EQUAL_EQUAL: res = (lv == rv); result_is_float = 0; break;
+        case CLIKE_TOKEN_BANG_EQUAL: res = (lv != rv); result_is_float = 0; break;
+        case CLIKE_TOKEN_LESS: res = (lv < rv); result_is_float = 0; break;
+        case CLIKE_TOKEN_LESS_EQUAL: res = (lv <= rv); result_is_float = 0; break;
+        case CLIKE_TOKEN_GREATER: res = (lv > rv); result_is_float = 0; break;
+        case CLIKE_TOKEN_GREATER_EQUAL: res = (lv >= rv); result_is_float = 0; break;
+        case CLIKE_TOKEN_AND_AND: res = (lv != 0 && rv != 0); result_is_float = 0; break;
+        case CLIKE_TOKEN_OR_OR: res = (lv != 0 || rv != 0); result_is_float = 0; break;
+        default: return node;
+    }
+    ClikeToken t = {0};
+    if (result_is_float) {
+        t.type = CLIKE_TOKEN_FLOAT_LITERAL;
+        t.float_val = res;
+    } else {
+        t.type = CLIKE_TOKEN_NUMBER;
+        t.int_val = (int)res;
+        t.float_val = res;
+    }
+    ASTNodeClike* newNode = newASTNodeClike(TCAST_NUMBER, t);
+    newNode->var_type = result_is_float ? TYPE_REAL : TYPE_INTEGER;
+    freeASTClike(node);
+    return newNode;
+}
+
+static ASTNodeClike* foldUnary(ASTNodeClike* node) {
+    double v; int vf;
+    if (!isConst(node->left, &v, &vf)) return node;
+    double res = 0; int is_float = vf;
+    switch (node->token.type) {
+        case CLIKE_TOKEN_MINUS: res = -v; break;
+        case CLIKE_TOKEN_BANG: res = !(v != 0); is_float = 0; break;
+        default: return node;
+    }
+    ClikeToken t = {0};
+    if (is_float) {
+        t.type = CLIKE_TOKEN_FLOAT_LITERAL; t.float_val = res;
+    } else {
+        t.type = CLIKE_TOKEN_NUMBER; t.int_val = (int)res; t.float_val = res;
+    }
+    ASTNodeClike* newNode = newASTNodeClike(TCAST_NUMBER, t);
+    newNode->var_type = is_float ? TYPE_REAL : TYPE_INTEGER;
+    freeASTClike(node);
+    return newNode;
+}
+
+static ASTNodeClike* optimizeNode(ASTNodeClike* node) {
+    if (!node) return NULL;
+    node->left = optimizeNode(node->left);
+    node->right = optimizeNode(node->right);
+    node->third = optimizeNode(node->third);
+    int j = 0;
+    for (int i = 0; i < node->child_count; ++i) {
+        node->children[i] = optimizeNode(node->children[i]);
+        if (node->children[i]) node->children[j++] = node->children[i];
+    }
+    node->child_count = j;
+
+    switch (node->type) {
+        case TCAST_BINOP: return foldBinary(node);
+        case TCAST_UNOP: return foldUnary(node);
+        case TCAST_IF: {
+            double cond; int cf;
+            if (isConst(node->left, &cond, &cf)) {
+                if (cond != 0) {
+                    ASTNodeClike* taken = node->right;
+                    freeASTClike(node->left);
+                    freeASTClike(node->third);
+                    free(node);
+                    return taken;
+                } else {
+                    ASTNodeClike* taken = node->third;
+                    freeASTClike(node->left);
+                    freeASTClike(node->right);
+                    free(node);
+                    return taken;
+                }
+            }
+            break;
+        }
+        default: break;
+    }
+    return node;
+}
+
+ASTNodeClike* optimizeClikeAST(ASTNodeClike* node) {
+    return optimizeNode(node);
+}
+

--- a/src/clike/opt.h
+++ b/src/clike/opt.h
@@ -1,0 +1,11 @@
+#ifndef CLIKE_OPT_H
+#define CLIKE_OPT_H
+
+#include "clike/ast.h"
+
+// Perform simple AST optimizations such as constant folding and
+// dead-branch elimination. The function returns the potentially
+// replaced node for convenience.
+ASTNodeClike* optimizeClikeAST(ASTNodeClike* node);
+
+#endif

--- a/src/clike/repl.c
+++ b/src/clike/repl.c
@@ -1,0 +1,60 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "clike/parser.h"
+#include "clike/codegen.h"
+#include "clike/builtins.h"
+#include "clike/semantics.h"
+#include "clike/opt.h"
+#include "vm/vm.h"
+#include "core/cache.h"
+#include "core/utils.h"
+#include "symbol/symbol.h"
+#include "globals.h"
+
+int gParamCount = 0;
+char **gParamValues = NULL;
+int clike_error_count = 0;
+int clike_warning_count = 0;
+
+static void initSymbolSystemClike(void) {
+    globalSymbols = createHashTable();
+    procedure_table = createHashTable();
+    current_procedure_table = procedure_table;
+}
+
+int main(void) {
+    char line[1024];
+    while (1) {
+        printf("clike> ");
+        if (!fgets(line, sizeof(line), stdin)) break;
+        if (strncmp(line, ":quit", 5) == 0) break;
+
+        const char *prefix = "int main() {\n";
+        const char *suffix = "\n}\n";
+        size_t len = strlen(prefix) + strlen(line) + strlen(suffix) + 1;
+        char *src = (char*)malloc(len);
+        snprintf(src, len, "%s%s%s", prefix, line, suffix);
+
+        ParserClike parser; initParserClike(&parser, src);
+        ASTNodeClike *prog = parseProgramClike(&parser);
+        initSymbolSystemClike();
+        clike_register_builtins();
+        analyzeSemanticsClike(prog);
+        prog = optimizeClikeAST(prog);
+        if (clike_error_count == 0) {
+            BytecodeChunk chunk; clike_compile(prog, &chunk);
+            VM vm; initVM(&vm);
+            interpretBytecode(&vm, &chunk, globalSymbols, procedure_table);
+            freeVM(&vm);
+            freeBytecodeChunk(&chunk);
+        }
+        freeASTClike(prog);
+        free(src);
+        if (globalSymbols) freeHashTable(globalSymbols);
+        if (procedure_table) freeHashTable(procedure_table);
+        clike_error_count = 0;
+        clike_warning_count = 0;
+    }
+    return 0;
+}

--- a/tools/clike_format.py
+++ b/tools/clike_format.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Simple formatter for Clike source files."""
+
+import argparse
+import sys
+
+INDENT = "    "
+
+def format_code(src: str) -> str:
+    indent = 0
+    lines = []
+    # ensure braces are on their own line
+    tokens = (
+        src.replace('{', '{\n')
+           .replace('}', '}\n')
+           .replace(';', ';\n')
+        ).splitlines()
+    for tok in tokens:
+        line = tok.strip()
+        if not line:
+            continue
+        if line.startswith('}'):
+            indent = max(indent - 1, 0)
+        lines.append(INDENT * indent + line)
+        if line.endswith('{'):
+            indent += 1
+    return "\n".join(lines) + "\n"
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Format Clike source")
+    parser.add_argument('file', nargs='?', help='File to format (reads stdin if omitted)')
+    args = parser.parse_args()
+    if args.file:
+        with open(args.file) as f:
+            src = f.read()
+    else:
+        src = sys.stdin.read()
+    sys.stdout.write(format_code(src))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- implement `opt.c` for AST constant folding and dead branch elimination before codegen
- add simple `clike_format.py` formatter in tools
- prototype interactive `clike-repl` using parser, VM, and optimizer

## Testing
- `cmake -S . -B build`
- `cmake --build build --target clike clike-repl`
- `python3 -m py_compile tools/clike_format.py`

------
https://chatgpt.com/codex/tasks/task_e_68a257127c80832aa793c1895122ac5b