### PR TITLE
Update Pascal tests for parser improvements

### DIFF
--- a/Tests/Pascal/BreakLoopTest.err
+++ b/Tests/Pascal/BreakLoopTest.err
@@ -1,1 +1,0 @@
-Parser error at line 120, column 4: Exp body (found token: END)

--- a/Tests/Pascal/BreakLoopTest.out
+++ b/Tests/Pascal/BreakLoopTest.out
@@ -1,0 +1,15 @@
+Testing FOR loop break...
+  1  2  3  4  5
+Breaking FOR loop at i = 5
+After FOR loop.
+
+Testing WHILE loop break...
+  1  2  3  4  5  6
+Breaking WHILE loop at i = 6
+After WHILE loop.
+
+Testing REPEAT loop break...
+  1  2  3  4  5  6  7
+Breaking REPEAT loop at i = 7
+After REPEAT loop.
+

--- a/Tests/Pascal/CommandLineParamTest.err
+++ b/Tests/Pascal/CommandLineParamTest.err
@@ -1,1 +1,0 @@
-Parser error at line 120, column 4: Exp body (found token: END)

--- a/Tests/Pascal/CommandLineParamTest.out
+++ b/Tests/Pascal/CommandLineParamTest.out
@@ -1,0 +1,6 @@
+--- Command Line Parameter Test ---
+ParamCount reported: 0
+
+No command line parameters were provided (after the program name).
+
+--- Test Complete ---

--- a/Tests/Pascal/ConstArrayTest.err
+++ b/Tests/Pascal/ConstArrayTest.err
@@ -1,1 +1,0 @@
-Parser error at line 120, column 4: Exp body (found token: END)

--- a/Tests/Pascal/ConstArrayTest.out
+++ b/Tests/Pascal/ConstArrayTest.out
@@ -1,0 +1,18 @@
+Testing Typed Array Constants:
+------------------------------
+Simple Const TestStr: Simple
+
+Testing CardValues (String Array):
+CardValues[1] = A(A)
+CardValues[10] = 10(10)
+CardValues[13] = K(K)
+Assigned CardValues[11] to s: J
+
+Testing IntSequence (Integer Array):
+IntSequence[0] = 10(10)
+IntSequence[1] = -5(-5)
+IntSequence[4] = 42(42)
+Looping through IntSequence:
+10 -5 100 0 42 
+
+Test complete.

--- a/Tests/Pascal/FormattingTestSuite.err
+++ b/Tests/Pascal/FormattingTestSuite.err
@@ -1,1 +1,0 @@
-Parser error at line 120, column 4: Exp body (found token: END)

--- a/Tests/Pascal/FormattingTestSuite.out
+++ b/Tests/Pascal/FormattingTestSuite.out
@@ -1,0 +1,31 @@
+Running pscal Formatting Test Suite
+===================================
+(Check output visually against comments in source code)
+
+--- Testing Integer Formatting (:width) ---
+Positive Integer Tests:
+Val=123< :5 >  123< :3 >123< :1 >123<
+Negative Integer Tests:
+Val=-45< :5 >  -45< :3 >-45< :1 >-45<
+Zero Integer Tests:
+Val=0< :5 >    0< :1 >0<
+
+--- Testing Real Formatting (:width, :width:decimals) ---
+Positive Real Tests:
+Val=123.4567< :10:2 >    123.46< :7:1 >  123.5< :5:0 >  123< :10 >1.234567E+02<
+Negative Real Tests:
+Val=-98.76< :8:1 >   -98.8< :5:0 >  -99< :12 >-9.876000E+01<
+Zero Real Tests:
+Val=0.0< :8:2 >    0.00< :5 >0.000000E+00<
+
+--- Testing String Formatting (:width) ---
+Short String Tests:
+Val=Hi< :5 >   Hi< :2 >Hi< :1 >H<
+Longer String Tests:
+Val=Pascal< :10 >    Pascal< :6 >Pascal< :4 >Pasc<
+
+--- Testing Other Types (Behavior May Vary) ---
+Char=X< :5 >    X<
+Bool=TRUE< :8 >    TRUE< :8 >   FALSE<
+
+Formatting Test Suite Completed.

--- a/Tests/Pascal/TestFileOperations.err
+++ b/Tests/Pascal/TestFileOperations.err
@@ -1,1 +1,0 @@
-Parser error at line 120, column 4: Exp body (found token: END)

--- a/Tests/Pascal/TestFileOperations.out
+++ b/Tests/Pascal/TestFileOperations.out
@@ -1,0 +1,16 @@
+Running pscal File I/O Test Suite...
+--- Testing Basic File Read/Write ---
+START: IOResult after successful rewrite: PASS
+START: IOResult after successful writeln: PASS
+START: IOResult after successful close: PASS
+--- Testing File Read ---
+START: IOResult after successful reset: PASS
+START: IOResult after successful readln 1: PASS
+START: File Read Test (Line 1): PASS
+START: IOResult after successful readln 2: PASS
+START: File Read Test (Line 2): PASS
+START: IOResult after successful close (read): PASS
+--- Testing IOResult on Error ---
+START: IOResult Error Test: PASS
+---
+File I/O Tests Completed.


### PR DESCRIPTION
## Summary
- provide concrete expected output for FormattingTestSuite instead of skipping
- run all Pascal tests without honoring `.skip` markers

## Testing
- `./Tests/run_pascal_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a910808f24832a8153c01613608676