### PR TITLE
Support typed constant arrays

### DIFF
--- a/Tests/Pascal/ConstArrayTest.p
+++ b/Tests/Pascal/ConstArrayTest.p
@@ -1,0 +1,21 @@
+program ConstArrayTest;
+
+const
+  CardValues: array[1..3] of string = ('A','2','3');
+  IntSeq: array[0..2] of integer = (10,-5,42);
+  TestStr: string = 'Simple';
+
+var
+  i: integer;
+  s: string;
+
+begin
+  writeln('Simple Const TestStr: ', TestStr);
+  writeln('CardValues[1] = ', CardValues[1]);
+  writeln('CardValues[3] = ', CardValues[3]);
+  s := CardValues[2];
+  writeln('Assigned CardValues[2] to s: ', s);
+  for i := 0 to 2 do
+    write(IntSeq[i], ' ');
+  writeln;
+end.


### PR DESCRIPTION
## Summary
- allow CONST declarations to include types and array initializers
- build array values for constant declarations at compile time
- add regression test for typed constant arrays

## Testing
- `cd Tests && ./run_tests.sh` *(fails: ApiSendReceiveTest.p, FormattingTestSuite.p, TestFileOperations.p)*
- `build/bin/pscal Tests/Pascal/ConstArrayTest.p`


------
https://chatgpt.com/codex/tasks/task_e_68a645af3564832a97a9885c53f32be5