### PR TITLE
Avoid Length builtin conflict in CalculateArea

### DIFF
--- a/Docs/Pascal_overview.md
+++ b/Docs/Pascal_overview.md
@@ -84,7 +84,7 @@ Implements Base64 encoding and decoding【F:lib/pascal/base64.pl†L1-L155】.
 ### CalculateArea
 Provides geometry helpers【F:lib/pascal/calculatearea.pl†L1-L31】.
 
-* `RectangleArea(length, width: real): real`
+* `RectangleArea(len, width: real): real`
 * `CircleArea(radius: real): real`
 * `TriangleArea(side1, side2, side3: real): real` – uses Heron’s formula.
 

--- a/lib/pascal/calculatearea.pl
+++ b/lib/pascal/calculatearea.pl
@@ -1,6 +1,7 @@
 unit CalculateArea;
 interface
 
+{ Use 'len' here to avoid clashing with the builtin Length() function }
 function RectangleArea(len, width: real): real;
 function CircleArea(radius: real) : real;
 function TriangleArea( side1, side2, side3: real): real;


### PR DESCRIPTION
## Summary
- avoid clashing with the Length builtin by using a `len` parameter in `RectangleArea`
- document the correct signature for `RectangleArea`

## Testing
- `./run_all_tests`
- `PASCAL_LIB_DIR=lib/pascal ./build/bin/pascal Examples/Pascal/AreaCalculation.p`


------
https://chatgpt.com/codex/tasks/task_e_68ab0afc2158832a8e859a69179828ae