### PR TITLE
Restore terminal state on VM start and exit

### DIFF
--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -124,4 +124,7 @@ BuiltinRoutineType getBuiltinType(const char *name);
 /* Register all built-in routines with the compiler/VM registry. */
 void registerAllBuiltins(void);
 
+/* Save and restore terminal state for the VM. */
+void vmInitTerminalState(void);
+
 #endif // BUILTIN_H

--- a/src/clike/main.c
+++ b/src/clike/main.c
@@ -13,6 +13,7 @@
 #include "core/utils.h"
 #include "symbol/symbol.h"
 #include "globals.h"
+#include "backend_ast/builtin.h"
 
 int gParamCount = 0;
 char **gParamValues = NULL;
@@ -33,6 +34,7 @@ static const char *CLIKE_USAGE =
     "     --dump-bytecode             Dump compiled bytecode before execution.\n";
 
 int main(int argc, char **argv) {
+    vmInitTerminalState();
     int dump_ast_json_flag = 0;
     int dump_bytecode_flag = 0;
     const char *path = NULL;

--- a/src/clike/repl.c
+++ b/src/clike/repl.c
@@ -12,6 +12,7 @@
 #include "core/utils.h"
 #include "symbol/symbol.h"
 #include "globals.h"
+#include "backend_ast/builtin.h"
 
 int gParamCount = 0;
 char **gParamValues = NULL;
@@ -25,6 +26,7 @@ static void initSymbolSystemClike(void) {
 }
 
 int main(void) {
+    vmInitTerminalState();
     char line[1024];
     while (1) {
         printf("clike> ");

--- a/src/main.c
+++ b/src/main.c
@@ -175,6 +175,7 @@ int runProgram(const char *source, const char *programName, int dump_ast_json_fl
 
 // Consistent main function structure for argument parsing
 int main(int argc, char *argv[]) {
+    vmInitTerminalState();
     int dump_ast_json_flag = 0;
     int dump_bytecode_flag = 0;
     const char *sourceFile = NULL;

--- a/src/vm/vm_main.c
+++ b/src/vm/vm_main.c
@@ -35,6 +35,7 @@ static void initSymbolSystem(void) {
 }
 
 int main(int argc, char* argv[]) {
+    vmInitTerminalState();
     if (argc < 2) {
         fprintf(stderr, "Usage: pscalvm <bytecode_file> [program_parameters...]\n");
         return 1;


### PR DESCRIPTION
## Summary
- Save terminal attributes at startup and restore them on exit
- Call terminal state initialization from each VM entry point

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `./run_all_tests`


------
https://chatgpt.com/codex/tasks/task_e_68a8b0953778832aae95506c1db71be8