### PR TITLE
Add Mandelbrot row extended builtin

### DIFF
--- a/Examples/Pascal/MandelbrotRow.p
+++ b/Examples/Pascal/MandelbrotRow.p
@@ -1,0 +1,30 @@
+program MandelbrotRowDemo;
+const
+  Width = 80;
+  Height = 24;
+  MaxIterations = 1000;
+  MinRe = -2.0;
+  MaxRe = 1.0;
+  MinIm = -1.2;
+  MaxIm = MinIm + (MaxRe - MinRe) * Height / Width;
+var
+  reFactor, imFactor, c_im: real;
+  row: array[0..Width-1] of integer;
+  x, y: integer;
+begin
+  reFactor := (MaxRe - MinRe) / (Width - 1);
+  imFactor := (MaxIm - MinIm) / (Height - 1);
+  for y := 0 to Height - 1 do
+  begin
+    c_im := MaxIm - y * imFactor;
+    MandelbrotRow(MinRe, reFactor, c_im, MaxIterations, Width - 1, row);
+    for x := 0 to Width - 1 do
+    begin
+      if row[x] < MaxIterations then
+        write('*')
+      else
+        write(' ');
+    end;
+    writeln;
+  end;
+end.

--- a/Examples/clike/mandelbrot_row
+++ b/Examples/clike/mandelbrot_row
@@ -1,0 +1,29 @@
+#!/usr/bin/env clike
+// Mandelbrot set demo using the MandelbrotRow extended builtin.
+// Renders an ASCII Mandelbrot to the console.
+
+int main() {
+    int width = 80;
+    int height = 24;
+    int maxIterations = 1000;
+    double minRe = -2.0;
+    double maxRe = 1.0;
+    double minIm = -1.2;
+    double maxIm = minIm + (maxRe - minRe) * height / width;
+    double reFactor = (maxRe - minRe) / (width - 1);
+    double imFactor = (maxIm - minIm) / (height - 1);
+    int row[80];
+    for (int y = 0; y < height; y++) {
+        double c_im = maxIm - y * imFactor;
+        mandelbrotrow(minRe, reFactor, c_im, maxIterations, width - 1, row);
+        for (int x = 0; x < width; x++) {
+            if (row[x] < maxIterations) {
+                printf("*");
+            } else {
+                printf(" ");
+            }
+        }
+        printf("\n");
+    }
+    return 0;
+}

--- a/src/ext_builtins/mandelbrot.c
+++ b/src/ext_builtins/mandelbrot.c
@@ -1,0 +1,54 @@
+#include "core/utils.h"
+#include "backend_ast/builtin.h"
+
+static Value vmBuiltinMandelbrotRow(struct VM_s* vm, int arg_count, Value* args) {
+    if (arg_count != 6) {
+        runtimeError(vm, "MandelbrotRow expects 6 arguments.");
+        return makeVoid();
+    }
+    if (args[0].type != TYPE_REAL || args[1].type != TYPE_REAL || args[2].type != TYPE_REAL ||
+        args[3].type != TYPE_INTEGER || args[4].type != TYPE_INTEGER ||
+        (args[5].type != TYPE_POINTER && args[5].type != TYPE_ARRAY)) {
+        runtimeError(vm, "MandelbrotRow argument types are (Real, Real, Real, Integer, Integer, VAR array).");
+        return makeVoid();
+    }
+
+    double minRe = args[0].r_val;
+    double reFactor = args[1].r_val;
+    double c_im = args[2].r_val;
+    int maxIterations = (int)args[3].i_val;
+    int maxX = (int)args[4].i_val;
+    Value* outArr = args[5].type == TYPE_POINTER ? (Value*)args[5].ptr_val : args[5].array_val;
+    if (!outArr) {
+        runtimeError(vm, "MandelbrotRow received a NIL pointer for output array.");
+        return makeVoid();
+    }
+
+    for (int x = 0; x <= maxX; ++x) {
+        double c_re = minRe + x * reFactor;
+        double Z_re = c_re;
+        double Z_im = c_im;
+        int n = 0;
+        while (n < maxIterations) {
+            double Z_re2 = Z_re * Z_re;
+            double Z_im2 = Z_im * Z_im;
+            if (Z_re2 + Z_im2 > 4.0) {
+                break;
+            }
+            double tmp = 2.0 * Z_re * Z_im + c_im;
+            Z_re = Z_re2 - Z_im2 + c_re;
+            Z_im = tmp;
+            n++;
+        }
+        freeValue(&outArr[x]);
+        outArr[x] = makeInt(n);
+    }
+
+    return makeVoid();
+}
+
+void registerMandelbrotRowBuiltin(void) {
+    registerBuiltinFunction("MandelbrotRow", AST_PROCEDURE_DECL, NULL);
+    registerVmBuiltin("mandelbrotrow", vmBuiltinMandelbrotRow);
+}
+

--- a/src/ext_builtins/register.c
+++ b/src/ext_builtins/register.c
@@ -5,6 +5,7 @@ void registerSwapBuiltin(void);
 void registerFactorialBuiltin(void);
 void registerFibonacciBuiltin(void);
 void registerFileExistsBuiltin(void);
+void registerMandelbrotRowBuiltin(void);
 
 void registerExtendedBuiltins(void) {
     registerGetPidBuiltin();
@@ -12,4 +13,5 @@ void registerExtendedBuiltins(void) {
     registerFactorialBuiltin();
     registerFibonacciBuiltin();
     registerFileExistsBuiltin();
+    registerMandelbrotRowBuiltin();
 }


### PR DESCRIPTION
## Summary
- add `mandelbrotrow` extended builtin computing iteration counts for a Mandelbrot row
- expose builtin to Pascal and register with VM
- avoid declaring `mandelbrotrow` in CLike builtins header
- provide Pascal and CLike examples using the new builtin
- allow builtin to accept either pointer or array output buffers

## Testing
- `cmake -B build -DSDL=OFF`
- `cmake --build build`
- `cd Tests && ./run_all_tests`


------
https://chatgpt.com/codex/tasks/task_e_68aa7244c9ec832aa29b573cae1d9df5