### PR TITLE
Handle SDL builtins returning values in C-like semantics

### DIFF
--- a/src/clike/semantics.c
+++ b/src/clike/semantics.c
@@ -57,6 +57,20 @@ static VarType builtinReturnType(const char* name) {
         return TYPE_BOOLEAN;
     }
 
+    if (strcasecmp(name, "createtexture") == 0 ||
+        strcasecmp(name, "createtargettexture") == 0 ||
+        strcasecmp(name, "loadimagetotexture") == 0 ||
+        strcasecmp(name, "loadsound") == 0 ||
+        strcasecmp(name, "getticks") == 0 ||
+        strcasecmp(name, "pollkey") == 0) {
+        return TYPE_INTEGER;
+    }
+
+    if (strcasecmp(name, "keypressed") == 0 ||
+        strcasecmp(name, "issoundplaying") == 0) {
+        return TYPE_BOOLEAN;
+    }
+
     return TYPE_VOID;
 }
 


### PR DESCRIPTION
## Summary
- ensure SDL-related builtins like `createtexture` and `keypressed` return the correct types in C-like semantic analysis
- support integer-returning SDL helpers such as `createtargettexture`, `loadimagetotexture`, `loadsound`, `getticks`, and `pollkey`
- treat boolean SDL helpers like `issoundplaying` properly

## Testing
- `Tests/run_clike_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aa847df450832a816fc260fd9cfca8