### PR TITLE
Improve hangman word list handling

### DIFF
--- a/src/clike/semantics.c
+++ b/src/clike/semantics.c
@@ -53,6 +53,10 @@ static VarType builtinReturnType(const char* name) {
         return TYPE_CHAR;
     }
 
+    if (strcasecmp(name, "mstreamloadfromfile") == 0) {
+        return TYPE_BOOLEAN;
+    }
+
     return TYPE_VOID;
 }
 
@@ -140,7 +144,7 @@ static void registerBuiltinFunctions(void) {
     functions[functionCount].type = TYPE_MEMORYSTREAM;
     functionCount++;
     functions[functionCount].name = strdup("mstreamloadfromfile");
-    functions[functionCount].type = TYPE_VOID;
+    functions[functionCount].type = TYPE_BOOLEAN;
     functionCount++;
     functions[functionCount].name = strdup("mstreamsavetofile");
     functions[functionCount].type = TYPE_VOID;


### PR DESCRIPTION
## Summary
- Distinguish used vs. remaining guesses in hangman progress bar
- Load word list from a configurable path and validate file existence
- Guard against failed node allocations when building word list
- Expose a boolean return from `mstreamloadfromfile` and register it as a function for CLike

## Testing
- `cmake -B build`
- `make -C build -j$(nproc)`
- `./build/bin/clike Tests/clike/MStreamWords.cl`
- `./build/bin/clike Tests/clike/PointerTorture.cl`


------
https://chatgpt.com/codex/tasks/task_e_68aa04214154832aa7723ae88206231a