### PR TITLE
Fix AST parent links in var initializer optimization

### DIFF
--- a/src/clike/parser.c
+++ b/src/clike/parser.c
@@ -447,7 +447,7 @@ static ASTNodeClike* varDeclarationNoSemi(ParserClike *p, ClikeToken type_token,
     }
 
     if (node->left) {
-        node->left = optimizeClikeAST(node->left);
+        setLeftClike(node, optimizeClikeAST(node->left));
         int ok;
         long long val = evalConstExpr(node->left, &ok);
         if (ok) {


### PR DESCRIPTION
## Summary
- ensure optimized initializer nodes keep correct parent pointers to pass AST verification

## Testing
- `bin/clike Examples/clike/sdl_mandelbrot_row`
- `cd Tests && ./run_all_tests`


------
https://chatgpt.com/codex/tasks/task_e_68aa8151d800832a96b4a92dd9bb1f27