### PR TITLE
Add runtime builtin registry

### DIFF
--- a/Docs/Pscal_Builtins.md
+++ b/Docs/Pscal_Builtins.md
@@ -2,6 +2,27 @@
 
 This document lists the built-in procedures and functions provided by Pscal.
 
+### Registering custom builtins
+
+Additional routines may be added at runtime using the builtin registry API.
+Include `backend_ast/builtin.h` and call `initVmBuiltinRegistry()` once during
+startup, then register new handlers:
+
+```c
+#include "backend_ast/builtin.h"
+
+static Value vmBuiltinFoo(VM* vm, int arg_count, Value* args) {
+    /* ... */
+    return makeInt(0);
+}
+
+void register_foo(void) {
+    registerVmBuiltin("foo", vmBuiltinFoo);
+}
+```
+
+Once registered, Pascal code can call `foo` like any other builtin.
+
 ## General
 - `inttostr` – Convert integer to string.
 - `length` – Length of string or array.

--- a/Docs/pscal_overview.md
+++ b/Docs/pscal_overview.md
@@ -38,7 +38,13 @@ end.
 
 ## Builtins
 
-Builtins are implemented in C and exposed to Pascal through a lookup table【F:src/backend_ast/builtin.c†L35-L176】. They cover:
+Builtins are implemented in C and registered with the VM at runtime. The helper
+functions `initVmBuiltinRegistry` and `registerVmBuiltin` from
+`backend_ast/builtin.h` populate a lookup table that the VM uses to dispatch
+calls. Front ends or plugins may call `registerVmBuiltin` to add new routines
+before executing bytecode.
+
+They cover:
 
 * **Math** – `abs`, `cos`, `sin`, `tan`, `exp`, `ln`, `sqrt`, `sqr`, `round`, `trunc`.
 * **Strings** – `length`, `copy`, `pos`, `chr`, `ord`, `inttostr`, `realtostr`, `upcase`.

--- a/Docs/standalone_vm_frontends.md
+++ b/Docs/standalone_vm_frontends.md
@@ -170,6 +170,14 @@ To invoke a builtin from generated code:
 3. At runtime the VM resolves the name and dispatches to the builtin
    implementation.
 
+Front ends may expose additional builtins by registering handlers before the VM
+executes:
+
+```c
+initVmBuiltinRegistry();
+registerVmBuiltin("foo", vmBuiltinFoo);
+```
+
 Example: call the `random` function which returns an integer.
 
 Python:

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -27,6 +27,34 @@
 #include <sys/time.h> // For gettimeofday
 #include <stdio.h>   // For printf, fprintf
 
+// Runtime builtin registry
+static VmBuiltinMapping* runtime_builtins = NULL;
+static size_t runtime_builtin_count = 0;
+static size_t runtime_builtin_capacity = 0;
+static bool runtime_builtins_initialized = false;
+
+void registerVmBuiltin(const char* name, VmBuiltinFn handler) {
+    if (!name || !handler) return;
+    if (runtime_builtin_count == runtime_builtin_capacity) {
+        size_t new_cap = runtime_builtin_capacity < 8 ? 8 : runtime_builtin_capacity * 2;
+        runtime_builtins = realloc(runtime_builtins, new_cap * sizeof(VmBuiltinMapping));
+        runtime_builtin_capacity = new_cap;
+    }
+    runtime_builtins[runtime_builtin_count].name = name;
+    runtime_builtins[runtime_builtin_count].handler = handler;
+    runtime_builtin_count++;
+}
+
+VmBuiltinFn getVmBuiltinHandler(const char *name) {
+    if (!name) return NULL;
+    for (size_t i = 0; i < runtime_builtin_count; i++) {
+        if (strcasecmp(name, runtime_builtins[i].name) == 0) {
+            return runtime_builtins[i].handler;
+        }
+    }
+    return NULL;
+}
+
 static DIR* dos_dir = NULL; // Used by dos_findfirst/findnext
 
 // Terminal cursor helper
@@ -212,17 +240,14 @@ static const VmBuiltinMapping vmBuiltinDispatchTable[] = {
     {"wherey", vmBuiltinWherey},
 };
 
-static const size_t num_vm_builtins = sizeof(vmBuiltinDispatchTable) / sizeof(vmBuiltinDispatchTable[0]);
-
-// This function now comes AFTER the table and comparison function it uses.
-VmBuiltinFn getVmBuiltinHandler(const char *name) {
-    if (!name) return NULL;
-    for (size_t i = 0; i < num_vm_builtins; i++) {
-        if (strcasecmp(name, vmBuiltinDispatchTable[i].name) == 0) {
-            return vmBuiltinDispatchTable[i].handler;
-        }
+void initVmBuiltinRegistry(void) {
+    if (runtime_builtins_initialized) return;
+    runtime_builtins_initialized = true;
+    size_t count = sizeof(vmBuiltinDispatchTable) / sizeof(vmBuiltinDispatchTable[0]);
+    for (size_t i = 0; i < count; i++) {
+        registerVmBuiltin(vmBuiltinDispatchTable[i].name,
+                          vmBuiltinDispatchTable[i].handler);
     }
-    return NULL;
 }
 
 Value vmBuiltinSqr(VM* vm, int arg_count, Value* args) {
@@ -2075,6 +2100,7 @@ BuiltinRoutineType getBuiltinType(const char *name) {
 }
 
 void registerAllBuiltins(void) {
+    initVmBuiltinRegistry();
     /* Graphics stubs (usable even without SDL) */
     registerBuiltinFunction("ClearDevice", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("CloseGraph", AST_PROCEDURE_DECL, NULL);

--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -14,6 +14,9 @@ typedef struct {
     VmBuiltinFn handler;
 } VmBuiltinMapping;
 
+/* Runtime builtin registry API */
+void registerVmBuiltin(const char* name, VmBuiltinFn handler);
+void initVmBuiltinRegistry(void);
 VmBuiltinFn getVmBuiltinHandler(const char* name);
 
 /* VM-native general built-ins */


### PR DESCRIPTION
## Summary
- Add dynamic runtime registry for builtins with registration API
- Populate registry from existing builtin table at startup
- Initialize runtime registry during builtin registration

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `Tests/run_tests.sh` *(fails: ApiSendReceiveTest.p)*

------
https://chatgpt.com/codex/tasks/task_e_68a503790560832a98d5e4b60e76f281