### PR TITLE
Use texture-based rendering for Mandelbrot row example

### DIFF
--- a/Examples/clike/sdl_mandelbrot_row
+++ b/Examples/clike/sdl_mandelbrot_row
@@ -16,9 +16,19 @@ int main() {
     double imFactor = (maxIm - minIm) / (height - 1);
 
     int row[1024];
+    int pixelData[1024 * 768 * 4];
+    int bytesPerPixel = 4;
+    int textureID;
+    int screenUpdateInterval = 1;
+    int bufferBaseIdx;
 
     printf("Calculating Mandelbrot set. The window will update as rows are drawn...\n");
     initgraph(width, height, "Mandelbrot in CLike (builtin)");
+    textureID = createtexture(width, height);
+    if (textureID < 0) {
+        printf("Error: unable to create texture.\n");
+        halt();
+    }
     cleardevice();
     updatescreen();
 
@@ -27,22 +37,36 @@ int main() {
         mandelbrotrow(minRe, reFactor, c_im, maxIterations, width - 1, &row);
         for (int x = 0; x < width; x++) {
             int n = row[x];
+            int R;
+            int G;
+            int B;
             if (n == maxIterations) {
-                setrgbcolor(0, 0, 0);
+                R = 0;
+                G = 0;
+                B = 0;
             } else {
-                int R = (n * 5) % 256;
-                int G = (n * 7 + 85) % 256;
-                int B = (n * 11 + 170) % 256;
-                setrgbcolor(R, G, B);
+                R = (n * 5) % 256;
+                G = (n * 7 + 85) % 256;
+                B = (n * 11 + 170) % 256;
             }
-            putpixel(x, y);
+            bufferBaseIdx = (y * width + x) * bytesPerPixel;
+            pixelData[bufferBaseIdx + 0] = R;
+            pixelData[bufferBaseIdx + 1] = G;
+            pixelData[bufferBaseIdx + 2] = B;
+            pixelData[bufferBaseIdx + 3] = 255;
         }
-        if ((y & 7) == 0) {
+        if (((y + 1) % screenUpdateInterval) == 0 || y == height - 1) {
+            updatetexture(textureID, pixelData);
+            cleardevice();
+            rendercopy(textureID);
             updatescreen();
             graphloop(0);
         }
     }
 
+    updatetexture(textureID, pixelData);
+    cleardevice();
+    rendercopy(textureID);
     updatescreen();
     printf("Mandelbrot rendered. Press Q in the console to quit.\n");
     int quit = 0;
@@ -55,6 +79,7 @@ int main() {
         }
         graphloop(16);
     }
+    destroytexture(textureID);
     closegraph();
     return 0;
 }


### PR DESCRIPTION
## Summary
- Render Mandelbrot rows through an SDL texture instead of per-pixel draws
- Update texture as rows are computed and copy it to the screen

## Testing
- `Tests/run_clike_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68aa7c36051c832aae9a6603669962cc