### PR TITLE
Allow char-to-string assignment in clike

### DIFF
--- a/Examples/clike/hangman5_mstream.cl
+++ b/Examples/clike/hangman5_mstream.cl
@@ -152,7 +152,8 @@ void show_hint(str secret, str so_far, int *hint_used) {
 }
 
 int play_round(struct WordNode* words, int word_count, int max_wrong) {
-    str secret, so_far, guessed, guess, ch;
+    str secret, so_far, guessed, guess;
+    char ch;
     int wrong, done, len, i, j, found, index;
     struct WordNode* current;
     int hint_used;
@@ -200,20 +201,20 @@ int play_round(struct WordNode* words, int word_count, int max_wrong) {
         len = strlen(guessed);
         i = 1;
         while (i <= len) {
-            if (guessed[i] == ch[1]) found = 1;
+            if (guessed[i] == ch) found = 1;
             i++;
         }
         if (found) {
-            printf("You already guessed '%c'. Try again.\n", ch[1]);
+            printf("You already guessed '%c'. Try again.\n", ch);
             continue;
         }
-        guessed = guessed + ch[1];
+        guessed = guessed + ch;
         found = 0;
         len = strlen(secret);
         i = 1;
         while (i <= len) {
-            if (secret[i] == ch[1]) {
-                so_far[i] = ch[1];
+            if (secret[i] == ch) {
+                so_far[i] = ch;
                 found = 1;
             }
             i++;

--- a/src/clike/semantics.c
+++ b/src/clike/semantics.c
@@ -227,7 +227,9 @@ static VarType analyzeExpr(ASTNodeClike *node, ScopeStack *scopes) {
             VarType lt = analyzeExpr(node->left, scopes);
             VarType rt = analyzeExpr(node->right, scopes);
             if (lt != TYPE_UNKNOWN && rt != TYPE_UNKNOWN) {
-                if (!(lt == TYPE_REAL && rt == TYPE_INTEGER) && lt != rt) {
+                if (!((lt == TYPE_REAL && rt == TYPE_INTEGER) ||
+                      (lt == TYPE_STRING && rt == TYPE_CHAR)) &&
+                    lt != rt) {
                     fprintf(stderr,
                             "Type error: cannot assign %s to %s at line %d, column %d\n",
                             varTypeToString(rt), varTypeToString(lt),


### PR DESCRIPTION
## Summary
- permit implicit char-to-string assignment in clike semantic analyzer
- append guessed character directly to string in Hangman example

## Testing
- `build/bin/clike --dump-ast-json Examples/clike/hangman5_mstream.cl`
- `cd Tests && ./run_all_tests` *(fails: stdout mismatch MultiDimArrayTest)*

------
https://chatgpt.com/codex/tasks/task_e_68a9dcfc6d28832a83e60ade95e2d71d