### PR TITLE
Strip OSC sequences from C-like test output

### DIFF
--- a/Tests/run_clike_tests.sh
+++ b/Tests/run_clike_tests.sh
@@ -33,10 +33,10 @@ for src in "$SCRIPT_DIR"/clike/*.cl; do
   run_status=$?
   set -e
 
-  # Strip ANSI escape sequences that may be emitted by the VM
-  perl -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]//g' "$actual_out" > "$actual_out.clean"
+  # Strip ANSI escape sequences (including OSC) that may be emitted by the VM
+  perl -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]|\e\][^\a]*(?:\a|\e\\)//g' "$actual_out" > "$actual_out.clean"
   mv "$actual_out.clean" "$actual_out"
-  perl -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]//g' "$actual_err" > "$actual_err.clean"
+  perl -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]|\e\][^\a]*(?:\a|\e\\)//g' "$actual_err" > "$actual_err.clean"
   mv "$actual_err.clean" "$actual_err"
 
   # Keep only the first two lines of stderr for deterministic comparisons


### PR DESCRIPTION
## Summary
- strip both CSI and OSC escape sequences in clike test runner to avoid spurious diffs

## Testing
- `./Tests/run_clike_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a9ff921ba0832aa16d0c34c41abb94