### PR TITLE
Fail when Pascal lib directory missing

### DIFF
--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -13,6 +13,7 @@
 #include "builtin.h"
 #include <sys/ioctl.h> // Make sure this is included
 #include <unistd.h>    // For STDOUT_FILENO
+#include <sys/stat.h>  // For stat
 
 
 const char *varTypeToString(VarType type) {
@@ -1180,6 +1181,12 @@ char *findUnitFile(const char *unit_name) {
     const char *base_path = getenv("PSCAL_LIB_DIR");
     if (base_path == NULL || *base_path == '\0') {
         base_path = "/usr/local/pscal/Pascal/lib/pascal";   // Default relative library path
+    }
+
+    struct stat dir_info;
+    if (stat(base_path, &dir_info) != 0 || !S_ISDIR(dir_info.st_mode)) {
+        fprintf(stderr, "Error: Pascal library directory not found. Searched path: %s\n", base_path);
+        EXIT_FAILURE_HANDLER();
     }
 
     // Allocate enough space: path + '/' + unit name + ".pl" + null terminator


### PR DESCRIPTION
## Summary
- abort the Pascal front end if the standard library directory can't be located, showing the attempted path

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `Tests/run_tests.sh` *(fails: Test failed: Pascal/ApiSendReceiveTest.p)*

------
https://chatgpt.com/codex/tasks/task_e_68a69d77e998832a903bade2642ee4e1