### PR TITLE
Fix AST node reuse in increment operators

### DIFF
--- a/src/clike/ast.c
+++ b/src/clike/ast.c
@@ -46,6 +46,28 @@ void setThirdClike(ASTNodeClike *parent, ASTNodeClike *child) {
     if (child) child->parent = parent;
 }
 
+ASTNodeClike *cloneASTClike(ASTNodeClike *node) {
+    if (!node) return NULL;
+    ASTNodeClike *copy = newASTNodeClike(node->type, node->token);
+    if (!copy) return NULL;
+    copy->var_type = node->var_type;
+    copy->is_array = node->is_array;
+    copy->array_size = node->array_size;
+    copy->dim_count = node->dim_count;
+    copy->element_type = node->element_type;
+    if (node->dim_count > 0 && node->array_dims) {
+        copy->array_dims = (int*)malloc(sizeof(int) * node->dim_count);
+        memcpy(copy->array_dims, node->array_dims, sizeof(int) * node->dim_count);
+    }
+    setLeftClike(copy, cloneASTClike(node->left));
+    setRightClike(copy, cloneASTClike(node->right));
+    setThirdClike(copy, cloneASTClike(node->third));
+    for (int i = 0; i < node->child_count; ++i) {
+        addChildClike(copy, cloneASTClike(node->children[i]));
+    }
+    return copy;
+}
+
 void freeASTClike(ASTNodeClike *node) {
     if (!node) return;
     for (int i = 0; i < node->child_count; ++i) freeASTClike(node->children[i]);

--- a/src/clike/ast.h
+++ b/src/clike/ast.h
@@ -54,6 +54,7 @@ typedef struct ASTNodeClike {
 } ASTNodeClike;
 
 ASTNodeClike *newASTNodeClike(ASTNodeTypeClike type, ClikeToken token);
+ASTNodeClike *cloneASTClike(ASTNodeClike *node);
 void addChildClike(ASTNodeClike *parent, ASTNodeClike *child);
 void setLeftClike(ASTNodeClike *parent, ASTNodeClike *child);
 void setRightClike(ASTNodeClike *parent, ASTNodeClike *child);

--- a/src/clike/parser.c
+++ b/src/clike/parser.c
@@ -810,7 +810,7 @@ static ASTNodeClike* unary(ParserClike *p) {
         ASTNodeClike *one = newASTNodeClike(TCAST_NUMBER, oneTok); one->var_type = TYPE_INTEGER;
         ClikeToken opTok = op; opTok.type = (op.type == CLIKE_TOKEN_PLUS_PLUS) ? CLIKE_TOKEN_PLUS : CLIKE_TOKEN_MINUS; opTok.lexeme = (op.type == CLIKE_TOKEN_PLUS_PLUS)?"+":"-"; opTok.length = 1;
         ASTNodeClike *bin = newASTNodeClike(TCAST_BINOP, opTok);
-        setLeftClike(bin, operand);
+        setLeftClike(bin, cloneASTClike(operand));
         setRightClike(bin, one);
         ClikeToken eqTok = op; eqTok.type = CLIKE_TOKEN_EQUAL; eqTok.lexeme = "="; eqTok.length = 1;
         ASTNodeClike *assign = newASTNodeClike(TCAST_ASSIGN, eqTok);
@@ -882,7 +882,7 @@ static ASTNodeClike* factor(ParserClike *p) {
             ASTNodeClike *one = newASTNodeClike(TCAST_NUMBER, oneTok); one->var_type = TYPE_INTEGER;
             ClikeToken opTok = op; opTok.type = (op.type == CLIKE_TOKEN_PLUS_PLUS)?CLIKE_TOKEN_PLUS:CLIKE_TOKEN_MINUS; opTok.lexeme = (op.type==CLIKE_TOKEN_PLUS_PLUS)?"+":"-"; opTok.length=1;
             ASTNodeClike *bin = newASTNodeClike(TCAST_BINOP, opTok);
-            setLeftClike(bin, idNode);
+            setLeftClike(bin, cloneASTClike(idNode));
             setRightClike(bin, one);
             ClikeToken eqTok = op; eqTok.type = CLIKE_TOKEN_EQUAL; eqTok.lexeme = "="; eqTok.length =1;
             ASTNodeClike *assign = newASTNodeClike(TCAST_ASSIGN, eqTok);

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1997,6 +1997,7 @@ comparison_error_label:
                     }
                 }
                 // --- END CORRECTED LOGIC ---
+                #ifdef DEBUG
                 if (target_slot->type == TYPE_POINTER) {
                     fprintf(stderr,
                             "[DEBUG set_local] slot %u ptr=%p base=%p (%s) val=%p\n",
@@ -2006,6 +2007,7 @@ comparison_error_label:
                             target_slot->base_type_node ? astTypeToString(target_slot->base_type_node->type) : "NULL",
                             target_slot->ptr_val);
                 }
+                #endif
 
                 // Free the temporary value that was popped from the stack.
                 freeValue(&value_from_stack);


### PR DESCRIPTION
## Summary
- clone AST subtrees when parsing pre/post increment to avoid shared nodes and invalid parent links
- add deep-copy helper for Clike AST nodes
- wrap pointer set-local debug output with `#ifdef DEBUG`

## Testing
- `Tests/run_clike_tests.sh`
- `build/bin/clike --dump-bytecode /tmp/increment.cl`


------
https://chatgpt.com/codex/tasks/task_e_68a680c4763c832ab7f6f8af94311a5d