### PR TITLE
Handle missing default input in eof builtin

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -1332,16 +1332,19 @@ Value vmBuiltinClose(VM* vm, int arg_count, Value* args) {
 }
 
 Value vmBuiltinEof(VM* vm, int arg_count, Value* args) {
-    FILE* stream = stdin;
+    FILE* stream = NULL;
 
     if (arg_count == 0) {
         if (vm->vmGlobalSymbols) {
             Symbol* inputSym = hashTableLookup(vm->vmGlobalSymbols, "input");
             if (inputSym && inputSym->value &&
-                inputSym->value->type == TYPE_FILE &&
-                inputSym->value->f_val) {
+                inputSym->value->type == TYPE_FILE) {
                 stream = inputSym->value->f_val;
             }
+        }
+        if (!stream) {
+            // No default input file has been opened; treat as EOF
+            return makeBoolean(true);
         }
     } else if (arg_count == 1) {
         if (args[0].type != TYPE_POINTER || !args[0].ptr_val) {

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -552,6 +552,23 @@ InterpretResult interpretBytecode(VM* vm, BytecodeChunk* chunk, HashTable* globa
     vm->vmGlobalSymbols = globals;    // Store globals table (ensure this is the intended one)
     vm->procedureTable = procedures; // <--- STORED procedureTable
 
+    // Initialize default file variables if present but not yet opened.
+    if (vm->vmGlobalSymbols) {
+        Symbol* inputSym = hashTableLookup(vm->vmGlobalSymbols, "input");
+        if (inputSym && inputSym->value &&
+            inputSym->value->type == TYPE_FILE &&
+            inputSym->value->f_val == NULL) {
+            inputSym->value->f_val = stdin;
+        }
+
+        Symbol* outputSym = hashTableLookup(vm->vmGlobalSymbols, "output");
+        if (outputSym && outputSym->value &&
+            outputSym->value->type == TYPE_FILE &&
+            outputSym->value->f_val == NULL) {
+            outputSym->value->f_val = stdout;
+        }
+    }
+
     // Establish a base call frame for the main program.  This allows inline
     // routines at the top level to utilize local variable opcodes without
     // triggering stack underflows due to the absence of an active frame.


### PR DESCRIPTION
## Summary
- Avoid blocking on stdin when calling `eof` without an open default input file by returning true for EOF
- Initialize default `input` and `output` file variables to `stdin` and `stdout` so programs have usable streams even without explicit assignments
- Add empty file used by default-input EOF test

## Testing
- `./build/bin/pscal Tests/EofDefaultInput.p`
- `./Tests/run_tests.sh` *(fails: ApiSendReceiveTest.p, FormattingTestSuite.p, TestFileOperations.p)*

------
https://chatgpt.com/codex/tasks/task_e_68a55baa64e8832ab963774689d9bd06