### PR TITLE
Fix integer indexing in Clike multibouncing balls example

### DIFF
--- a/Examples/Clike/sdl_multibouncingballs.c
+++ b/Examples/Clike/sdl_multibouncingballs.c
@@ -30,6 +30,8 @@ int main() {
     float Speed_pps;
     float Angle;
     int speedRange;
+    int ii;
+    int jj;
 
     WindowWidth = 1280;
     WindowHeight = 1024;
@@ -49,23 +51,24 @@ int main() {
 
     i = 0;
     while (i < NumBalls) {
-        radius[i] = 8 + random(13);
-        x[i] = radius[i] + random(WindowWidth - 2 * radius[i]);
-        y[i] = radius[i] + random(WindowHeight - 2 * radius[i]);
+        ii = trunc(i);
+        radius[ii] = 8 + random(13);
+        x[ii] = radius[ii] + random(WindowWidth - 2 * radius[ii]);
+        y[ii] = radius[ii] + random(WindowHeight - 2 * radius[ii]);
         speedRange = trunc(MaxInitialSpeed - MinInitialSpeed + 1);
         Speed_pps = MinInitialSpeed + random(speedRange);
         Angle = random(360) * (Pi / 180.0);
-        dx[i] = cos(Angle) * Speed_pps / TargetFPS;
-        dy[i] = sin(Angle) * Speed_pps / TargetFPS;
-        if ((abs(dx[i]) < 0.1) && (abs(dy[i]) < 0.1)) {
-            dx[i] = (MinInitialSpeed / TargetFPS) * 0.707;
-            dy[i] = (MinInitialSpeed / TargetFPS) * 0.707;
+        dx[ii] = cos(Angle) * Speed_pps / TargetFPS;
+        dy[ii] = sin(Angle) * Speed_pps / TargetFPS;
+        if ((abs(dx[ii]) < 0.1) && (abs(dy[ii]) < 0.1)) {
+            dx[ii] = (MinInitialSpeed / TargetFPS) * 0.707;
+            dy[ii] = (MinInitialSpeed / TargetFPS) * 0.707;
         }
-        r[i] = random(206) + 50;
-        g[i] = random(206) + 50;
-        b[i] = random(206) + 50;
-        mass[i] = radius[i] * radius[i];
-        active[i] = 1;
+        r[ii] = random(206) + 50;
+        g[ii] = random(206) + 50;
+        b[ii] = random(206) + 50;
+        mass[ii] = radius[ii] * radius[ii];
+        active[ii] = 1;
         // Ensure loop index remains an integer for subsequent array indexing.
         i = trunc(i + 1);
     }
@@ -83,26 +86,28 @@ int main() {
 
         i = 0;
         while (i < NumBalls) {
-            if (active[i]) {
-                x[i] = x[i] + dx[i];
-                y[i] = y[i] + dy[i];
-                if ((x[i] - radius[i]) < 0) {
-                    x[i] = radius[i];
-                    dx[i] = -dx[i];
-                } else if ((x[i] + radius[i]) > MaxX) {
-                    x[i] = MaxX - radius[i];
-                    dx[i] = -dx[i];
+            ii = trunc(i);
+            if (active[ii]) {
+                x[ii] = x[ii] + dx[ii];
+                y[ii] = y[ii] + dy[ii];
+                if ((x[ii] - radius[ii]) < 0) {
+                    x[ii] = radius[ii];
+                    dx[ii] = -dx[ii];
+                } else if ((x[ii] + radius[ii]) > MaxX) {
+                    x[ii] = MaxX - radius[ii];
+                    dx[ii] = -dx[ii];
                 }
-                if ((y[i] - radius[i]) < 0) {
-                    y[i] = radius[i];
-                    dy[i] = -dy[i];
-                } else if ((y[i] + radius[i]) > MaxY) {
-                    y[i] = MaxY - radius[i];
-                    dy[i] = -dy[i];
+                if ((y[ii] - radius[ii]) < 0) {
+                    y[ii] = radius[ii];
+                    dy[ii] = -dy[ii];
+                } else if ((y[ii] + radius[ii]) > MaxY) {
+                    y[ii] = MaxY - radius[ii];
+                    dy[ii] = -dy[ii];
                 }
                 j = trunc(i + 1);
                 while (j < NumBalls) {
-                    if (active[j]) {
+                    jj = trunc(j);
+                    if (active[jj]) {
                         float distSq;
                         float sumRadiiSq;
                         float nx;
@@ -123,32 +128,32 @@ int main() {
                         float ty;
                         float m1;
                         float m2;
-                        distSq = (x[i] - x[j]) * (x[i] - x[j]) + (y[i] - y[j]) * (y[i] - y[j]);
-                        sumRadiiSq = (radius[i] + radius[j]) * (radius[i] + radius[j]);
+                        distSq = (x[ii] - x[jj]) * (x[ii] - x[jj]) + (y[ii] - y[jj]) * (y[ii] - y[jj]);
+                        sumRadiiSq = (radius[ii] + radius[jj]) * (radius[ii] + radius[jj]);
                         if (distSq <= sumRadiiSq) {
                             dist = sqrt(distSq);
                             if (dist == 0.0) {
-                                x[i] = x[i] + (random(11) - 5) * 0.1;
-                                y[j] = y[j] + (random(11) - 5) * 0.1;
-                                dist = sqrt((x[i] - x[j]) * (x[i] - x[j]) + (y[i] - y[j]) * (y[i] - y[j]));
+                                x[ii] = x[ii] + (random(11) - 5) * 0.1;
+                                y[jj] = y[jj] + (random(11) - 5) * 0.1;
+                                dist = sqrt((x[ii] - x[jj]) * (x[ii] - x[jj]) + (y[ii] - y[jj]) * (y[ii] - y[jj]));
                                 if (dist == 0.0) {
                                     dist = 0.001;
                                 }
                             }
-                            nx = (x[j] - x[i]) / dist;
-                            ny = (y[j] - y[i]) / dist;
+                            nx = (x[jj] - x[ii]) / dist;
+                            ny = (y[jj] - y[ii]) / dist;
                             tx = -ny;
                             ty = nx;
-                            v1x = dx[i];
-                            v1y = dy[i];
-                            v2x = dx[j];
-                            v2y = dy[j];
+                            v1x = dx[ii];
+                            v1y = dy[ii];
+                            v2x = dx[jj];
+                            v2y = dy[jj];
                             v1n = v1x * nx + v1y * ny;
                             v1t = v1x * tx + v1y * ty;
                             v2n = v2x * nx + v2y * ny;
                             v2t = v2x * tx + v2y * ty;
-                            m1 = mass[i];
-                            m2 = mass[j];
+                            m1 = mass[ii];
+                            m2 = mass[jj];
                             if ((m1 + m2) == 0) {
                                 new_v1n = 0;
                                 new_v2n = 0;
@@ -156,16 +161,16 @@ int main() {
                                 new_v1n = (v1n * (m1 - m2) + 2 * m2 * v2n) / (m1 + m2);
                                 new_v2n = (v2n * (m2 - m1) + 2 * m1 * v1n) / (m1 + m2);
                             }
-                            dx[i] = new_v1n * nx + v1t * tx;
-                            dy[i] = new_v1n * ny + v1t * ty;
-                            dx[j] = new_v2n * nx + v2t * tx;
-                            dy[j] = new_v2n * ny + v2t * ty;
-                            overlap = (radius[i] + radius[j]) - dist;
+                            dx[ii] = new_v1n * nx + v1t * tx;
+                            dy[ii] = new_v1n * ny + v1t * ty;
+                            dx[jj] = new_v2n * nx + v2t * tx;
+                            dy[jj] = new_v2n * ny + v2t * ty;
+                            overlap = (radius[ii] + radius[jj]) - dist;
                             if (overlap > 0.0) {
-                                x[i] = x[i] - (overlap / 2.0) * nx;
-                                y[i] = y[i] - (overlap / 2.0) * ny;
-                                x[j] = x[j] + (overlap / 2.0) * nx;
-                                y[j] = y[j] + (overlap / 2.0) * ny;
+                                x[ii] = x[ii] - (overlap / 2.0) * nx;
+                                y[ii] = y[ii] - (overlap / 2.0) * ny;
+                                x[jj] = x[jj] + (overlap / 2.0) * nx;
+                                y[jj] = y[jj] + (overlap / 2.0) * ny;
                             }
                         }
                     }
@@ -179,9 +184,10 @@ int main() {
         cleardevice();
         i = 0;
         while (i < NumBalls) {
-            if (active[i]) {
-                setrgbcolor(r[i], g[i], b[i]);
-                fillcircle(trunc(x[i]), trunc(y[i]), radius[i]);
+            ii = trunc(i);
+            if (active[ii]) {
+                setrgbcolor(r[ii], g[ii], b[ii]);
+                fillcircle(trunc(x[ii]), trunc(y[ii]), radius[ii]);
             }
             i = trunc(i + 1);
         }


### PR DESCRIPTION
## Summary
- ensure loop indices are truncated to integers before array access in `sdl_multibouncingballs.c`

## Testing
- `./build/bin/clike Examples/Clike/sdl_multibouncingballs.c`
- `cd build && ctest --output-on-failure` *(fails: Errors while running CTest)*

------
https://chatgpt.com/codex/tasks/task_e_68a269b9e5e4832ab43476df90701a29