### PR TITLE
docs: add clike usage tutorial

### DIFF
--- a/Docs/clike_tutorial.md
+++ b/Docs/clike_tutorial.md
@@ -1,0 +1,35 @@
+# Tutorial: Using the clike Compiler
+
+The `clike` binary compiles a small C-style language and immediately executes it on the Pscal virtual machine.
+
+## Build the compiler
+
+From the repository root run:
+
+```sh
+cmake -B build
+cmake --build build --target clike
+```
+
+This generates `build/bin/clike`.
+
+## Run a program
+
+Invoke the compiler with a source file:
+
+```sh
+build/bin/clike path/to/program.c
+```
+
+For example, run the text-based Hangman game:
+
+```sh
+build/bin/clike Examples/Clike/hangman5.c
+```
+
+The compiler translates the source to VM bytecode and executes it immediately.
+
+## Sample programs
+
+Additional examples live in `Examples/Clike`, including `sdl_multibouncingballs.c` for an SDL demo and `hangman5.c` for a console game.
+

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ language can be found in `Examples/Clike`.
 
 ## CLike front end
 
-`build/bin/clike/clike` implements a compact C-like compiler that integrates 
+`build/bin/clike` implements a compact C-like compiler that integrates
 with the pscal vm.  The grammar covers variable and function declarations,
 conditionals, loops and expressions. VM builtins can be invoked simply by
 calling a function name that lacks a user definition.
@@ -84,7 +84,8 @@ build/bin/clike program.c
 ```
 
 Sample programs demonstrating the Tiny C subset are available in
-`Examples/clike`.
+`Examples/clike`. For a step-by-step guide see
+[Docs/clike_tutorial.md](Docs/clike_tutorial.md).
 
 ## Runtime library
 


### PR DESCRIPTION
## Summary
- add step-by-step guide for the clike compiler
- document clike usage and link from README

## Testing
- `bash Tests/run_clike_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a4f4ebe5d0832ab94f36f92472e164