### PR TITLE
Ensure disassembler prints addresses in decimal

### DIFF
--- a/src/compiler/bytecode.c
+++ b/src/compiler/bytecode.c
@@ -310,7 +310,7 @@ int disassembleInstruction(BytecodeChunk* chunk, int offset, HashTable* procedur
             uint16_t jump_operand = (uint16_t)(chunk->code[offset + 1] << 8) | chunk->code[offset + 2];
             int target_addr = offset + 3 + (int16_t)jump_operand;
             const char* targetName = findProcedureNameByAddress(procedureTable, target_addr);
-            printf("%-16s %4d (to %04X)", "OP_JUMP_IF_FALSE", (int16_t)jump_operand, target_addr);
+            printf("%-16s %4d (to %04d)", "OP_JUMP_IF_FALSE", (int16_t)jump_operand, target_addr);
             if (targetName) {
                 printf(" -> %s", targetName);
             }
@@ -322,7 +322,7 @@ int disassembleInstruction(BytecodeChunk* chunk, int offset, HashTable* procedur
             int16_t jump_operand_sint = (int16_t)jump_operand_uint;
             int target_addr = offset + 3 + jump_operand_sint;
             const char* targetName = findProcedureNameByAddress(procedureTable, target_addr);
-            printf("%-16s %4d (to %04X)", "OP_JUMP", jump_operand_sint, target_addr);
+            printf("%-16s %4d (to %04d)", "OP_JUMP", jump_operand_sint, target_addr);
             if (targetName) {
                 printf(" -> %s", targetName);
             }
@@ -630,7 +630,7 @@ int disassembleInstruction(BytecodeChunk* chunk, int offset, HashTable* procedur
                 AS_STRING(chunk->constants[name_index])) {
                 targetProcName = AS_STRING(chunk->constants[name_index]);
             }
-            printf("%-16s %04X (%s) (%d args)\n",
+            printf("%-16s %04d (%s) (%d args)\n",
                    "OP_CALL", address, targetProcName, declared_arity);
             return offset + 6;
         }
@@ -650,7 +650,7 @@ int disassembleInstruction(BytecodeChunk* chunk, int offset, HashTable* procedur
         // The AST_BREAK node is handled by the compiler generating jump instructions.
 
         default:
-            printf("Unknown opcode %02X\n", instruction);
+            printf("Unknown opcode %d\n", instruction);
             return offset + 1;
     }
 }
@@ -675,7 +675,7 @@ void disassembleBytecodeChunk(BytecodeChunk* chunk, const char* name, HashTable*
                 }
             }
             printf("\n");
-            printf("--- %s %s (at %04X) ---\n", routineTypeStr, procNameAtOffset, offset);
+            printf("--- %s %s (at %04d) ---\n", routineTypeStr, procNameAtOffset, offset);
         }
         // Call the public, enhanced disassembleInstruction
         offset = disassembleInstruction(chunk, offset, procedureTable);

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -2322,7 +2322,7 @@ comparison_error_label:
                 Symbol* proc_symbol = findProcedureByAddress(vm->procedureTable, target_address);
                 if (proc_symbol && proc_symbol->is_alias) proc_symbol = proc_symbol->real_symbol;
                 if (!proc_symbol) {
-                    runtimeError(vm, "VM Error: Could not retrieve procedure symbol for called address %04X.", target_address);
+                    runtimeError(vm, "VM Error: Could not retrieve procedure symbol for called address %04d.", target_address);
                     vm->frameCount--;
                     return INTERPRET_RUNTIME_ERROR;
                 }


### PR DESCRIPTION
## Summary
- Use decimal formatting for unknown opcode warnings so all disassembly output is consistent

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./Tests/run_tests.sh` *(fails: ApiSendReceiveTest.p)*
- `./Tests/run_clike_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a281a81a14832aa5452401dfc39762