### PR TITLE
Fix RectangleArea parameter name to avoid builtin clash

### DIFF
--- a/lib/pascal/calculatearea.pl
+++ b/lib/pascal/calculatearea.pl
@@ -1,7 +1,7 @@
 unit CalculateArea;
 interface
 
-function RectangleArea( length, width: real): real;
+function RectangleArea(len, width: real): real;
 function CircleArea(radius: real) : real;
 function TriangleArea( side1, side2, side3: real): real;
 
@@ -10,9 +10,9 @@ implementation
 const
    PI = 3.14159;
 
-function RectangleArea( length, width: real): real;
+function RectangleArea(len, width: real): real;
 begin
-   RectangleArea := length * width;
+   RectangleArea := len * width;
 end;
 
 function CircleArea(radius: real) : real;


### PR DESCRIPTION
## Summary
- avoid Pascal builtin `length` collision by renaming RectangleArea parameter to `len`

## Testing
- `./build/bin/pascal Examples/Pascal/AreaCalculation.p`
- `cd Tests && ./run_all_tests`

------
https://chatgpt.com/codex/tasks/task_e_68ab072c0658832ab058a9f595273cef