### PR TITLE
Remove obsolete termbackground builtin

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -202,7 +202,6 @@ static const VmBuiltinMapping vmBuiltinDispatchTable[] = {
     {"sqrt", vmBuiltinSqrt},
     {"succ", vmBuiltinSucc},
     {"tan", vmBuiltinTan},
-    {"termbackground", vmBuiltinTermbackground},
     {"textbackground", vmBuiltinTextbackground},
     {"textbackgrounde", vmBuiltinTextbackgrounde},
     {"textcolor", vmBuiltinTextcolor},
@@ -886,19 +885,6 @@ Value vmBuiltinTextbackground(VM* vm, int arg_count, Value* args) {
     gCurrentBgIsExt = false;
     return makeVoid();
 }
-
-Value vmBuiltinTermbackground(VM* vm, int arg_count, Value* args) {
-    if (arg_count != 1 || args[0].type != TYPE_INTEGER) {
-        runtimeError(vm, "TermBackground expects 1 integer argument.");
-        return makeVoid();
-    }
-    gCurrentTextBackground = (int)(AS_INTEGER(args[0]) % 8);
-    gCurrentBgIsExt = false;
-    applyCurrentTextAttributes(stdout);
-    fflush(stdout);
-    return makeVoid();
-}
-
 Value vmBuiltinTextcolore(VM* vm, int arg_count, Value* args) {
     if (arg_count != 1 || (args[0].type != TYPE_INTEGER && args[0].type != TYPE_BYTE && args[0].type != TYPE_WORD)) { // <<< MODIFIED LINE
         runtimeError(vm, "TextColorE expects an integer-compatible argument (Integer, Word, Byte)."); // Changed error message

--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -55,7 +55,6 @@ Value vmBuiltinKeypressed(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinReadkey(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinTextcolor(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinTextbackground(struct VM_s* vm, int arg_count, Value* args);
-Value vmBuiltinTermbackground(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinTextcolore(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinTextbackgrounde(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinBoldtext(struct VM_s* vm, int arg_count, Value* args);


### PR DESCRIPTION
## Summary
- delete mistaken `vmBuiltinTermbackground` declaration and definition
- drop `termbackground` entry from builtin dispatch table

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `./run_all_tests` *(fails: Test exited with 1: TermBackgroundTest; Test failed (stdout mismatch): BreakContinue; ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a91d9145a8832ab1c5df8fd4f76175