### PR TITLE
Add Fibonacci extended builtin

### DIFF
--- a/src/ext_builtins/fibonacci.c
+++ b/src/ext_builtins/fibonacci.c
@@ -1,0 +1,31 @@
+#include "core/utils.h"
+#include "backend_ast/builtin.h"
+
+static Value vmBuiltinFibonacci(struct VM_s* vm, int arg_count, Value* args) {
+    if (arg_count != 1) {
+        runtimeError(vm, "Fibonacci expects exactly 1 argument.");
+        return makeInt(-1);
+    }
+    if (args[0].type != TYPE_INTEGER) {
+        runtimeError(vm, "Fibonacci argument must be an integer.");
+        return makeInt(-1);
+    }
+    long long n = args[0].i_val;
+    if (n < 0) {
+        runtimeError(vm, "Fibonacci argument must be non-negative.");
+        return makeInt(-1);
+    }
+    long long a = 0;
+    long long b = 1;
+    for (long long i = 0; i < n; ++i) {
+        long long temp = a;
+        a = b;
+        b = temp + b;
+    }
+    return makeInt(a);
+}
+
+void registerFibonacciBuiltin(void) {
+    registerBuiltinFunction("Fibonacci", AST_FUNCTION_DECL, NULL);
+    registerVmBuiltin("fibonacci", vmBuiltinFibonacci);
+}

--- a/src/ext_builtins/register.c
+++ b/src/ext_builtins/register.c
@@ -3,9 +3,11 @@
 void registerGetPidBuiltin(void);
 void registerSwapBuiltin(void);
 void registerFactorialBuiltin(void);
+void registerFibonacciBuiltin(void);
 
 void registerExtendedBuiltins(void) {
     registerGetPidBuiltin();
     registerSwapBuiltin();
     registerFactorialBuiltin();
+    registerFibonacciBuiltin();
 }


### PR DESCRIPTION
## Summary
- add Fibonacci function as extended builtin in ext_builtins
- register Fibonacci builtin during VM initialization

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `Tests/run_tests.sh` *(fails: ApiSendReceiveTest.p, ConstArrayTest.p, FormattingTestSuite.p, TestFileOperations.p)*

------
https://chatgpt.com/codex/tasks/task_e_68a6783cf860832aa3ad68f3438e0c55