### PR TITLE
Handle clike strlen via existing VM builtin

### DIFF
--- a/src/clike/builtins.c
+++ b/src/clike/builtins.c
@@ -1,7 +1,13 @@
 #include "clike/builtins.h"
 #include "backend_ast/builtin.h"
+#include <string.h>
 
 int clike_get_builtin_id(const char *name) {
+    // The VM exposes Pascal's `length` builtin for string length.  Map the
+    // C-like `strlen` to that builtin so we don't need a backend change.
+    if (strcmp(name, "strlen") == 0) {
+        name = "length";
+    }
     return getBuiltinIDForCompiler(name);
 }
 


### PR DESCRIPTION
## Summary
- Map C-like `strlen` to the VM's existing `length` builtin without touching backend code

## Testing
- `cmake -S . -B build`
- `cmake --build build -j 8`
- `Tests/run_clike_tests.sh`
- `Tests/run_tests.sh` *(fails: ApiSendReceiveTest.p – api_receive: Argument must be a valid MStream)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a92042a0832aa79ec1a545714d27