### PR TITLE
Fix char literal emission in clike codegen

### DIFF
--- a/src/clike/codegen.c
+++ b/src/clike/codegen.c
@@ -532,6 +532,11 @@ static void compileExpression(ASTNodeClike *node, BytecodeChunk *chunk, FuncCont
             Value v;
             if (node->token.type == CLIKE_TOKEN_FLOAT_LITERAL) {
                 v = makeReal(node->token.float_val);
+            } else if (node->token.type == CLIKE_TOKEN_CHAR_LITERAL ||
+                       node->var_type == TYPE_CHAR) {
+                // Treat character literals distinctly from integers so
+                // they are emitted as CHAR constants in the bytecode.
+                v = makeChar((char)node->token.int_val);
             } else {
                 v = makeInt(node->token.int_val);
             }


### PR DESCRIPTION
## Summary
- Emit character literals as `CHAR` values rather than integers in C-like compiler
- Prevent VM type mismatch errors when assigning char literals to strings

## Testing
- `cmake --build build --target clike`
- `Tests/run_clike_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a7e42bbee8832abf9f1676dbf76e37