### PR TITLE
Add C-style cast support to clike parser

### DIFF
--- a/Examples/clike/chudnovsky_native
+++ b/Examples/clike/chudnovsky_native
@@ -6,7 +6,7 @@ double chudnovsky_native(long n) {
     double K = 6.0;
     double S = L;
     for (long i = 1; i < n; i++) {
-        double i3 = (double)i * i * i;
+        double i3 = (double)(i * i * i);
         M = (K * K * K - 16.0 * K) * M / i3;
         L = L + 545140134.0;
         X = X * -262537412640768000.0;


### PR DESCRIPTION
## Summary
- add parsing for C-style casts by translating to builtin conversions
- restore Chudnovsky example to use C-style cast

## Testing
- `cmake -S . -B build`
- `cmake --build build -j $(nproc)`
- `bash Tests/run_clike_tests.sh` *(fails: stdout mismatch in Printf64)*
- `echo 5 | build/bin/clike Examples/clike/chudnovsky_native`


------
https://chatgpt.com/codex/tasks/task_e_68aa9fe9faa8832a8390b91ae1d7ed31