### PR TITLE
Add Chudnovsky pi builtin and examples

### DIFF
--- a/Docs/project_overview.md
+++ b/Docs/project_overview.md
@@ -28,7 +28,7 @@ The project follows a classic compiler and virtual machine design:
 * **Networking**: A networking API using `libcurl` allows for making HTTP requests and handling responses.
 * **Rich Built-in Library**: A comprehensive set of built-in functions is provided for:
     * File I/O (`readln`, `writeln`, `fileexists`).
-    * Math (`sin`, `cos`, `sqrt`, `factorial`, `fibonacci`).
+    * Math (`sin`, `cos`, `sqrt`, `factorial`, `fibonacci`, `chudnovsky`).
     * String manipulation (`copy`, `pos`, `length`).
     * System interaction (`getpid`, `dos_exec`).
 * **Bytecode Caching**: To speed up subsequent runs, the compiler can cache bytecode for source files that have not been modified.

--- a/Examples/clike/README.md
+++ b/Examples/clike/README.md
@@ -14,9 +14,11 @@ build/bin/clike Examples/Clike/<program>
 
 ## Programs
 - `factorial_native` – Calculates factorials using a native function
-- `factorial_ext` – Calculates factorials using an extended builtin function 
+- `factorial_ext` – Calculates factorials using an extended builtin function
 - `fibonacci_native` – Calculates fibonacci numbers using a native function
 - `fibonacci_ext` – Calculates fibonacci numbers using an extended builtin function
+- `chudnovsky_native` – Approximates π using a native Chudnovsky implementation
+- `chudnovsky_ext` – Approximates π using an extended builtin implementation
 
 - `hangman5` – text-based hangman game ported from Pascal.
 - `hello` – Hello World!

--- a/Examples/clike/chudnovsky_ext
+++ b/Examples/clike/chudnovsky_ext
@@ -1,0 +1,8 @@
+#!/usr/bin/env clike
+int main() {
+    long n;
+    printf("Please enter an integer value for iterations: ");
+    scanf(n);
+    printf("pi: %.15f\n", chudnovsky(n));
+    return 0;
+}

--- a/Examples/clike/chudnovsky_native
+++ b/Examples/clike/chudnovsky_native
@@ -1,0 +1,25 @@
+#!/usr/bin/env clike
+double chudnovsky_native(long n) {
+    double M = 1.0;
+    double L = 13591409.0;
+    double X = 1.0;
+    double K = 6.0;
+    double S = L;
+    for (long i = 1; i < n; i++) {
+        double i3 = (double)i * i * i;
+        M = (K * K * K - 16.0 * K) * M / i3;
+        L = L + 545140134.0;
+        X = X * -262537412640768000.0;
+        S = S + M * L / X;
+        K = K + 12.0;
+    }
+    return 426880.0 * sqrt(10005.0) / S;
+}
+
+int main() {
+    long n;
+    printf("Please enter an integer value for iterations: ");
+    scanf(n);
+    printf("pi: %.15f\n", chudnovsky_native(n));
+    return 0;
+}

--- a/src/ext_builtins/chudnovsky.c
+++ b/src/ext_builtins/chudnovsky.c
@@ -1,0 +1,42 @@
+#include "core/utils.h"
+#include "backend_ast/builtin.h"
+#include <math.h>
+
+static Value vmBuiltinChudnovsky(struct VM_s* vm, int arg_count, Value* args) {
+    if (arg_count != 1) {
+        runtimeError(vm, "Chudnovsky expects exactly 1 argument.");
+        return makeReal(0.0);
+    }
+    if (args[0].type != TYPE_INTEGER) {
+        runtimeError(vm, "Chudnovsky argument must be an integer.");
+        return makeReal(0.0);
+    }
+    long n = args[0].i_val;
+    if (n <= 0) {
+        runtimeError(vm, "Chudnovsky argument must be positive.");
+        return makeReal(0.0);
+    }
+
+    long double M = 1.0L;
+    long double L = 13591409.0L;
+    long double X = 1.0L;
+    long double K = 6.0L;
+    long double S = L;
+
+    for (long k = 1; k < n; ++k) {
+        long double k3 = (long double)k * k * k;
+        M = (K * K * K - 16.0L * K) * M / k3;
+        L += 545140134.0L;
+        X *= -262537412640768000.0L;
+        S += M * L / X;
+        K += 12.0L;
+    }
+
+    long double pi = 426880.0L * sqrtl(10005.0L) / S;
+    return makeReal((double)pi);
+}
+
+void registerChudnovskyBuiltin(void) {
+    registerBuiltinFunction("Chudnovsky", AST_FUNCTION_DECL, NULL);
+    registerVmBuiltin("chudnovsky", vmBuiltinChudnovsky);
+}

--- a/src/ext_builtins/register.c
+++ b/src/ext_builtins/register.c
@@ -6,6 +6,7 @@ void registerFactorialBuiltin(void);
 void registerFibonacciBuiltin(void);
 void registerFileExistsBuiltin(void);
 void registerMandelbrotRowBuiltin(void);
+void registerChudnovskyBuiltin(void);
 
 void registerExtendedBuiltins(void) {
     registerGetPidBuiltin();
@@ -14,4 +15,5 @@ void registerExtendedBuiltins(void) {
     registerFibonacciBuiltin();
     registerFileExistsBuiltin();
     registerMandelbrotRowBuiltin();
+    registerChudnovskyBuiltin();
 }


### PR DESCRIPTION
## Summary
- add `chudnovsky` extended builtin to approximate π via the Chudnovsky series
- provide native and builtin CLike sample programs to benchmark π computation
- document new examples and builtin in project overview

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd Tests && ./run_all_tests`


------
https://chatgpt.com/codex/tasks/task_e_68aa94b7efec832a9f1612965dc4e112