### PR TITLE
Restore open array type mismatch test

### DIFF
--- a/Tests/Pascal/OpenArrayBaseTypeMismatch.p
+++ b/Tests/Pascal/OpenArrayBaseTypeMismatch.p
@@ -7,5 +7,5 @@ end;
 var
   arr: array[1..5] of real;
 begin
-  Proc(arr);
+  Proc(arr); { wrong base type }
 end.


### PR DESCRIPTION
## Summary
- Revert OpenArrayBaseTypeMismatch to negative test with mismatched real array
- Clarify expected failure with inline comment and restore .err file

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `build/bin/pascal Tests/Pascal/OpenArrayBaseTypeMismatch.p` (fails as expected)


------
https://chatgpt.com/codex/tasks/task_e_68a7805bc868832ab9b98d094184caa3