### PR TITLE
Fix identifier line numbers and stabilize API test

### DIFF
--- a/Tests/Pascal/ApiSendReceiveTest.data
+++ b/Tests/Pascal/ApiSendReceiveTest.data
@@ -1,0 +1,1 @@
+Example Domain

--- a/Tests/Pascal/ApiSendReceiveTest.err
+++ b/Tests/Pascal/ApiSendReceiveTest.err
@@ -1,2 +1,0 @@
-api_send: curl_easy_perform() failed: HTTP response code said error
-[Error Location] Offset: 32, Line: 32

--- a/Tests/Pascal/ApiSendReceiveTest.out
+++ b/Tests/Pascal/ApiSendReceiveTest.out
@@ -1,1 +1,1 @@
-Unexpected API response
+API send/receive test passed

--- a/Tests/Pascal/ApiSendReceiveTest.p
+++ b/Tests/Pascal/ApiSendReceiveTest.p
@@ -4,8 +4,10 @@ var
   ms: mstream;
   response: string;
   url: string;
+  cwd: string;
 begin
-  url := 'http://example.com/';
+  cwd := getenv('PWD');
+  url := 'file://' + cwd + '/Pascal/ApiSendReceiveTest.data';
   ms := api_send(url, '');
   response := api_receive(ms);
   if pos('Example Domain', response) = 0 then

--- a/Tests/Pascal/ArgumentOrderMismatch.err
+++ b/Tests/Pascal/ArgumentOrderMismatch.err
@@ -1,2 +1,2 @@
-L32: Compiler Error: argument 1 to 'mix' expects type INTEGER but got REAL.
+L13: Compiler Error: argument 1 to 'mix' expects type INTEGER but got REAL.
 Compilation failed with errors.

--- a/Tests/Pascal/ArgumentTypeMismatch.err
+++ b/Tests/Pascal/ArgumentTypeMismatch.err
@@ -1,2 +1,2 @@
-L32: Compiler Error: argument 2 to 'foo' expects type REAL but got INTEGER.
+L11: Compiler Error: argument 2 to 'foo' expects type REAL but got INTEGER.
 Compilation failed with errors.

--- a/Tests/Pascal/ArrayArgumentMismatch.err
+++ b/Tests/Pascal/ArrayArgumentMismatch.err
@@ -1,2 +1,2 @@
-L32: Compiler Error: argument 1 to 'proc' expects an array but got INTEGER.
+L12: Compiler Error: argument 1 to 'proc' expects an array but got INTEGER.
 Compilation failed with errors.

--- a/Tests/Pascal/OpenArrayBaseTypeMismatch.err
+++ b/Tests/Pascal/OpenArrayBaseTypeMismatch.err
@@ -1,2 +1,2 @@
-L5: Compiler Error: argument 1 to 'proc' expects type ARRAY but got ARRAY.
+L10: Compiler Error: argument 1 to 'proc' expects type ARRAY but got ARRAY.
 Compilation failed with errors.

--- a/src/Pascal/lexer.c
+++ b/src/Pascal/lexer.c
@@ -205,7 +205,9 @@ void advance(Lexer *lexer) {
 
 Token *identifier(Lexer *lexer) {
     size_t start = lexer->pos;
-    
+    int token_line = lexer->line;
+    int token_column = lexer->column;
+
     while (lexer->current_char && (isalnum((unsigned char)lexer->current_char) || lexer->current_char == '_'))
         advance(lexer);
     size_t len = lexer->pos - start;
@@ -228,6 +230,8 @@ Token *identifier(Lexer *lexer) {
 
     Token *token = malloc(sizeof(Token));
     token->type = TOKEN_IDENTIFIER; // Default to IDENTIFIER
+    token->line = token_line;
+    token->column = token_column;
     for (int i = 0; i < (int)NUM_KEYWORDS; i++) {
         // ADD DEBUG PRINT 3: See the comparison being made
         // DEBUG_PRINT("identifier: Comparing \"_%s_\" with keyword \"_%s_\"\n", id_str, keywords[i].keyword);


### PR DESCRIPTION
## Summary
- propagate lexer line and column info for identifiers so diagnostics reference correct source lines
- rewrite `ApiSendReceiveTest` to fetch local test data via `getenv('PWD')` and expect success deterministically
- update Pascal test expectations for argument mismatch line numbers

## Testing
- `Tests/run_pascal_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a7759680f4832a96642c46dfeefb29