### PR TITLE
Support C-style escapes in Pascal strings

### DIFF
--- a/Docs/language_reference.md
+++ b/Docs/language_reference.md
@@ -37,7 +37,8 @@ variables and subroutines appear before the main `begin ... end.` block.
 - **Comments** may be written using `{ ... }`, `(* ... *)` or `//` to the
   end of the line.
 - **String literals** are enclosed in single quotes; use two single quotes
-  to represent an embedded quote: `'don''t'`.
+  to represent an embedded quote: `'don''t'`. C-style escapes such as
+  `\n`, `\t`, `\\`, `\e` and `\a` are recognised inside strings.
 - **Character literals** are strings of length one or the `#nn` escape for
   code points.
 


### PR DESCRIPTION
## Summary
- Allow backslash escape sequences (e.g. `\n`, `\t`, `\e`, `\a`, `\\`) in Pascal string literals
- Document escape sequence support in the language reference

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd Tests && ./run_all_tests`


------
https://chatgpt.com/codex/tasks/task_e_68a8a4eebe90832ab762b076a30269cc