### PR TITLE
Strip OSC sequences in tiny tests

### DIFF
--- a/Tests/run_tiny_tests.sh
+++ b/Tests/run_tiny_tests.sh
@@ -40,7 +40,7 @@ for src in "$SCRIPT_DIR"/tiny/*.tiny; do
   fi
   run_status=$?
 
-  perl -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]//g' "$actual_out" > "$actual_out.clean"
+  perl -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]//g; s/\e\].*?\a//g' "$actual_out" > "$actual_out.clean"
   mv "$actual_out.clean" "$actual_out"
 
   if [ -f "$out_file" ]; then


### PR DESCRIPTION
## Summary
- strip OSC (Operating System Command) escape sequences from VM output in tiny test harness

## Testing
- `Tests/run_tiny_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aa53128bc4832a887c6bd27107805f