### PR TITLE
Improve open array type mismatch diagnostics

### DIFF
--- a/Tests/Pascal/OpenArrayBaseTypeMismatch.err
+++ b/Tests/Pascal/OpenArrayBaseTypeMismatch.err
@@ -1,2 +1,2 @@
-L10: Compiler Error: argument 1 to 'proc' expects type ARRAY but got ARRAY.
+L10: Compiler Error: argument 1 to 'proc' expects type ARRAY OF INTEGER but got ARRAY OF REAL.
 Compilation failed with errors.

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -2041,6 +2041,16 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
                                             "L%d: Compiler Error: argument %d to '%s' expects %s but got an array.\n",
                                             line, i + 1, calleeName,
                                             varTypeToString(param_actual->var_type));
+                                } else if (param_actual->var_type == TYPE_ARRAY && arg_actual->var_type == TYPE_ARRAY) {
+                                    AST* param_elem = resolveTypeAlias(param_actual->right);
+                                    AST* arg_elem   = resolveTypeAlias(arg_actual->right);
+                                    const char* exp_str = param_elem ? varTypeToString(param_elem->var_type) : "UNKNOWN";
+                                    const char* got_str = arg_elem ? varTypeToString(arg_elem->var_type) : "UNKNOWN";
+                                    fprintf(stderr,
+                                            "L%d: Compiler Error: argument %d to '%s' expects type ARRAY OF %s but got ARRAY OF %s.\n",
+                                            line, i + 1, calleeName,
+                                            exp_str,
+                                            got_str);
                                 } else {
                                     fprintf(stderr,
                                             "L%d: Compiler Error: argument %d to '%s' expects type %s but got %s.\n",


### PR DESCRIPTION
## Summary
- enhance error reporting for mismatched open array parameter types
- update expected test output for OpenArrayBaseTypeMismatch

## Testing
- `cd build && cmake -DSDL=OFF .. && make`
- `cd Tests && ./run_all_tests`
- `../build/bin/pascal Pascal/OpenArrayBaseTypeMismatch.p`


------
https://chatgpt.com/codex/tasks/task_e_68a77d682e34832a9fec12a73a7c5908