### PR TITLE
VM: expose string length via index 0

### DIFF
--- a/Docs/CLike_overview.md
+++ b/Docs/CLike_overview.md
@@ -1,0 +1,52 @@
+# CLike Front End Overview
+
+The `clike` front end provides a small C-style language that targets the
+Pscal virtual machine.
+
+## Core Semantics
+
+- **Array subscripts are zero-based** – Arrays start at index 0; the first
+  element of `a` is `a[0]`.
+- **String indexing is 1-based** – Characters in a `str` start at index 1
+  (`s[1]` is the first character). Accessing `s[0]` returns the length of the
+  string as an integer.
+- **`str` values are pointers** – A `str` variable already evaluates to a
+  pointer to its character buffer.  Pass the variable directly to
+  functions; taking an additional address yields a pointer-to-pointer and
+  confuses element access.
+- **Concatenation with `+`** – The `+` operator joins strings, e.g.
+  `buffer = mstreambuffer(ms) + "\n";`.
+- **Standard string helpers** – Built-ins such as `strlen`, `copy` and
+  `upcase` operate on `str` values.
+- **Dynamic allocation** – Use `new(&node);` to allocate structures;
+  fields are accessed with the usual `->` syntax.
+
+## Example: Sorting a String
+
+```clike
+void sort_string(str s) {
+    int i, j, len;
+    char tmp;
+    len = strlen(s);
+    i = 1;
+    while (i <= len) {
+        j = i + 1;
+        while (j <= len) {
+            if (s[i] > s[j]) {
+                tmp = s[i];
+                s[i] = s[j];
+                s[j] = tmp;
+            }
+            j++;
+        }
+        i++;
+    }
+}
+
+str guessed = "ST";
+sort_string(guessed);  // pass the string value, not its address
+```
+
+For tutorials and additional details, see
+[`clike_tutorial.md`](clike_tutorial.md) and
+[`clike_repl_tutorial.md`](clike_repl_tutorial.md).

--- a/Examples/clike/hangman5_mstream.cl
+++ b/Examples/clike/hangman5_mstream.cl
@@ -49,18 +49,18 @@ void show_guesses_bar(int wrong, int max_wrong) {
     printf(" [%d/%d]\n", remaining, max_wrong);
 }
 
-void sort_string(str *s) {
+void sort_string(str s) {
     int i, j, len;
     char tmp;
-    len = strlen(*s);
+    len = strlen(s);
     i = 1;
     while (i <= len) {
         j = i + 1;
         while (j <= len) {
-            if ((*s)[i] > (*s)[j]) {
-                tmp = (*s)[i];
-                (*s)[i] = (*s)[j];
-                (*s)[j] = tmp;
+            if (s[i] > s[j]) {
+                tmp = s[i];
+                s[i] = s[j];
+                s[j] = tmp;
             }
             j++;
         }
@@ -186,7 +186,7 @@ int play_round(struct WordNode* words, int word_count, int max_wrong) {
         GotoXY(1, 8);
         show_guesses_bar(wrong, max_wrong);
         GotoXY(1, 10);
-        sort_string(&guessed);
+        sort_string(guessed);
         if (strlen(guessed) > 0) printf("Letters chosen so far: %s", guessed);
         GotoXY(1, 11);
         printf("Enter a letter (A-Z, or ? for hint): ");
@@ -239,7 +239,7 @@ int play_round(struct WordNode* words, int word_count, int max_wrong) {
     GotoXY(1, 9);
     show_guesses_bar(wrong, max_wrong);
     GotoXY(1, 11);
-    sort_string(&guessed);
+    sort_string(guessed);
     if (strlen(guessed) > 0) printf("Letters chosen: %s", guessed);
     GotoXY(1, 13);
     if (wrong >= max_wrong) {


### PR DESCRIPTION
## Summary
- Allow `OP_GET_ELEMENT_ADDRESS` on strings to treat index 0 as a request for length
- Extend `OP_GET_INDIRECT`/`SET_INDIRECT` to handle special string-length pointers and forbid writing to them
- Clarify in `CLike_overview.md` that only strings use 1-based subscripts and `s[0]` yields the string length

## Testing
- `cmake -B build`
- `cmake --build build`
- `Tests/run_clike_tests.sh` *(fails: stdout mismatches for multiple tests such as BreakContinue, Exit, ExitCode, etc.)*
- `TERM=dumb build/bin/clike /tmp/strlen_test.cl | perl -pe 's/\e\[[0-9;]*[a-zA-Z]//g'`

------
https://chatgpt.com/codex/tasks/task_e_68a9f07ee404832ab2c4044d68b613e6