### PR TITLE
Fix integer overflow in Chudnovsky example

### DIFF
--- a/Examples/clike/chudnovsky_native
+++ b/Examples/clike/chudnovsky_native
@@ -6,7 +6,7 @@ double chudnovsky_native(long n) {
     double K = 6.0;
     double S = L;
     for (long i = 1; i < n; i++) {
-        double i3 = (double)(i * i * i);
+        double i3 = (double)i * (double)i * (double)i;
         M = (K * K * K - 16.0 * K) * M / i3;
         L = L + 545140134.0;
         X = X * -262537412640768000.0;


### PR DESCRIPTION
## Summary
- prevent integer overflow in chudnovsky_native by performing i^3 calculation in double precision

## Testing
- `Tests/run_clike_tests.sh`
- `time build/bin/clike Examples/clike/chudnovsky_native <<'EOF'
2097153
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68aaa5baaff4832a9481a6dc93ef4fbe