### PR TITLE
Ensure SDL windows open in foreground

### DIFF
--- a/src/backend_ast/sdl.c
+++ b/src/backend_ast/sdl.c
@@ -197,6 +197,10 @@ Value vmBuiltinInitgraph(VM* vm, int arg_count, Value* args) {
     SDL_RenderClear(gSdlRenderer);
     SDL_RenderPresent(gSdlRenderer);
     SDL_PumpEvents(); // Process any pending events so the window becomes visible
+    SDL_RaiseWindow(gSdlWindow); // Ensure the window appears in the foreground
+#if SDL_VERSION_ATLEAST(2,0,5)
+    SDL_SetWindowInputFocus(gSdlWindow); // Request focus for the new window
+#endif
 
     gSdlCurrentColor.r = 255; gSdlCurrentColor.g = 255; gSdlCurrentColor.b = 255; gSdlCurrentColor.a = 255;
     


### PR DESCRIPTION
## Summary
- raise newly created SDL windows and request input focus so they appear in the foreground

## Testing
- `cmake ..`
- `make -j2`
- `./run_all_tests` *(fails: Test failed (stdout mismatch): strlen)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9cc1b748832a94b1edff9ccceca7