### PR TITLE
Fix hint handling in clike hangman example

### DIFF
--- a/Examples/clike/hangman5.cl
+++ b/Examples/clike/hangman5.cl
@@ -291,9 +291,10 @@ int play_round(struct WordNode* words, int word_count, int max_wrong) {
         printf("%s", msg);
         scanf(guess);
         if (strlen(guess) == 0) continue;
-        if (guess == '?') { 
-          show_hint(secret, so_far, &hint_used); 
-          continue; 
+        if (strlen(guess) == 1 && guess[1] == '?') {
+            show_hint(secret, so_far, &hint_used);
+            readkey();
+            continue;
         }
         ch = upcase(guess[1]);
         found = 0; len = strlen(guessed); i = 1;


### PR DESCRIPTION
## Summary
- Correct `?` input handling in `hangman5.cl` by checking the first character and pausing so the hint is visible

## Testing
- `cmake .. && make`
- `./run_all_tests` *(fails: Arithmetic test mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4b2e31f8832a95441c91ed221a85