### PR TITLE
Handle char guesses correctly in hangman mstream example

### DIFF
--- a/Examples/clike/hangman5_mstream.cl
+++ b/Examples/clike/hangman5_mstream.cl
@@ -152,8 +152,8 @@ void show_hint(str secret, str so_far, int *hint_used) {
 }
 
 int play_round(struct WordNode* words, int word_count, int max_wrong) {
-    str secret, so_far, guessed, guess;
-    int wrong, done, ch, len, i, j, found, index;
+    str secret, so_far, guessed, guess, ch;
+    int wrong, done, len, i, j, found, index;
     struct WordNode* current;
     int hint_used;
 
@@ -200,20 +200,20 @@ int play_round(struct WordNode* words, int word_count, int max_wrong) {
         len = strlen(guessed);
         i = 1;
         while (i <= len) {
-            if (guessed[i] == ch) found = 1;
+            if (guessed[i] == ch[1]) found = 1;
             i++;
         }
         if (found) {
-            printf("You already guessed '%c'. Try again.\n", ch);
+            printf("You already guessed '%c'. Try again.\n", ch[1]);
             continue;
         }
-        guessed = guessed + chr(ch);
+        guessed = guessed + ch[1];
         found = 0;
         len = strlen(secret);
         i = 1;
         while (i <= len) {
-            if (secret[i] == ch) {
-                so_far[i] = ch;
+            if (secret[i] == ch[1]) {
+                so_far[i] = ch[1];
                 found = 1;
             }
             i++;


### PR DESCRIPTION
## Summary
- fix crash in `hangman5_mstream.cl` by treating user guesses as characters instead of integers
- append and compare guesses directly without calling `chr`

## Testing
- `cd Tests && ./run_all_tests` *(fails: pascal, clike, pscalvm binaries not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a93030b928832aaa846166c3356e0d