### PR TITLE
Optimize Mandelbrot row rendering

### DIFF
--- a/Examples/clike/sdl_mandelbrot_row
+++ b/Examples/clike/sdl_mandelbrot_row
@@ -19,8 +19,7 @@ int main() {
     int row[width];
     byte pixelData[width * height * bytesPerPixel];
     int textureID;
-    int screenUpdateInterval = 1;
-    int bufferBaseIdx;
+    int screenUpdateInterval = 16; // update screen every 16 rows
 
     printf("Calculating Mandelbrot set. The window will update as rows are drawn...\n");
     initgraph(width, height, "Mandelbrot in CLike (builtin)");
@@ -37,6 +36,7 @@ int main() {
     for (int y = 0; y < height; y++) {
         double c_im = maxIm - y * imFactor;
         mandelbrotrow(minRe, reFactor, c_im, maxIterations, width - 1, &row);
+        int idx = y * width * bytesPerPixel;
         for (int x = 0; x < width; x++) {
             n = row[x];
             if (n == maxIterations) {
@@ -48,11 +48,11 @@ int main() {
                 G = (n * 7 + 85) % 256;
                 B = (n * 11 + 170) % 256;
             }
-            bufferBaseIdx = (y * width + x) * bytesPerPixel;
-            pixelData[bufferBaseIdx + 0] = R;
-            pixelData[bufferBaseIdx + 1] = G;
-            pixelData[bufferBaseIdx + 2] = B;
-            pixelData[bufferBaseIdx + 3] = 255;
+            pixelData[idx + 0] = R;
+            pixelData[idx + 1] = G;
+            pixelData[idx + 2] = B;
+            pixelData[idx + 3] = 255;
+            idx += bytesPerPixel;
         }
         if (((y + 1) % screenUpdateInterval) == 0 || y == height - 1) {
             updatetexture(textureID, pixelData);

--- a/src/ext_builtins/mandelbrot.c
+++ b/src/ext_builtins/mandelbrot.c
@@ -1,5 +1,6 @@
 #include "core/utils.h"
 #include "backend_ast/builtin.h"
+#include <string.h>
 
 static Value vmBuiltinMandelbrotRow(struct VM_s* vm, int arg_count, Value* args) {
     if (arg_count != 6) {
@@ -54,8 +55,9 @@ static Value vmBuiltinMandelbrotRow(struct VM_s* vm, int arg_count, Value* args)
         return makeVoid();
     }
 
-    for (int x = 0; x <= maxX; ++x) {
-        double c_re = minRe + x * reFactor;
+    double c_re = minRe;
+    Value *outPtr = outArr;
+    for (int x = 0; x <= maxX; ++x, c_re += reFactor, ++outPtr) {
         double Z_re = c_re;
         double Z_im = c_im;
         int n = 0;
@@ -70,8 +72,12 @@ static Value vmBuiltinMandelbrotRow(struct VM_s* vm, int arg_count, Value* args)
             Z_im = tmp;
             n++;
         }
-        freeValue(&outArr[x]);
-        outArr[x] = makeInt(n);
+        if (outPtr->type != TYPE_INTEGER) {
+            freeValue(outPtr);
+            memset(outPtr, 0, sizeof(Value));
+            outPtr->type = TYPE_INTEGER;
+        }
+        outPtr->i_val = n;
     }
 
     return makeVoid();


### PR DESCRIPTION
## Summary
- Speed up MandelbrotRow builtin by iterating with pointers, incrementally computing real coordinates, and avoiding unnecessary reallocations.
- Tweak SDL Mandelbrot example to update the screen less often and streamline pixel buffer writes.

## Testing
- `cmake -DSDL=OFF ..`
- `make -j2`
- `cd ../Tests && ./run_all_tests`


------
https://chatgpt.com/codex/tasks/task_e_68aa946085dc832a824e560b20eeaa19