### PR TITLE
Allow multiple variable declarations in CLike frontend

### DIFF
--- a/src/clike/codegen.c
+++ b/src/clike/codegen.c
@@ -299,6 +299,16 @@ static void compileStatement(ASTNodeClike *node, BytecodeChunk *chunk, FuncConte
                              node->left->element_type);
                     free(name);
                     compileStatement(node->left, chunk, ctx);
+                } else if (node->left->type == TCAST_COMPOUND) {
+                    for (int i = 0; i < node->left->child_count; ++i) {
+                        ASTNodeClike *child = node->left->children[i];
+                        char* name = tokenToCString(child->token);
+                        addLocal(ctx, name, child->var_type, child->is_array,
+                                 child->dim_count, child->array_dims,
+                                 child->element_type);
+                        free(name);
+                        compileStatement(child, chunk, ctx);
+                    }
                 } else {
                     compileExpression(node->left, chunk, ctx);
                     writeBytecodeChunk(chunk, OP_POP, node->token.line);

--- a/src/clike/semantics.c
+++ b/src/clike/semantics.c
@@ -267,6 +267,10 @@ static void analyzeStmt(ASTNodeClike *node, ScopeStack *scopes, VarType retType)
             if (node->left) {
                 if (node->left->type == TCAST_VAR_DECL) {
                     analyzeStmt(node->left, scopes, retType);
+                } else if (node->left->type == TCAST_COMPOUND) {
+                    for (int i = 0; i < node->left->child_count; ++i) {
+                        analyzeStmt(node->left->children[i], scopes, retType);
+                    }
                 } else {
                     analyzeExpr(node->left, scopes);
                 }


### PR DESCRIPTION
## Summary
- support comma-separated variable declarations for builtin and struct types
- handle multi-variable initialization in `for` loop headers
- update semantic analysis and code generation for compound declarations

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `Tests/run_all_tests`


------
https://chatgpt.com/codex/tasks/task_e_68a7b4a50a68832aa6989efcf11c0b4d