### PR TITLE
feat: add terminal screen switch builtins

### DIFF
--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -75,6 +75,8 @@ Value vmBuiltinNormalcolors(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinBeep(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinSavecursor(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinRestorecursor(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinPushscreen(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinPopscreen(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinHighvideo(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinGetenvint(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinValreal(struct VM_s* vm, int arg_count, Value* args);


### PR DESCRIPTION
## Summary
- remove automatic alternate-screen setup during VM init
- add PushScreen/PopScreen builtins with nested screen support
- save and restore text/background colors for each screen

## Testing
- `cmake ..`
- `make -j4`
- `cd Tests && ./run_all_tests` *(fails: stdout mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d15b4588832a8927c19e97fb1d0b