### PR TITLE
Rename pscal/dscal binaries to pascal/dascal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,8 +206,8 @@ function(add_pscal_executable target_name)
 
     list(APPEND TARGET_LINK_LIBS m) # Math library
 
-    # Specific options for dscal (ASan)
-    if(${target_name} STREQUAL "dscal")
+    # Specific options for dascal (ASan)
+    if(${target_name} STREQUAL "dascal")
         list(APPEND TARGET_LINK_LIBS "-fsanitize=address")
     endif()
 
@@ -224,14 +224,14 @@ function(add_pscal_executable target_name)
     endif()
 
     # Specific compile definitions and options
-    if(${target_name} STREQUAL "pscal")
+    if(${target_name} STREQUAL "pascal")
         target_compile_options(${target_name} PRIVATE -O3)
         if(RELEASE_BUILD)
             target_compile_definitions(${target_name} PRIVATE RELEASE)
         else()
             target_compile_definitions(${target_name} PRIVATE DEBUGNOT)
         endif()
-    elseif(${target_name} STREQUAL "dscal")
+    elseif(${target_name} STREQUAL "dascal")
         target_compile_definitions(${target_name} PRIVATE DEBUG)
         target_compile_options(${target_name} PRIVATE -fsanitize=address -g)
     elseif(${target_name} STREQUAL "hscal")
@@ -240,8 +240,8 @@ function(add_pscal_executable target_name)
     endif()
 endfunction()
 
-add_pscal_executable(pscal)
-add_pscal_executable(dscal)
+add_pscal_executable(pascal)
+add_pscal_executable(dascal)
 # add_pscal_executable(hscal) // Lets not build this normally
 
 # Standalone VM binary
@@ -361,8 +361,8 @@ add_subdirectory(Examples)
 
 # ---- optional install ----
 include(GNUInstallDirs)
-install(TARGETS pscal dscal pscalvm
+install(TARGETS pascal dascal pscalvm
         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 
-add_test(NAME pscal_tests COMMAND bash ${CMAKE_SOURCE_DIR}/Tests/run_tests.sh)
+add_test(NAME pascal_tests COMMAND bash ${CMAKE_SOURCE_DIR}/Tests/run_tests.sh)
 add_test(NAME clike_tests COMMAND bash ${CMAKE_SOURCE_DIR}/Tests/run_clike_tests.sh)

--- a/Docs/extending_builtins.md
+++ b/Docs/extending_builtins.md
@@ -110,7 +110,7 @@ end.
 Running the program prints the current process ID:
 
 ```sh
-$ build/bin/pscal Examples/Pascal/show_builtins.p
+$ build/bin/pascal Examples/Pascal/show_builtins.p
 PID = 12345
 After Swap: a=2 b=1
 ```

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -1,14 +1,14 @@
 cmake_minimum_required(VERSION 3.24)
 project(pscal_examples NONE)
 
-# Path to the pscal interpreter built by main project
-set(PSCAL_BIN ${CMAKE_BINARY_DIR}/bin/pscal)
+# Path to the pascal interpreter built by main project
+set(PASCAL_BIN ${CMAKE_BINARY_DIR}/bin/pascal)
 
 # Basic example target
 add_custom_target(run_basic_examples
     COMMAND ${CMAKE_COMMAND} -E echo "Running basic examples..."
-    COMMAND ${PSCAL_BIN} ${CMAKE_CURRENT_SOURCE_DIR}/AreaCalculation.p
-    COMMAND ${PSCAL_BIN} ${CMAKE_CURRENT_SOURCE_DIR}/DosExample.p
+    COMMAND ${PASCAL_BIN} ${CMAKE_CURRENT_SOURCE_DIR}/AreaCalculation.p
+    COMMAND ${PASCAL_BIN} ${CMAKE_CURRENT_SOURCE_DIR}/DosExample.p
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
@@ -16,7 +16,7 @@ add_custom_target(run_basic_examples
 if(SDL)
     add_custom_target(run_sdl_examples
         COMMAND ${CMAKE_COMMAND} -E echo "Running SDL examples..."
-        COMMAND ${PSCAL_BIN} ${CMAKE_CURRENT_SOURCE_DIR}/SDLSimplePong
+        COMMAND ${PASCAL_BIN} ${CMAKE_CURRENT_SOURCE_DIR}/SDLSimplePong
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
 else()

--- a/Examples/Pascal/AreaCalculation.p
+++ b/Examples/Pascal/AreaCalculation.p
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 program AreaCalculation;
 uses CalculateArea,crt;
 

--- a/Examples/Pascal/CRTFunctionsDemo.p
+++ b/Examples/Pascal/CRTFunctionsDemo.p
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 program CRTFunctionsDemo;
 
 uses CRT;

--- a/Examples/Pascal/ColorPalette256
+++ b/Examples/Pascal/ColorPalette256
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 PROGRAM ColorPalette256Demo;
 
 USES Crt; // Assumes CRT contains ClrScr, GotoXY, TextColorE, TextColor, Write, WriteLn, ReadKey, NormVideo
@@ -17,7 +17,7 @@ BEGIN
   ClrScr; // Clear the terminal screen
 
   GotoXY(1, 1);
-  WriteLn('pscal 256-Color Palette Demonstration');
+  WriteLn('pascal 256-Color Palette Demonstration');
   WriteLn('--------------------------------------');
   WriteLn('(Requires a terminal emulator supporting 256 colors)');
 

--- a/Examples/Pascal/DosExample.p
+++ b/Examples/Pascal/DosExample.p
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 program DosExample;
 uses dos;
 var

--- a/Examples/Pascal/Mando16Color
+++ b/Examples/Pascal/Mando16Color
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 PROGRAM MandelbrotColorASCII;
 
 USES Crt;

--- a/Examples/Pascal/Mando256Color
+++ b/Examples/Pascal/Mando256Color
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 PROGRAM Mandelbrot256Color;
 
 USES Crt; // Assumes CRT.pas contains TextColorE, GotoXY, etc.

--- a/Examples/Pascal/MandoMono
+++ b/Examples/Pascal/MandoMono
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 PROGRAM MandelbrotASCII;
 
 USES Crt;  // For GotoXY, Write, ScreenCols, ScreenRows, ClrScr, ReadKey

--- a/Examples/Pascal/SDLBouncingBall
+++ b/Examples/Pascal/SDLBouncingBall
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 program AmigaBoingBallTextureDemo_v4;
 
 const

--- a/Examples/Pascal/SDLBreakout
+++ b/Examples/Pascal/SDLBreakout
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 program PscalBreakout;
 
 uses CRT; // For Delay, potentially KeyPressed/ReadKey if not using full GraphLoop for input

--- a/Examples/Pascal/SDLInteractiveMandelbrot
+++ b/Examples/Pascal/SDLInteractiveMandelbrot
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 PROGRAM SDLTextureMandelbrotZoomFixed;
 
 USES CRT;

--- a/Examples/Pascal/SDLMultiBouncingBalls
+++ b/Examples/Pascal/SDLMultiBouncingBalls
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 PROGRAM SDLMultiBouncingBalls;
 
 USES CRT;

--- a/Examples/Pascal/area.p
+++ b/Examples/Pascal/area.p
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 Program Calculate_Area (input, output);
 uses crt;
 var 

--- a/Examples/Pascal/crtd
+++ b/Examples/Pascal/crtd
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 program CrtDemo;
 
 uses CRT;

--- a/Examples/Pascal/gtn
+++ b/Examples/Pascal/gtn
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 program GuessTheNumber;
 
 uses CRT; // Uses the CRT unit for screen control and ReadKey

--- a/Examples/Pascal/hangman
+++ b/Examples/Pascal/hangman
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 program HangmanGame;
 
 uses CRT;

--- a/Examples/Pascal/hangman2
+++ b/Examples/Pascal/hangman2
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 program HangmanGame;
 
 uses CRT;

--- a/Examples/Pascal/hangman3
+++ b/Examples/Pascal/hangman3
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 program HangmanGame;
 
 uses CRT;

--- a/Examples/Pascal/hangman4
+++ b/Examples/Pascal/hangman4
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 program HangmanGame;
 
 uses CRT;

--- a/Examples/Pascal/hangman5
+++ b/Examples/Pascal/hangman5
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 program HangmanGameWithPointers;
 
 uses CRT;

--- a/Examples/Pascal/mandoSDL
+++ b/Examples/Pascal/mandoSDL
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 PROGRAM SDLMandelbrotWithStatus;
 
 // USES System; // Implicit for Sqrt, Trunc, WriteLn etc. if not global

--- a/Examples/Pascal/mandoSDL_Linux
+++ b/Examples/Pascal/mandoSDL_Linux
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 PROGRAM SDLMandelbrotCRTStatus;
 
 USES CRT;

--- a/Examples/Pascal/plasma
+++ b/Examples/Pascal/plasma
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 PROGRAM Plasma256Color;
 
 USES Crt; // Assumes Sin, Sqrt, GotoXY, ClrScr, Write, WriteLn, TextColorE, TextColor, TextBackground, NormVideo, ReadKey, ScreenCols, ScreenRows

--- a/Examples/Pascal/plasmaSDL256
+++ b/Examples/Pascal/plasmaSDL256
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 PROGRAM SDLPlasma256Color;
 
 // USES System; // Implicitly used for Sin, Sqrt, Trunc if not global

--- a/Examples/Pascal/plasmaSDL_RGB
+++ b/Examples/Pascal/plasmaSDL_RGB
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 PROGRAM SDLPlasmaRGB;
 
 // USES System; // Implicit for Sin, Sqrt, Trunc if not global

--- a/Examples/Pascal/pwav
+++ b/Examples/Pascal/pwav
@@ -1,13 +1,13 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 program PlayWaveFile;
 
 {
   This program plays a specified WAV audio file.
   The filename must be provided as the first command-line argument
-  when running the program with the pscal interpreter.
+  when running the program with the pascal interpreter.
 
   Example usage (assuming the program is compiled to 'playwav'):
-  pscal playwav my_sound.wav
+  pascal playwav my_sound.wav
 
   It assumes sound built-ins and command-line built-ins (ParamCount, ParamStr)
   and Delay are globally available.
@@ -27,8 +27,8 @@ begin
   if ParamCount() < 1 then
   begin
     writeln('Error: No WAV filename provided on the command line.');
-    writeln('Usage: pscal <program_name> <wave_file.wav>');
-    writeln('Example: pscal playwav ding.wav');
+    writeln('Usage: pascal <program_name> <wave_file.wav>');
+    writeln('Example: pascal playwav ding.wav');
     Halt(1); // Halt the program with an error code
   end;
 

--- a/Examples/Pascal/quad
+++ b/Examples/Pascal/quad
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 program Quadratic;
 // From http://progopedia.com/implementation/turbo-pascal/
 

--- a/Examples/Pascal/rand_check
+++ b/Examples/Pascal/rand_check
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 program TestRandomDistribution;
 
 uses

--- a/Examples/Pascal/rps
+++ b/Examples/Pascal/rps
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 program RockPaperScissors;
 
 uses CRT;

--- a/Examples/Pascal/serp
+++ b/Examples/Pascal/serp
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 program SierpinskiTriangle;
 
 uses CRT; // Assuming your CRT unit provides GotoXY, ClrScr, Write, ReadKey

--- a/Examples/Pascal/snake3
+++ b/Examples/Pascal/snake3
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 program SnakeGame;
 
 uses CRT;

--- a/Examples/Pascal/weather
+++ b/Examples/Pascal/weather
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 program DisplayWeather;
 
 uses CRT, SysUtils; // Assuming CRT for file ops, SysUtils for ParamStr etc.

--- a/Misc/tall
+++ b/Misc/tall
@@ -1,11 +1,11 @@
 #!/bin/bash
-# Set PSCAL to use a different interpreter, e.g.,
-#   PSCAL=/path/to/pscal ./tall
+# Set PASCAL to use a different interpreter, e.g.,
+#   PASCAL=/path/to/pascal ./tall
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TESTS="${TESTS:-$ROOT/Tests/Pascal}"  # all your .p / .pas files live here
 
-PSCAL="${PSCAL:-$ROOT/build/bin/pscal}"       # plain interpreter
+PASCAL="${PASCAL:-$ROOT/build/bin/pascal}"       # plain interpreter
 
 for f in "$TESTS/TestSuite7.p" \
          "$TESTS/MathSuite01.p" \
@@ -14,8 +14,8 @@ do
   [ -r "$f" ] || echo "Missing test file: $f"
 done
 
-if [[ ! -x "$PSCAL" ]]; then
-  echo "pscal binary not found or not executable: $PSCAL" >&2
+if [[ ! -x "$PASCAL" ]]; then
+  echo "pascal binary not found or not executable: $PASCAL" >&2
   exit 1
 fi
 
@@ -28,17 +28,17 @@ run () {
 }
 
 # ---------- individual suites ----------
-run "MDArray"        "$PSCAL" "$TESTS/MultiDimArrayTest.p"
-run "TestSuite"      "$PSCAL" "$TESTS/TestSuite7.p"
-run "MathSuite"      "$PSCAL" "$TESTS/MathSuite01.p"
-run "BitwiseAndExprSuite"      "$PSCAL" "$TESTS/BitwiseAndExprSuite.p"
-run "TypeTestSuite"      "$PSCAL" "$TESTS/TypeTestSuite.p"
-run "FormattingTestSuite"      "$PSCAL" "$TESTS/FormattingTestSuite.p"
-run "TestFileOperations"      "$PSCAL" "$TESTS/TestFileOperations.p"
-run "PointerTortureTest"      "$PSCAL" "$TESTS/PointerTortureTest.p"
+run "MDArray"        "$PASCAL" "$TESTS/MultiDimArrayTest.p"
+run "TestSuite"      "$PASCAL" "$TESTS/TestSuite7.p"
+run "MathSuite"      "$PASCAL" "$TESTS/MathSuite01.p"
+run "BitwiseAndExprSuite"      "$PASCAL" "$TESTS/BitwiseAndExprSuite.p"
+run "TypeTestSuite"      "$PASCAL" "$TESTS/TypeTestSuite.p"
+run "FormattingTestSuite"      "$PASCAL" "$TESTS/FormattingTestSuite.p"
+run "TestFileOperations"      "$PASCAL" "$TESTS/TestFileOperations.p"
+run "PointerTortureTest"      "$PASCAL" "$TESTS/PointerTortureTest.p"
 
 # assorted one‑offs
-run "Assorted (tid)" "$PSCAL" "$TESTS/TestIncDecWithVerify.p"
-run "Assorted (tcs)" "$PSCAL" "$TESTS/tcs"
-run "Assorted (tb)"  "$PSCAL" "$TESTS/tb"
+run "Assorted (tid)" "$PASCAL" "$TESTS/TestIncDecWithVerify.p"
+run "Assorted (tcs)" "$PASCAL" "$TESTS/tcs"
+run "Assorted (tb)"  "$PASCAL" "$TESTS/tb"
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ cmake ..            # add -DSDL=ON to enable SDL support
 make
 ```
 
-Binaries are written to `build/bin` (e.g. `pscal` and `dscal`).
+Binaries are written to `build/bin` (e.g. `pascal` and `dascal`).
 
-The `dscal` binary has very verbose debugging enabled
+The `dascal` binary has very verbose debugging enabled
 
 To build without SDL explicitly:
 

--- a/Tests/Makefile
+++ b/Tests/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all test
 
-# pscal binary is assumed to be one directory up
-PSCAL = ../build/bin/pscal
+# pascal binary is assumed to be one directory up
+PASCAL = ../build/bin/pascal
 
 # List of test files
 TESTS := \
@@ -27,7 +27,7 @@ test:
 	@for t in $(TESTS); do \
 	echo "----------------------------------------------------"; \
 	echo "Running $$t:"; \
-	$(PSCAL) $$t; \
+        $(PASCAL) $$t; \
 	echo "----------------------------------------------------"; \
 	echo ""; \
 	done
@@ -35,7 +35,7 @@ test:
 	@for t in $(FAIL_TESTS); do \
 	echo "----------------------------------------------------"; \
 	echo "Running $$t (expected failure):"; \
-	if $(PSCAL) $$t >/tmp/pscal_output 2>&1; then \
+        if $(PASCAL) $$t >/tmp/pscal_output 2>&1; then \
 	echo "ERROR: $$t unexpectedly succeeded"; \
 	cat /tmp/pscal_output; \
 	exit 1; \
@@ -55,7 +55,7 @@ test:
 	for t in $(SDL_TESTS); do \
 	echo "----------------------------------------------------"; \
 	echo "Running $$t:"; \
-	$(PSCAL) $$t; \
+        $(PASCAL) $$t; \
 	echo "----------------------------------------------------"; \
 	echo ""; \
 	done; \

--- a/Tests/Pascal/LinkedListDemo.p
+++ b/Tests/Pascal/LinkedListDemo.p
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 program LinkedListDemo;
 
 type

--- a/Tests/Pascal/SDLFeaturesTest.p
+++ b/Tests/Pascal/SDLFeaturesTest.p
@@ -1,4 +1,4 @@
-#!/usr/bin/env pscal
+#!/usr/bin/env pascal
 PROGRAM SDLFeaturesTest;
 
 USES CRT; // For console WriteLn and ReadKey

--- a/Tests/run_tests.sh
+++ b/Tests/run_tests.sh
@@ -3,10 +3,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
-PSCAL_BIN="$ROOT_DIR/build/bin/pscal"
+PASCAL_BIN="$ROOT_DIR/build/bin/pascal"
 
-if [ ! -x "$PSCAL_BIN" ]; then
-  echo "pscal binary not found at $PSCAL_BIN" >&2
+if [ ! -x "$PASCAL_BIN" ]; then
+  echo "pascal binary not found at $PASCAL_BIN" >&2
   exit 1
 fi
 
@@ -63,7 +63,7 @@ EXIT_CODE=0
 echo "Running positive tests..."
 for t in "${POSITIVE_TESTS[@]}"; do
   echo "---- $t ----"
-  if ! (cd "$SCRIPT_DIR" && "$PSCAL_BIN" "$t"); then
+  if ! (cd "$SCRIPT_DIR" && "$PASCAL_BIN" "$t"); then
     echo "Test failed: $t" >&2
     EXIT_CODE=1
   fi
@@ -77,7 +77,7 @@ for t in "${NEGATIVE_TESTS[@]}"; do
     continue
   fi
   echo "---- $t (expected failure) ----"
-  if (cd "$SCRIPT_DIR" && "$PSCAL_BIN" "$t") >/tmp/pscal_output 2>&1; then
+  if (cd "$SCRIPT_DIR" && "$PASCAL_BIN" "$t") >/tmp/pscal_output 2>&1; then
     echo "ERROR: $t unexpectedly succeeded" >&2
     cat /tmp/pscal_output
     EXIT_CODE=1

--- a/src/main.c
+++ b/src/main.c
@@ -31,13 +31,13 @@ List *inserted_global_names = NULL;
 #define PROGRAM_VERSION "undefined.version_DEV"
 #endif
 
-const char *PSCAL_USAGE =
-    "Usage: pscal <options> <source_file> [program_parameters...]\n"
+const char *PASCAL_USAGE =
+    "Usage: pascal <options> <source_file> [program_parameters...]\n"
     "   Options:\n"
     "     -v                          Display version.\n"
     "     --dump-ast-json             Dump AST to JSON and exit.\n"
     "     --dump-bytecode             Dump compiled bytecode before execution.\n"
-    "   or: pscal (with no arguments to display version and usage)";
+    "   or: pascal (with no arguments to display version and usage)";
 
 void initSymbolSystem(void) {
 #ifdef DEBUG
@@ -181,7 +181,7 @@ int main(int argc, char *argv[]) {
 
     if (argc == 1) {
         printf("Pscal Interpreter Version: %s\n", PROGRAM_VERSION);
-        printf("%s\n", PSCAL_USAGE);
+        printf("%s\n", PASCAL_USAGE);
         return EXIT_SUCCESS;
     }
 
@@ -197,7 +197,7 @@ int main(int argc, char *argv[]) {
             dump_bytecode_flag = 1;
         } else if (argv[i][0] == '-') {
             fprintf(stderr, "Unknown option: %s\n", argv[i]);
-            fprintf(stderr, "%s\n", PSCAL_USAGE);
+            fprintf(stderr, "%s\n", PASCAL_USAGE);
             return EXIT_FAILURE;
         } else {
             // First non-option argument is the source file
@@ -224,7 +224,7 @@ int main(int argc, char *argv[]) {
 
     if (!sourceFile) {
         fprintf(stderr, "Error: No source file specified.\n");
-        fprintf(stderr, "%s\n", PSCAL_USAGE);
+        fprintf(stderr, "%s\n", PASCAL_USAGE);
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
## Summary
- rename main and debug binaries to **pascal** and **dascal**
- adjust build scripts, docs and tests for new binary names
- update examples and usage strings to match the new executable names

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `Tests/run_tests.sh` *(fails: Pascal/ApiSendReceiveTest.p, Pascal/ConstArrayTest.p, Pascal/FormattingTestSuite.p, Pascal/TestFileOperations.p)*
- `Tests/run_tiny_tests.sh`
- `Tests/run_clike_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a68b951950832ab82253cde50a18c4