### PR TITLE
Add cleanup of text files post-tests

### DIFF
--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -63,4 +63,4 @@ test:
 	else \
 	echo "Skipping SDL tests (SDL option is OFF)"; \
 	fi
-	
+	@rm -f *.txt


### PR DESCRIPTION
## Summary
- remove leftover text files after running tests by deleting *.txt at end of the test recipe

## Testing
- `cd Tests && make test` *(fails: ../build/bin/pscal: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a558ea73a0832a83a8413a53f651ba