### PR TITLE
Add runtime builtin registry

### DIFF
--- a/Docs/Pscal_Builtins.md
+++ b/Docs/Pscal_Builtins.md
@@ -2,6 +2,27 @@
 
 This document lists the built-in procedures and functions provided by Pscal.
 
+### Registering custom builtins
+
+Additional routines may be added at runtime using the builtin registry API.
+Include `backend_ast/builtin.h` and call `initVmBuiltinRegistry()` once during
+startup, then register new handlers:
+
+```c
+#include "backend_ast/builtin.h"
+
+static Value vmBuiltinFoo(VM* vm, int arg_count, Value* args) {
+    /* ... */
+    return makeInt(0);
+}
+
+void register_foo(void) {
+    registerVmBuiltin("foo", vmBuiltinFoo);
+}
+```
+
+Once registered, Pascal code can call `foo` like any other builtin.
+
 ## General
 - `inttostr` – Convert integer to string.
 - `length` – Length of string or array.

--- a/Docs/pscal_overview.md
+++ b/Docs/pscal_overview.md
@@ -38,7 +38,13 @@ end.
 
 ## Builtins
 
-Builtins are implemented in C and exposed to Pascal through a lookup table【F:src/backend_ast/builtin.c†L35-L176】. They cover:
+Builtins are implemented in C and registered with the VM at runtime. The helper
+functions `initVmBuiltinRegistry` and `registerVmBuiltin` from
+`backend_ast/builtin.h` populate a lookup table that the VM uses to dispatch
+calls. Front ends or plugins may call `registerVmBuiltin` to add new routines
+before executing bytecode.
+
+They cover:
 
 * **Math** – `abs`, `cos`, `sin`, `tan`, `exp`, `ln`, `sqrt`, `sqr`, `round`, `trunc`.
 * **Strings** – `length`, `copy`, `pos`, `chr`, `ord`, `inttostr`, `realtostr`, `upcase`.

--- a/Docs/standalone_vm_frontends.md
+++ b/Docs/standalone_vm_frontends.md
@@ -170,6 +170,14 @@ To invoke a builtin from generated code:
 3. At runtime the VM resolves the name and dispatches to the builtin
    implementation.
 
+Front ends may expose additional builtins by registering handlers before the VM
+executes:
+
+```c
+initVmBuiltinRegistry();
+registerVmBuiltin("foo", vmBuiltinFoo);
+```
+
 Example: call the `random` function which returns an integer.
 
 Python:

--- a/Tests/RuntimeBuiltinRegistryTest.p
+++ b/Tests/RuntimeBuiltinRegistryTest.p
@@ -1,0 +1,5 @@
+program RuntimeBuiltinRegistryTest;
+begin
+  if TestDynamicBuiltin() <> 123 then
+    halt(1);
+end.

--- a/Tests/run_tests.sh
+++ b/Tests/run_tests.sh
@@ -63,9 +63,16 @@ EXIT_CODE=0
 echo "Running positive tests..."
 for t in "${POSITIVE_TESTS[@]}"; do
   echo "---- $t ----"
-  if ! (cd "$SCRIPT_DIR" && "$PSCAL_BIN" "$t"); then
-    echo "Test failed: $t" >&2
-    EXIT_CODE=1
+  if [ "$t" = "RuntimeBuiltinRegistryTest.p" ]; then
+    if ! (cd "$SCRIPT_DIR" && PSC_TEST_DYNAMIC_BUILTIN=1 "$PSCAL_BIN" "$t"); then
+      echo "Test failed: $t" >&2
+      EXIT_CODE=1
+    fi
+  else
+    if ! (cd "$SCRIPT_DIR" && "$PSCAL_BIN" "$t"); then
+      echo "Test failed: $t" >&2
+      EXIT_CODE=1
+    fi
   fi
   echo
   echo

--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -14,6 +14,9 @@ typedef struct {
     VmBuiltinFn handler;
 } VmBuiltinMapping;
 
+/* Runtime builtin registry API */
+void registerVmBuiltin(const char* name, VmBuiltinFn handler);
+void initVmBuiltinRegistry(void);
 VmBuiltinFn getVmBuiltinHandler(const char* name);
 
 /* VM-native general built-ins */

--- a/src/main.c
+++ b/src/main.c
@@ -39,6 +39,15 @@ const char *PSCAL_USAGE =
     "     --dump-bytecode             Dump compiled bytecode before execution.\n"
     "   or: pscal (with no arguments to display version and usage)";
 
+static Value vmBuiltinTestDynamic(struct VM_s* vm, int arg_count, Value* args) {
+    (void)vm;
+    (void)args;
+    if (arg_count != 0) {
+        return makeInt(-1);
+    }
+    return makeInt(123);
+}
+
 void initSymbolSystem(void) {
 #ifdef DEBUG
     inserted_global_names = createList();
@@ -70,6 +79,12 @@ int runProgram(const char *source, const char *programName, int dump_ast_json_fl
     
     /* Register built-in functions and procedures. */
     registerAllBuiltins();
+
+    const char *dyn_env = getenv("PSC_TEST_DYNAMIC_BUILTIN");
+    if (dyn_env) {
+        registerBuiltinFunction("TestDynamicBuiltin", AST_FUNCTION_DECL, NULL);
+        registerVmBuiltin("testdynamicbuiltin", vmBuiltinTestDynamic);
+    }
     
 #ifdef DEBUG
     fprintf(stderr, "Completed all built-in registrations. About to init lexer.\n");


### PR DESCRIPTION
## Summary
- Add environment-gated test builtin and register it through runtime builtin registry
- Enhance builtin lookup so compiler recognizes dynamically registered builtins
- Add RuntimeBuiltinRegistryTest and adjust test runner to exercise dynamic builtin registration

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `Tests/run_tests.sh` *(fails: ApiSendReceiveTest.p – HTTP response code said error)*
- `Tests/run_clike_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a503790560832a98d5e4b60e76f281