### PR TITLE
Support optional VAR parameter for ReadKey builtin

### DIFF
--- a/Docs/Pscal_Builtins.md
+++ b/Docs/Pscal_Builtins.md
@@ -29,7 +29,7 @@ This document lists the built-in procedures and functions provided by Pscal.
 - `wherey` – Current cursor Y position.
 - `gotoxy` – Move cursor.
 - `keypressed` – True if key waiting.
-- `readkey` – Read key.
+- `readkey` – Read key. Optionally accepts a `VAR` char to store the key pressed.
 - `textcolor` – Set text color.
 - `textbackground` – Set background color.
 - `textcolore` – Extended text color.

--- a/Docs/pscal_overview.md
+++ b/Docs/pscal_overview.md
@@ -42,7 +42,7 @@ Builtins are implemented in C and exposed to Pascal through a lookup table【F:s
 
 * **Math** – `abs`, `cos`, `sin`, `tan`, `exp`, `ln`, `sqrt`, `sqr`, `round`, `trunc`.
 * **Strings** – `length`, `copy`, `pos`, `chr`, `ord`, `inttostr`, `realtostr`, `upcase`.
-* **I/O** – `readln`, `writeln`, `readkey`, `halt`, `gotoxy`, `whereX`, `textcolor`.
+* **I/O** – `readln`, `writeln`, `readkey` (optional char parameter), `halt`, `gotoxy`, `whereX`, `textcolor`.
 * **Files & streams** – `assign`, `reset`, `rewrite`, `close`, `eof`, memory stream helpers (`mstreamcreate`, `mstreamloadfromfile`, etc.).
 * **Random numbers** – `randomize`, `random`.
 * **System utilities** – `paramcount`, `paramstr`, `exit`, `ioresult`.

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -648,16 +648,30 @@ Value vmBuiltinKeypressed(VM* vm, int arg_count, Value* args) {
 }
 
 Value vmBuiltinReadkey(VM* vm, int arg_count, Value* args) {
-    if (arg_count != 0) {
-        runtimeError(vm, "ReadKey expects 0 arguments.");
+    if (arg_count != 0 && arg_count != 1) {
+        runtimeError(vm, "ReadKey expects 0 or 1 argument.");
         return makeChar('\0');
     }
     vmEnableRawMode();
 
     char c;
     if (read(STDIN_FILENO, &c, 1) != 1) {
-        return makeChar('\0');
+        c = '\0';
     }
+
+    if (arg_count == 1) {
+        if (args[0].type != TYPE_POINTER || args[0].ptr_val == NULL) {
+            runtimeError(vm, "ReadKey argument must be a VAR char.");
+        } else {
+            Value* dst = (Value*)args[0].ptr_val;
+            if (dst->type == TYPE_CHAR) {
+                dst->c_val = c;
+            } else {
+                runtimeError(vm, "ReadKey argument must be of type CHAR.");
+            }
+        }
+    }
+
     return makeChar(c);
 }
 

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -2057,7 +2057,7 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
                     is_var_param = true;
                 }
                 else if (calleeName && (
-                    (i == 0 && (strcasecmp(calleeName, "new") == 0 || strcasecmp(calleeName, "dispose") == 0 || strcasecmp(calleeName, "assign") == 0 || strcasecmp(calleeName, "reset") == 0 || strcasecmp(calleeName, "rewrite") == 0 || strcasecmp(calleeName, "close") == 0 || strcasecmp(calleeName, "inc") == 0 || strcasecmp(calleeName, "dec") == 0 || strcasecmp(calleeName, "mstreamloadfromfile") == 0 || strcasecmp(calleeName, "mstreamsavetofile") == 0 || strcasecmp(calleeName, "mstreamfree") == 0 || strcasecmp(calleeName, "eof") == 0)) ||
+                    (i == 0 && (strcasecmp(calleeName, "new") == 0 || strcasecmp(calleeName, "dispose") == 0 || strcasecmp(calleeName, "assign") == 0 || strcasecmp(calleeName, "reset") == 0 || strcasecmp(calleeName, "rewrite") == 0 || strcasecmp(calleeName, "close") == 0 || strcasecmp(calleeName, "inc") == 0 || strcasecmp(calleeName, "dec") == 0 || strcasecmp(calleeName, "mstreamloadfromfile") == 0 || strcasecmp(calleeName, "mstreamsavetofile") == 0 || strcasecmp(calleeName, "mstreamfree") == 0 || strcasecmp(calleeName, "eof") == 0 || strcasecmp(calleeName, "readkey") == 0)) ||
                     (strcasecmp(calleeName, "readln") == 0 && (i > 0 || (i == 0 && arg_node->var_type != TYPE_FILE))) ||
                     (strcasecmp(calleeName, "getmousestate") == 0) || // All params are VAR
                     (strcasecmp(calleeName, "gettextsize") == 0 && i > 0) // Width and Height are VAR


### PR DESCRIPTION
## Summary
- allow `ReadKey` to accept an optional VAR char and store the pressed key
- compile `ReadKey` calls with an argument as a VAR parameter
- document `ReadKey`'s optional parameter

## Testing
- `./Tests/run_all_tests` *(fails: api_send curl_easy_perform() failed: HTTP response code said error)*

------
https://chatgpt.com/codex/tasks/task_e_68a63e24c9c0832a9a07f9002f898d1d