### PR TITLE
Use texture-based progressive rendering in SDL Mandelbrot examples

### DIFF
--- a/Examples/Pascal/mandoSDL
+++ b/Examples/Pascal/mandoSDL
@@ -11,6 +11,10 @@ CONST
   MaxIterations = 128;
   StatusUpdateInterval = 20; // Print status every 20 rows
   ScreenUpdateInterval = 1;  // Refresh SDL window every row
+  MandelBytesPerPixel = 4;
+
+TYPE
+  PixelBuffer = ARRAY[0..(WindowWidth * WindowHeight * MandelBytesPerPixel) - 1] OF Byte;
 
 VAR
   Px, Py        : Integer; // Pixel coordinates
@@ -28,6 +32,11 @@ VAR
   ReRange, ImRange : Real;
   ScaleRe, ScaleIm : Real;
   CurrentMaxX, CurrentMaxY : Integer;
+  ViewPixelWidth, ViewPixelHeight : Integer;
+
+  MandelTextureID : Integer;
+  PixelData : PixelBuffer;
+  BufferBaseIdx : Integer;
 
   PercentDone : Integer;
 
@@ -45,28 +54,38 @@ BEGIN
   // You could add a Delay(1000) here if you want users to definitely see the message
 
   InitGraph(WindowWidth, WindowHeight, WindowTitle);
+  MandelTextureID := CreateTexture(WindowWidth, WindowHeight);
+  IF MandelTextureID < 0 THEN
+  BEGIN
+    WriteLn('Error: unable to create texture.');
+    Halt;
+  END;
   ClearDevice;  UpdateScreen;  // show blank window immediately
 
   CurrentMaxX := GetMaxX;
   CurrentMaxY := GetMaxY;
+  ViewPixelWidth  := CurrentMaxX + 1;
+  ViewPixelHeight := CurrentMaxY + 1;
 
   ReRange := MaxRe - MinRe;
-  MaxIm := MinIm + (ReRange * (CurrentMaxY + 1)) / (CurrentMaxX + 1);
+  MaxIm := MinIm + (ReRange * ViewPixelHeight) / ViewPixelWidth;
   ImRange := MaxIm - MinIm;
 
-  IF CurrentMaxX > 0 THEN ScaleRe := ReRange / CurrentMaxX ELSE ScaleRe := 0;
-  IF CurrentMaxY > 0 THEN ScaleIm := ImRange / CurrentMaxY ELSE ScaleIm := 0;
+  IF ViewPixelWidth > 1 THEN ScaleRe := ReRange / (ViewPixelWidth - 1)
+  ELSE IF ViewPixelWidth = 1 THEN ScaleRe := ReRange ELSE ScaleRe := 0;
+  IF ViewPixelHeight > 1 THEN ScaleIm := ImRange / (ViewPixelHeight - 1)
+  ELSE IF ViewPixelHeight = 1 THEN ScaleIm := ImRange ELSE ScaleIm := 0;
 
   // Initialize progress tracking
   PercentDone := 0;
 
-  // Main loop through each pixel
-  FOR Py := 0 TO CurrentMaxY DO
+  // Main loop through each pixel, updating texture progressively
+  FOR Py := 0 TO ViewPixelHeight - 1 DO
   BEGIN
     y0 := MaxIm - (Py * ScaleIm);
-    x0 := MinRe;
-    FOR Px := 0 TO CurrentMaxX DO
+    FOR Px := 0 TO ViewPixelWidth - 1 DO
     BEGIN
+      x0 := MinRe + (Px * ScaleRe);
 
       x := 0.0;
       y := 0.0;
@@ -91,10 +110,11 @@ BEGIN
         B := (Iteration * 11 + 170) MOD 256;
       END;
 
-      SetRGBColor(R, G, B);
-      PutPixel(Px, Py);
-
-      x0 := x0 + ScaleRe;
+      BufferBaseIdx := (Py * ViewPixelWidth + Px) * MandelBytesPerPixel;
+      PixelData[BufferBaseIdx + 0] := R;
+      PixelData[BufferBaseIdx + 1] := G;
+      PixelData[BufferBaseIdx + 2] := B;
+      PixelData[BufferBaseIdx + 3] := 255;
     END; // END FOR Px
 
     // Status Update Logic
@@ -109,9 +129,12 @@ BEGIN
         WriteLn('Processing row ', Py + 1, ' of ', CurrentMaxY + 1, '. Approximately 100% complete...');
     END;
 
-    // Periodic screen update so the window displays while calculating
-    IF (Py + 1) MOD ScreenUpdateInterval = 0 THEN
+    // Periodic texture and screen update so the window displays while calculating
+    IF ((Py + 1) MOD ScreenUpdateInterval = 0) OR (Py = ViewPixelHeight - 1) THEN
     BEGIN
+      UpdateTexture(MandelTextureID, PixelData);
+      ClearDevice;
+      RenderCopy(MandelTextureID);
       UpdateScreen;
       GraphLoop(0);
     END;
@@ -121,11 +144,14 @@ BEGIN
   WriteLn('-----------------------------------------------------');
   WriteLn('Calculation complete! Displaying Mandelbrot set.');
 
+  UpdateTexture(MandelTextureID, PixelData);
+  ClearDevice;
+  RenderCopy(MandelTextureID);
   UpdateScreen;
 
-  // WriteLn('Mandelbrot set displayed. Press any key to exit.'); // Console message
   GraphLoop(100);
   ReadKey;
 
+  DestroyTexture(MandelTextureID);
   CloseGraph;
 END.

--- a/Examples/Pascal/mandoSDL_Linux
+++ b/Examples/Pascal/mandoSDL_Linux
@@ -9,6 +9,7 @@ CONST
   WindowTitle   = 'Mandelbrot Set Explorer (SDL)';
   MaxIterations = 150;
   ScreenUpdateInterval = 1;
+  MandelBytesPerPixel = 4;
 
   // Console layout for status messages
   InitialMsgLineCount = 5; // Number of lines used for initial messages
@@ -17,6 +18,9 @@ CONST
   DefaultMinRe  = -2.0;
   DefaultMaxRe  =  1.0;
   DefaultMinIm  = -1.2;
+
+TYPE
+  PixelBuffer = ARRAY[0..(WindowWidth * WindowHeight * MandelBytesPerPixel) - 1] OF Byte;
 
 VAR
   Px, Py        : Integer;
@@ -27,6 +31,11 @@ VAR
   MinRe, MaxRe, MinIm, MaxIm : Real;
   ReRange, ImRange, ScaleRe, ScaleIm : Real;
   CurrentMaxX, CurrentMaxY : Integer;
+  ViewPixelWidth, ViewPixelHeight : Integer;
+
+  MandelTextureID : Integer;
+  PixelData : PixelBuffer;
+  BufferBaseIdx : Integer;
 
   PercentDone   : Integer;
   StatusLineY   : Integer; // <<<< MOVED TO VAR SECTION
@@ -56,35 +65,43 @@ BEGIN
 
   // --- Initialize SDL Graphics ---
   InitGraph(WindowWidth, WindowHeight, WindowTitle);
+  MandelTextureID := CreateTexture(WindowWidth, WindowHeight);
+  IF MandelTextureID < 0 THEN
+  BEGIN
+    GotoXY(1, StatusLineY); ClrEol;
+    WriteLn('Error: unable to create texture.');
+    Halt;
+  END;
   ClearDevice;  // SDL clear
   UpdateScreen; // Show the cleared SDL screen immediately
 
   CurrentMaxX := GetMaxX;
   CurrentMaxY := GetMaxY;
+  ViewPixelWidth  := CurrentMaxX + 1;
+  ViewPixelHeight := CurrentMaxY + 1;
 
   // --- Calculate Full Viewport & Scaling ---
   ReRange := MaxRe - MinRe;
-  IF (CurrentMaxX + 1) > 0 THEN
-      MaxIm := MinIm + (ReRange * (CurrentMaxY + 1)) / (CurrentMaxX + 1)
-  ELSE
-      MaxIm := MinIm;
+  MaxIm := MinIm + (ReRange * ViewPixelHeight) / ViewPixelWidth;
   ImRange := MaxIm - MinIm;
 
   // --- Update Console with Precise MaxIm ---
   GotoXY(1, 2); ClrEol; // Clear the old "approx" line in the console
   Write('View Region: Re[', MinRe:0:1, '..', MaxRe:0:1, '], Im[', MinIm:0:1, '..', MaxIm:0:1, ']');
 
-  IF CurrentMaxX > 0 THEN ScaleRe := ReRange / CurrentMaxX ELSE ScaleRe := 0;
-  IF CurrentMaxY > 0 THEN ScaleIm := ImRange / CurrentMaxY ELSE ScaleIm := 0;
+  IF ViewPixelWidth > 1 THEN ScaleRe := ReRange / (ViewPixelWidth - 1)
+  ELSE IF ViewPixelWidth = 1 THEN ScaleRe := ReRange ELSE ScaleRe := 0;
+  IF ViewPixelHeight > 1 THEN ScaleIm := ImRange / (ViewPixelHeight - 1)
+  ELSE IF ViewPixelHeight = 1 THEN ScaleIm := ImRange ELSE ScaleIm := 0;
 
   GotoXY(1, StatusLineY); // Position for the first progress message
   Write('Rendering... Please wait.'); // Initial message on the status line
   ClrEol; // Clear rest of this line
 
   // --- Main Rendering Loop ---
-  FOR Py := 0 TO CurrentMaxY DO
+  FOR Py := 0 TO ViewPixelHeight - 1 DO
   BEGIN
-    FOR Px := 0 TO CurrentMaxX DO
+    FOR Px := 0 TO ViewPixelWidth - 1 DO
     BEGIN
       x0 := MinRe + (Px * ScaleRe);
       y0 := MaxIm - (Py * ScaleIm);
@@ -107,13 +124,19 @@ BEGIN
         B := (Iteration * 5 + 160) MOD 256;
       END;
 
-      SetRGBColor(R, G, B);
-      PutPixel(Px, Py);
+      BufferBaseIdx := (Py * ViewPixelWidth + Px) * MandelBytesPerPixel;
+      PixelData[BufferBaseIdx + 0] := R;
+      PixelData[BufferBaseIdx + 1] := G;
+      PixelData[BufferBaseIdx + 2] := B;
+      PixelData[BufferBaseIdx + 3] := 255;
     END; // END FOR Px
 
-    // --- Periodic SDL Event Processing and Screen Update ---
-    IF (Py + 1) MOD ScreenUpdateInterval = 0 THEN
+    // --- Periodic SDL Event Processing and Texture Update ---
+    IF ((Py + 1) MOD ScreenUpdateInterval = 0) OR (Py = ViewPixelHeight - 1) THEN
     BEGIN
+      UpdateTexture(MandelTextureID, PixelData);
+      ClearDevice;
+      RenderCopy(MandelTextureID);
       UpdateScreen;
       GraphLoop(0);
     END;
@@ -128,7 +151,8 @@ BEGIN
   END; // END FOR Py
 
   // --- Finalize ---
-  UpdateScreen; // Final SDL screen update
+  UpdateTexture(MandelTextureID, PixelData);
+  ClearDevice; RenderCopy(MandelTextureID); UpdateScreen;
 
   GotoXY(1, StatusLineY); ClrEol; // Clear the last progress message
   Write('Calculation complete! Displaying Mandelbrot set.');
@@ -141,6 +165,7 @@ BEGIN
   GraphLoop(100);
   ReadKey;
 
+  DestroyTexture(MandelTextureID);
   CloseGraph;
 
   // --- Restore Console ---

--- a/Examples/clike/sdl_mandelbrot
+++ b/Examples/clike/sdl_mandelbrot
@@ -30,6 +30,10 @@ int main() {
     int B;
     int quit;
     int ScreenUpdateInterval;
+    int MandelBytesPerPixel;
+    int textureID;
+    int bufferBaseIdx;
+    int pixelData[1024 * 768 * 4];
 
     WindowWidth = 1024;
     WindowHeight = 768;
@@ -39,9 +43,15 @@ int main() {
     MinIm = -1.2;
 
     ScreenUpdateInterval = 1;
+    MandelBytesPerPixel = 4;
 
     printf("Calculating Mandelbrot set. The window will update as rows are drawn...\n");
     initgraph(WindowWidth, WindowHeight, "Mandelbrot in CLike");
+    textureID = createtexture(WindowWidth, WindowHeight);
+    if (textureID < 0) {
+        printf("Error: unable to create texture.\n");
+        halt();
+    }
     cleardevice();
     updatescreen();
     MaxX = getmaxx();
@@ -71,23 +81,34 @@ int main() {
                 n = n + 1;
             }
             if (n == MaxIterations) {
-                setrgbcolor(0, 0, 0);
+                R = 0;
+                G = 0;
+                B = 0;
             } else {
                 R = (n * 5) % 256;
                 G = (n * 7 + 85) % 256;
                 B = (n * 11 + 170) % 256;
-                setrgbcolor(R, G, B);
             }
-            putpixel(x, y);
+            bufferBaseIdx = (y * (MaxX + 1) + x) * MandelBytesPerPixel;
+            pixelData[bufferBaseIdx + 0] = R;
+            pixelData[bufferBaseIdx + 1] = G;
+            pixelData[bufferBaseIdx + 2] = B;
+            pixelData[bufferBaseIdx + 3] = 255;
             x = x + 1;
         }
-        if ((y + 1) % ScreenUpdateInterval == 0) {
+        if (((y + 1) % ScreenUpdateInterval) == 0 || y == MaxY) {
+            updatetexture(textureID, pixelData);
+            cleardevice();
+            rendercopy(textureID);
             updatescreen();
             graphloop(0);
         }
         y = y + 1;
     }
 
+    updatetexture(textureID, pixelData);
+    cleardevice();
+    rendercopy(textureID);
     updatescreen();
     printf("Mandelbrot rendered. Press Q in the console to quit.\n");
     quit = 0;
@@ -101,6 +122,7 @@ int main() {
         }
         graphloop(16);
     }
+    destroytexture(textureID);
     closegraph();
     return 0;
 }


### PR DESCRIPTION
## Summary
- Switch Pascal SDL Mandelbrot examples to render into a pixel buffer and update an SDL texture progressively
- Apply the same texture-based rendering approach to the CLike SDL Mandelbrot example

## Testing
- `cd Tests && ./run_all_tests` *(fails: pascal/clike binaries not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa71a87868832a934ebd5b3e7afcf8