### PR TITLE
Pause for input on VM errors

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -658,6 +658,22 @@ void vmInitTerminalState(void) {
     vmEnableRawMode();
 }
 
+// Pause to allow the user to read error messages before the VM exits.
+void vmPauseBeforeExit(void) {
+    // Return the terminal to a sane state so input works as expected.
+    vmRestoreTerminal();
+    const char show_cursor[] = "\x1B[?25h";
+    write(STDOUT_FILENO, show_cursor, sizeof(show_cursor) - 1);
+
+    fprintf(stderr, "Press Enter to exit...");
+    fflush(stderr);
+
+    int ch;
+    while ((ch = getchar()) != '\n' && ch != EOF) {
+        // Discard until newline or EOF.
+    }
+}
+
 static void vmEnableRawMode(void) {
     vmSetupTermHandlers();
     if (vm_raw_mode)

--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -142,5 +142,6 @@ void registerAllBuiltins(void);
 
 /* Save and restore terminal state for the VM. */
 void vmInitTerminalState(void);
+void vmPauseBeforeExit(void);
 
 #endif // BUILTIN_H

--- a/src/clike/main.c
+++ b/src/clike/main.c
@@ -151,6 +151,9 @@ int main(int argc, char **argv) {
 
     VM vm; initVM(&vm);
     InterpretResult result = interpretBytecode(&vm, &chunk, globalSymbols, procedure_table);
+    if (result != INTERPRET_OK) {
+        vmPauseBeforeExit();
+    }
     freeVM(&vm);
     freeBytecodeChunk(&chunk);
     freeASTClike(prog);

--- a/src/main.c
+++ b/src/main.c
@@ -270,6 +270,8 @@ int main(int argc, char *argv[]) {
     // Call runProgram
     int result = runProgram(source_buffer, programName, dump_ast_json_flag, dump_bytecode_flag);
     free(source_buffer); // Free the source code buffer
-
+    if (result != EXIT_SUCCESS) {
+        vmPauseBeforeExit();
+    }
     return result;
 }

--- a/src/vm/vm_main.c
+++ b/src/vm/vm_main.c
@@ -58,6 +58,9 @@ int main(int argc, char* argv[]) {
     VM vm;
     initVM(&vm);
     InterpretResult result = interpretBytecode(&vm, &chunk, globalSymbols, procedure_table);
+    if (result != INTERPRET_OK) {
+        vmPauseBeforeExit();
+    }
     freeVM(&vm);
     freeBytecodeChunk(&chunk);
     if (globalSymbols) freeHashTable(globalSymbols);


### PR DESCRIPTION
## Summary
- add `vmPauseBeforeExit` to restore the terminal and wait for Enter
- invoke the pause when VM execution or front-ends report errors

## Testing
- `cmake ..`
- `make -j2`
- `cd Tests && ./run_all_tests` *(fails: ExtendedBuiltinsTest, LowHighCharTest)*

------
https://chatgpt.com/codex/tasks/task_e_68a9323ded8c832aaf93dcadc89a2078