### PR TITLE
Handle EOF in hangman loader

### DIFF
--- a/Examples/Clike/hangman6.cl
+++ b/Examples/Clike/hangman6.cl
@@ -53,6 +53,8 @@ struct WordNode* load_words(int* word_count, int min_length, int max_length, int
     reset(f);
     while (!eof(f) && *word_count < word_limit) {
         readln(f, line);
+        // Finalise the read and stop if we hit EOF or encountered an error.
+        if (ioresult() != 0 || eof(f)) break;
         len = strlen(line);
         if (len >= min_length && len <= max_length) {
             valid = 1;


### PR DESCRIPTION
## Summary
- guard against EOF in hangman word loader so it stops on failed reads

## Testing
- `build/bin/clike Examples/Clike/hangman6.cl` *(fails: Operands not comparable for operator '>=')*


------
https://chatgpt.com/codex/tasks/task_e_68a7d24a262c832a91292df51eb52ede