### PR TITLE
Add support for externally linked VM builtins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,12 @@ if(SDL)
     )
 endif()
 
+# ---- User-supplied builtin sources ----
+# Any .c files placed in src/ext_builtins will be automatically
+# compiled and linked into the main binaries.
+file(GLOB PSCAL_EXT_BUILTIN_SOURCES CONFIGURE_DEPENDS src/ext_builtins/*.c)
+list(APPEND PSCAL_SOURCES ${PSCAL_EXT_BUILTIN_SOURCES})
+
 
 # ---- Executable Targets Function ----
 function(add_pscal_executable target_name)
@@ -265,6 +271,9 @@ set(CLIKE_SOURCES
     src/symbol/symbol.c
     src/clike/stubs.c
 )
+
+# Include user-supplied builtins in clike as well
+list(APPEND CLIKE_SOURCES ${PSCAL_EXT_BUILTIN_SOURCES})
 
 # When SDL support is enabled, clike needs the same SDL backend sources
 # as the main executables to provide implementations for graphics and

--- a/Docs/extending_builtins.md
+++ b/Docs/extending_builtins.md
@@ -1,0 +1,51 @@
+# Extending VM Built-ins
+
+Pscal allows additional built-in routines to be linked into the virtual
+machine at build time.  This makes it easy to expose host functionality
+without modifying the core source tree.  Any `*.c` files placed in
+`src/ext_builtins` are automatically compiled and linked into the
+executables.
+
+## Creating a new builtin
+
+Drop a C file into `src/ext_builtins` that defines one or more builtin
+handlers and registers them in a `registerExtendedBuiltins` function.
+The repository includes `src/ext_builtins/getpid.c`, which exposes the
+process ID through a `GetPid` Pascal function:
+
+```c
+#include <unistd.h>
+#include "core/utils.h"
+#include "backend_ast/builtin.h"
+
+static Value vmBuiltinGetPid(struct VM_s* vm, int arg_count, Value* args) {
+    (void)vm; (void)args;
+    return arg_count == 0 ? makeInt(getpid()) : makeInt(-1);
+}
+
+void registerExtendedBuiltins(void) {
+    registerBuiltinFunction("GetPid", AST_FUNCTION_DECL, NULL);
+    registerVmBuiltin("getpid", vmBuiltinGetPid);
+}
+```
+
+Any additional files added to `src/ext_builtins` will be picked up the
+next time you run CMake and `make`.
+
+## Using the builtin
+
+After rebuilding, the new routine can be invoked from Pascal code:
+
+```pascal
+program ShowPID;
+begin
+  writeln('PID = ', GetPid());
+end.
+```
+
+Running the program prints the current process ID:
+
+```sh
+$ build/bin/pscal show_pid.p
+PID = 12345
+```

--- a/Examples/Pascal/show_pid.p
+++ b/Examples/Pascal/show_pid.p
@@ -1,0 +1,4 @@
+program ShowPID;
+begin
+  writeln('PID = ', GetPid());
+end.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ sudo ln -s "${REPO_DIR}/lib" /usr/local/Pscal/lib
 
 Alternatively, set the `PSCAL_LIB_DIR` environment variable to point at a copy of the `lib` directory.
 
+## Extending built-ins
+
+Additional VM primitives can be linked in by dropping C source files into
+`src/ext_builtins`.  Each file should implement a `registerExtendedBuiltins`
+function that registers its routines.  See
+[Docs/extending_builtins.md](Docs/extending_builtins.md) for details and an
+example that exposes the host process ID in `src/ext_builtins/getpid.c`.
+
 ## License
 
 Pscal is released into the public domain under [The Unlicense](LICENSE).

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -214,12 +214,36 @@ static const VmBuiltinMapping vmBuiltinDispatchTable[] = {
 
 static const size_t num_vm_builtins = sizeof(vmBuiltinDispatchTable) / sizeof(vmBuiltinDispatchTable[0]);
 
+/* Dynamic registry for user-supplied VM built-ins. */
+static VmBuiltinMapping *extra_vm_builtins = NULL;
+static size_t num_extra_vm_builtins = 0;
+
+void registerVmBuiltin(const char *name, VmBuiltinFn handler) {
+    if (!name || !handler) return;
+    VmBuiltinMapping *new_table = realloc(extra_vm_builtins,
+        sizeof(VmBuiltinMapping) * (num_extra_vm_builtins + 1));
+    if (!new_table) return;
+    extra_vm_builtins = new_table;
+    extra_vm_builtins[num_extra_vm_builtins].name = strdup(name);
+    extra_vm_builtins[num_extra_vm_builtins].handler = handler;
+    num_extra_vm_builtins++;
+}
+
+/* Weak hook that external modules can override to register additional
+ * built-ins.  The default implementation does nothing. */
+__attribute__((weak)) void registerExtendedBuiltins(void) {}
+
 // This function now comes AFTER the table and comparison function it uses.
 VmBuiltinFn getVmBuiltinHandler(const char *name) {
     if (!name) return NULL;
     for (size_t i = 0; i < num_vm_builtins; i++) {
         if (strcasecmp(name, vmBuiltinDispatchTable[i].name) == 0) {
             return vmBuiltinDispatchTable[i].handler;
+        }
+    }
+    for (size_t i = 0; i < num_extra_vm_builtins; i++) {
+        if (strcasecmp(name, extra_vm_builtins[i].name) == 0) {
+            return extra_vm_builtins[i].handler;
         }
     }
     return NULL;
@@ -2035,10 +2059,14 @@ Value vmBuiltinDelay(VM* vm, int arg_count, Value* args) {
 
 int getBuiltinIDForCompiler(const char *name) {
     if (!name) return -1;
-    size_t count = sizeof(vmBuiltinDispatchTable) / sizeof(vmBuiltinDispatchTable[0]);
-    for (size_t i = 0; i < count; ++i) {
+    for (size_t i = 0; i < num_vm_builtins; ++i) {
         if (strcasecmp(name, vmBuiltinDispatchTable[i].name) == 0) {
             return (int)i;
+        }
+    }
+    for (size_t i = 0; i < num_extra_vm_builtins; ++i) {
+        if (strcasecmp(name, extra_vm_builtins[i].name) == 0) {
+            return (int)(num_vm_builtins + i);
         }
     }
     return -1;
@@ -2205,6 +2233,9 @@ void registerAllBuiltins(void) {
     registerBuiltinFunction("BIWhereX", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("WhereY", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("BIWhereY", AST_FUNCTION_DECL, NULL);
+
+    /* Allow externally linked modules to add more builtins. */
+    registerExtendedBuiltins();
 }
 
 #ifndef SDL

--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -15,6 +15,11 @@ typedef struct {
 } VmBuiltinMapping;
 
 VmBuiltinFn getVmBuiltinHandler(const char* name);
+void registerVmBuiltin(const char *name, VmBuiltinFn handler);
+
+/* Optional hook for externally linked built-ins.  The weak
+ * definition in builtin.c does nothing unless overridden. */
+void registerExtendedBuiltins(void);
 
 /* VM-native general built-ins */
 Value vmBuiltinInttostr(struct VM_s* vm, int arg_count, Value* args);

--- a/src/ext_builtins/getpid.c
+++ b/src/ext_builtins/getpid.c
@@ -1,0 +1,13 @@
+#include <unistd.h>
+#include "core/utils.h"
+#include "backend_ast/builtin.h"
+
+static Value vmBuiltinGetPid(struct VM_s* vm, int arg_count, Value* args) {
+    (void)vm; (void)args;
+    return arg_count == 0 ? makeInt(getpid()) : makeInt(-1);
+}
+
+void registerExtendedBuiltins(void) {
+    registerBuiltinFunction("GetPid", AST_FUNCTION_DECL, NULL);
+    registerVmBuiltin("getpid", vmBuiltinGetPid);
+}


### PR DESCRIPTION
## Summary
- allow registration of extra VM builtins via `registerVmBuiltin` and weak `registerExtendedBuiltins`
- compile any C sources in `src/ext_builtins` and include sample `GetPid` builtin
- document how to add custom builtins and provide `GetPid` example

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure` *(fails: pscal_tests; network call to example.com returned an error)*
- `./bin/pscal ../Examples/Pascal/show_pid.p`


------
https://chatgpt.com/codex/tasks/task_e_68a53ca01fd4832aa51adbd5a83446a4