### PR TITLE
Add factorial extended builtin

### DIFF
--- a/src/ext_builtins/factorial.c
+++ b/src/ext_builtins/factorial.c
@@ -1,0 +1,28 @@
+#include "core/utils.h"
+#include "backend_ast/builtin.h"
+
+static Value vmBuiltinFactorial(struct VM_s* vm, int arg_count, Value* args) {
+    if (arg_count != 1) {
+        runtimeError(vm, "Factorial expects exactly 1 argument.");
+        return makeInt(-1);
+    }
+    if (args[0].type != TYPE_INTEGER) {
+        runtimeError(vm, "Factorial argument must be an integer.");
+        return makeInt(-1);
+    }
+    long long n = args[0].i_val;
+    if (n < 0) {
+        runtimeError(vm, "Factorial argument must be non-negative.");
+        return makeInt(-1);
+    }
+    long long result = 1;
+    for (long long i = 2; i <= n; ++i) {
+        result *= i;
+    }
+    return makeInt(result);
+}
+
+void registerFactorialBuiltin(void) {
+    registerBuiltinFunction("Factorial", AST_FUNCTION_DECL, NULL);
+    registerVmBuiltin("factorial", vmBuiltinFactorial);
+}

--- a/src/ext_builtins/register.c
+++ b/src/ext_builtins/register.c
@@ -2,8 +2,10 @@
 
 void registerGetPidBuiltin(void);
 void registerSwapBuiltin(void);
+void registerFactorialBuiltin(void);
 
 void registerExtendedBuiltins(void) {
     registerGetPidBuiltin();
     registerSwapBuiltin();
+    registerFactorialBuiltin();
 }


### PR DESCRIPTION
## Summary
- add extended builtin function `Factorial` for computing factorials
- register `Factorial` in extended builtin initialization

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd Tests && ./run_all_tests` *(fails: ApiSendReceiveTest.p, ConstArrayTest.p, FormattingTestSuite.p, TestFileOperations.p)*

------
https://chatgpt.com/codex/tasks/task_e_68a674844bdc832a89d95cefcbaaa606