### PR TITLE
Add fallback to default Pascal library search path

### DIFF
--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -1213,6 +1213,19 @@ char *findUnitFile(const char *unit_name) {
         *slash = '\0';
     }
 
+    const char *default_path = "/usr/local/pscal/lib";
+    size_t max_len = strlen(default_path) + 1 + strlen(unit_name) + 3 + 1;
+    char *file_name = malloc(max_len);
+    if (!file_name) {
+        fprintf(stderr, "Memory allocation error in findUnitFile\n");
+        EXIT_FAILURE_HANDLER();
+    }
+    snprintf(file_name, max_len, "%s/%s.pl", default_path, unit_name);
+    if (access(file_name, F_OK) == 0) {
+        return file_name;
+    }
+    free(file_name);
+
     return NULL;
 }
 


### PR DESCRIPTION
## Summary
- ensure the compiler checks `/usr/local/pscal/lib` for units when PSCAL_LIB_DIR and local paths don't provide them

## Testing
- `./Tests/run_tests.sh` *(fails: ApiSendReceiveTest.p)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c4d71628832a8ac17536547766a0