### PR TITLE
Add FileExists extended builtin

### DIFF
--- a/Tests/Pascal/ExtendedBuiltinsTest.p
+++ b/Tests/Pascal/ExtendedBuiltinsTest.p
@@ -22,6 +22,17 @@ begin
     halt(1);
   end;
 
+  if not FileExists('Pascal/ExtendedBuiltinsTest.p') then
+  begin
+    writeln('FileExists failed to detect existing file');
+    halt(1);
+  end;
+  if FileExists('Pascal/nonexistent.file') then
+  begin
+    writeln('FileExists falsely reported missing file');
+    halt(1);
+  end;
+
   writeln('Extended builtins test passed: pid=', pid, ' a=', a^, ' b=', b^);
   Dispose(a); Dispose(b);
 end.

--- a/src/ext_builtins/fileexists.c
+++ b/src/ext_builtins/fileexists.c
@@ -1,0 +1,31 @@
+#include <stdio.h>
+#include "core/utils.h"
+#include "backend_ast/builtin.h"
+
+static Value vmBuiltinFileExists(struct VM_s* vm, int arg_count, Value* args) {
+    if (arg_count != 1) {
+        runtimeError(vm, "FileExists expects exactly 1 argument.");
+        return makeBoolean(0);
+    }
+    if (args[0].type != TYPE_STRING) {
+        runtimeError(vm, "FileExists argument must be a string.");
+        return makeBoolean(0);
+    }
+    const char* path = args[0].s_val;
+    if (!path) {
+        runtimeError(vm, "FileExists received NIL string.");
+        return makeBoolean(0);
+    }
+    FILE* f = fopen(path, "r");
+    if (f) {
+        fclose(f);
+        return makeBoolean(1);
+    }
+    return makeBoolean(0);
+}
+
+void registerFileExistsBuiltin(void) {
+    registerBuiltinFunction("FileExists", AST_FUNCTION_DECL, NULL);
+    registerVmBuiltin("fileexists", vmBuiltinFileExists);
+}
+

--- a/src/ext_builtins/register.c
+++ b/src/ext_builtins/register.c
@@ -4,10 +4,12 @@ void registerGetPidBuiltin(void);
 void registerSwapBuiltin(void);
 void registerFactorialBuiltin(void);
 void registerFibonacciBuiltin(void);
+void registerFileExistsBuiltin(void);
 
 void registerExtendedBuiltins(void) {
     registerGetPidBuiltin();
     registerSwapBuiltin();
     registerFactorialBuiltin();
     registerFibonacciBuiltin();
+    registerFileExistsBuiltin();
 }


### PR DESCRIPTION
## Summary
- add FileExists builtin to check for file presence
- register FileExists builtin and test for both existing and missing files

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `PSCAL_LIB_DIR=../lib/pascal ../build/bin/pascal Pascal/ExtendedBuiltinsTest.p`
- `./Tests/run_pascal_tests.sh` (fails: Pascal library directory not found)


------
https://chatgpt.com/codex/tasks/task_e_68a76e8031ec832aaf4bca55738449ba