### PR TITLE
Flush pending input in SDL demo to prevent immediate exit

### DIFF
--- a/Examples/Clike/sdl_multibouncingballs.c
+++ b/Examples/Clike/sdl_multibouncingballs.c
@@ -75,6 +75,7 @@ int main() {
 
     quit = 0;
     printf("Multi Bouncing Balls... Press Q in the console to quit.\n");
+    while (keypressed()) { readkey(); } // Clear any buffered key presses
     while (!quit) {
         if (keypressed()) {
             int c;


### PR DESCRIPTION
## Summary
- discard buffered input before main loop in `sdl_multibouncingballs` demo so leftover keystrokes don't trigger an early quit

## Testing
- ⚠️ `./Tests/run_clike_tests.sh` (clike binary not found)


------
https://chatgpt.com/codex/tasks/task_e_68a26c401390832a80220d2ec53ce30f