### PR TITLE
Fix pixel buffer type in SDL Mandelbrot examples

### DIFF
--- a/Examples/clike/sdl_mandelbrot
+++ b/Examples/clike/sdl_mandelbrot
@@ -33,7 +33,7 @@ int main() {
     int MandelBytesPerPixel;
     int textureID;
     int bufferBaseIdx;
-    int pixelData[1024 * 768 * 4];
+    char pixelData[1024 * 768 * 4];
 
     WindowWidth = 1024;
     WindowHeight = 768;
@@ -90,10 +90,10 @@ int main() {
                 B = (n * 11 + 170) % 256;
             }
             bufferBaseIdx = (y * (MaxX + 1) + x) * MandelBytesPerPixel;
-            pixelData[bufferBaseIdx + 0] = R;
-            pixelData[bufferBaseIdx + 1] = G;
-            pixelData[bufferBaseIdx + 2] = B;
-            pixelData[bufferBaseIdx + 3] = 255;
+            pixelData[bufferBaseIdx + 0] = chr(R);
+            pixelData[bufferBaseIdx + 1] = chr(G);
+            pixelData[bufferBaseIdx + 2] = chr(B);
+            pixelData[bufferBaseIdx + 3] = chr(255);
             x = x + 1;
         }
         if (((y + 1) % ScreenUpdateInterval) == 0 || y == MaxY) {

--- a/Examples/clike/sdl_mandelbrot_row
+++ b/Examples/clike/sdl_mandelbrot_row
@@ -17,7 +17,7 @@ int main() {
 
     int bytesPerPixel = 4;
     int row[width];
-    int pixelData[width * height * bytesPerPixel];
+    char pixelData[width * height * bytesPerPixel];
     int textureID;
     int screenUpdateInterval = 1;
     int bufferBaseIdx;
@@ -50,10 +50,10 @@ int main() {
                 B = (n * 11 + 170) % 256;
             }
             bufferBaseIdx = (y * width + x) * bytesPerPixel;
-            pixelData[bufferBaseIdx + 0] = R;
-            pixelData[bufferBaseIdx + 1] = G;
-            pixelData[bufferBaseIdx + 2] = B;
-            pixelData[bufferBaseIdx + 3] = 255;
+            pixelData[bufferBaseIdx + 0] = chr(R);
+            pixelData[bufferBaseIdx + 1] = chr(G);
+            pixelData[bufferBaseIdx + 2] = chr(B);
+            pixelData[bufferBaseIdx + 3] = chr(255);
         }
         if (((y + 1) % screenUpdateInterval) == 0 || y == height - 1) {
             updatetexture(textureID, pixelData);


### PR DESCRIPTION
## Summary
- use byte-based pixel buffers in `sdl_mandelbrot` and `sdl_mandelbrot_row`
- convert color values with `chr` so `updatetexture` receives bytes

## Testing
- `cmake --build build`
- `build/bin/clike Examples/clike/sdl_mandelbrot_row` *(fails: call to undefined function 'initgraph')*


------
https://chatgpt.com/codex/tasks/task_e_68aa8796d9c8832abd519c4145fd8864