### PR TITLE
Fix stack handling for array assignments

### DIFF
--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1637,6 +1637,16 @@ comparison_error_label:
                     }
                 }
 
+                /*
+                 * Mirror the behaviour of OP_SET_LOCAL where the assigned value
+                 * remains on the stack.  This allows assignments used as
+                 * expressions to work consistently and prevents later OP_POP
+                 * instructions from underflowing the stack after an array
+                 * assignment.  Push a copy of the value we just stored so the
+                 * caller can continue to use it if needed.
+                 */
+                push(vm, makeCopyOfValue(&value_to_set));
+
                 freeValue(&value_to_set);
                 freeValue(&pointer_to_lvalue);
                 break;


### PR DESCRIPTION
## Summary
- ensure OP_SET_INDIRECT leaves the assigned value on the stack
- document why the value is pushed back after array assignments

## Testing
- `./Tests/run_clike_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a25d6e3864832a80290da5b7904e51