### PR TITLE
Implement FreeSound Pascal builtin

### DIFF
--- a/Docs/Pscal_VM_Builtins.md
+++ b/Docs/Pscal_VM_Builtins.md
@@ -125,6 +125,7 @@ The following built-ins are available when Pscal is compiled with SDL support.
 - `initsoundsystem` – Initialize audio.
 - `quitsoundsystem` – Shut down audio.
 - `loadsound` – Load sound file.
+- `freesound` – Free a loaded sound.
 - `playsound` – Play sound.
 - `issoundplaying` – Query if sound playing.
 - `inittextsystem` – Initialize text subsystem.

--- a/Examples/clike/builtins.h
+++ b/Examples/clike/builtins.h
@@ -60,6 +60,7 @@ int exit();
 int exp();
 int fillcircle();
 int fillrect();
+int freesound();
 int getenv();
 int getmaxx();
 int getmaxy();

--- a/src/backend_ast/audio.c
+++ b/src/backend_ast/audio.c
@@ -267,6 +267,15 @@ Value vmBuiltinPlaysound(VM* vm, int arg_count, Value* args) {
     return makeVoid();
 }
 
+Value vmBuiltinFreesound(VM* vm, int arg_count, Value* args) {
+    if (arg_count != 1 || args[0].type != TYPE_INTEGER) {
+        runtimeError(vm, "FreeSound expects 1 integer argument.");
+    } else {
+        audioFreeSound((int)args[0].i_val);
+    }
+    return makeVoid();
+}
+
 Value vmBuiltinQuitsoundsystem(VM* vm, int arg_count, Value* args) {
     if (arg_count != 0) runtimeError(vm, "QuitSoundSystem expects 0 arguments.");
     else audioQuitSystem();

--- a/src/backend_ast/audio.h
+++ b/src/backend_ast/audio.h
@@ -34,6 +34,7 @@ void audioQuitSystem(void);
 Value vmBuiltinInitsoundsystem(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinLoadsound(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinPlaysound(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinFreesound(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinQuitsoundsystem(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinIssoundplaying(struct VM_s* vm, int arg_count, Value* args);
 

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -97,6 +97,7 @@ static const VmBuiltinMapping vmBuiltinDispatchTable[] = {
 #ifdef SDL
     {"fillcircle", vmBuiltinFillcircle},
     {"fillrect", vmBuiltinFillrect},
+    {"freesound", vmBuiltinFreesound},
 #endif
     {"getdate", vmBuiltinDosGetdate},
     {"getenv", vmBuiltinGetenv},
@@ -2620,6 +2621,7 @@ void registerAllBuiltins(void) {
     registerBuiltinFunction("DrawPolygon", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("DrawRect", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("FillRect", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("FreeSound", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("GetMouseState", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("GetPixelColor", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("GetTextSize", AST_PROCEDURE_DECL, NULL);


### PR DESCRIPTION
## Summary
- expose FreeSound audio builtin so Pascal and clike programs can release sound resources
- document FreeSound in builtin reference

## Testing
- `./Tests/run_pascal_tests.sh`
- `./Tests/run_clike_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ab27ccd238832a966bd234b16e79ee