### PR TITLE
Add break loop test for CLike frontend

### DIFF
--- a/Tests/clike/tb.c
+++ b/Tests/clike/tb.c
@@ -1,0 +1,39 @@
+int main() {
+    int i;
+    printf("Testing FOR loop break...");
+    for (i = 1; i <= 10; i = i + 1) {
+        printf(i);
+        if (i == 5) {
+            printf("Breaking FOR loop at i = 5");
+            break;
+        }
+    }
+    printf("After FOR loop.");
+    printf("");
+
+    printf("Testing WHILE loop break...");
+    i = 0;
+    while (i < 10) {
+        i = i + 1;
+        printf(i);
+        if (i == 6) {
+            printf("Breaking WHILE loop at i = 6");
+            break;
+        }
+    }
+    printf("After WHILE loop.");
+    printf("");
+
+    printf("Testing DO-WHILE loop break...");
+    i = 0;
+    do {
+        i = i + 1;
+        printf(i);
+        if (i == 7) {
+            printf("Breaking DO-WHILE loop at i = 7");
+            break;
+        }
+    } while (i < 10);
+    printf("After DO-WHILE loop.");
+    return 0;
+}

--- a/Tests/clike/tb.out
+++ b/Tests/clike/tb.out
@@ -1,0 +1,29 @@
+Testing FOR loop break...
+1
+2
+3
+4
+5
+Breaking FOR loop at i = 5
+After FOR loop.
+
+Testing WHILE loop break...
+1
+2
+3
+4
+5
+6
+Breaking WHILE loop at i = 6
+After WHILE loop.
+
+Testing DO-WHILE loop break...
+1
+2
+3
+4
+5
+6
+7
+Breaking DO-WHILE loop at i = 7
+After DO-WHILE loop.


### PR DESCRIPTION
## Summary
- Add `tb` test for CLike frontend covering `break` in `for`, `while`, and `do-while` loops
- Document missing features preventing other `tall` Pascal tests from being ported (switch/case, enums, ++/--, structs, bitwise ops, file I/O, etc.)

## Testing
- `Tests/run_clike_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a4d028a574832ab4f5458d7a098d40