### PR TITLE
Fix overflow in ColorPalette256 example

### DIFF
--- a/Examples/Pascal/ColorPalette256
+++ b/Examples/Pascal/ColorPalette256
@@ -50,8 +50,9 @@ BEGIN
         //    Write the number, padded to 3 spaces, with spaces around it
         Write(' ', colorIndex:3, ' ');
 
-        // Move to the next color index
-        colorIndex := colorIndex + 1;
+        // Move to the next color index without exceeding 255
+        IF colorIndex < 255 THEN
+          colorIndex := colorIndex + 1;
       END;
     END; // End FOR col
     WriteLn; // Move to the next line in the console after each row of colors


### PR DESCRIPTION
## Summary
- prevent `colorIndex` from incrementing past 255 in the ColorPalette256 demo

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest`
- `PASCAL_LIB_DIR=lib/pascal build/bin/pascal Examples/Pascal/ColorPalette256 >/tmp/palette_output.txt < /dev/null`
- `grep -n "Range check" /tmp/palette_output.txt`


------
https://chatgpt.com/codex/tasks/task_e_68ab07d580a4832aa0680e723017c3db