### PR TITLE
Fix hangman mstream input handling

### DIFF
--- a/Examples/Clike/hangman5_mstream.cl
+++ b/Examples/Clike/hangman5_mstream.cl
@@ -189,7 +189,7 @@ int play_round(struct WordNode* words, int word_count, int max_wrong) {
         if (strlen(guessed) > 0) printf("Letters chosen so far: %s", guessed);
         GotoXY(1, 14);
         printf("Enter a letter (A-Z, or ? for hint): ");
-        if (scanf(guess) != 1) continue;
+        scanf(guess);
         if (strlen(guess) == 0) continue;
         if (guess[1] == '?') {
             show_hint(secret, so_far, &hint_used);
@@ -272,7 +272,7 @@ int main() {
         if (result) wins++; else losses++;
         printf("Score: %d wins / %d losses\n", wins, losses);
         printf("Play again? (Y/Enter=Yes, N=No): ");
-        if (scanf(input) != 1) break;
+        scanf(input);
         if (strlen(input) == 0) continue;
         if (upcase(input[1]) != 'Y') playing = 0;
     }


### PR DESCRIPTION
## Summary
- Prevent hangman5_mstream from ignoring user guesses by removing incorrect `scanf` return checks.
- Simplify play-again prompt to avoid premature exit.

## Testing
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)`
- `cd Tests && ./run_all_tests`


------
https://chatgpt.com/codex/tasks/task_e_68a7f5db7d08832ab57e5b015766384f