### PR TITLE
clike: use integer division for integer operands

### DIFF
--- a/src/clike/opt.c
+++ b/src/clike/opt.c
@@ -25,7 +25,17 @@ static ASTNodeClike* foldBinary(ASTNodeClike* node) {
         case CLIKE_TOKEN_PLUS: res = lv + rv; break;
         case CLIKE_TOKEN_MINUS: res = lv - rv; break;
         case CLIKE_TOKEN_STAR: res = lv * rv; break;
-        case CLIKE_TOKEN_SLASH: res = lv / rv; result_is_float = 1; break;
+        case CLIKE_TOKEN_SLASH:
+            if (lf || rf) {
+                /* If either operand is float, perform floating-point division. */
+                res = lv / rv;
+                result_is_float = 1;
+            } else {
+                /* Both operands are integers: mimic C's integer division. */
+                res = (double)((long long)lv / (long long)rv);
+                result_is_float = 0;
+            }
+            break;
         case CLIKE_TOKEN_EQUAL_EQUAL: res = (lv == rv); result_is_float = 0; break;
         case CLIKE_TOKEN_BANG_EQUAL: res = (lv != rv); result_is_float = 0; break;
         case CLIKE_TOKEN_LESS: res = (lv < rv); result_is_float = 0; break;


### PR DESCRIPTION
## Summary
- ensure `/` between ints uses OP_INT_DIV to avoid promoting to real
- fold constant integer divisions to integers in optimizer

## Testing
- `./build/bin/clike --dump-bytecode /tmp/div.c`
- `./build/bin/clike --dump-bytecode /tmp/div_const.c`
- `bash Tests/run_clike_tests.sh` *(fails: Test failed (stdout mismatch): graphics)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e5723000832a88b3b21b1f821844