### PR TITLE
Use MandelbrotRow builtin in SDLInteractiveMandelbrot example

### DIFF
--- a/Examples/Pascal/SDLInteractiveMandelbrot
+++ b/Examples/Pascal/SDLInteractiveMandelbrot
@@ -1,6 +1,7 @@
 #!/usr/bin/env pascal
 PROGRAM SDLTextureMandelbrotZoomFixed;
 
+{ Demonstrates Mandelbrot rendering using the MandelbrotRow builtin }
 USES CRT;
 
 CONST
@@ -26,10 +27,6 @@ TYPE
   FlatPixelBuffer = ARRAY[0..(MandelWindowWidth * MandelWindowHeight * MandelBytesPerPixel) - 1] OF Byte;
 
 VAR
-  x0, y0, zx, zy, zxTemp : Real;
-  Iteration           : Integer;
-  R_calc, G_calc, B_calc : Byte;
-
   MinRe, MaxRe, MinIm, MaxIm : Real;
   ViewPixelWidth, ViewPixelHeight : Integer;
   ReRange, ImRange           : Real;
@@ -93,21 +90,30 @@ BEGIN
 END;
 
 PROCEDURE FillPixelDataAndDisplayProgressively;
-VAR LocalPy, LocalPx, BufferBaseIdx : Integer;
+VAR
+  LocalPy, LocalPx, BufferBaseIdx : Integer;
+  RowIterations : ARRAY[0..MandelWindowWidth - 1] OF Integer;
+  c_im : Real;
+  Iteration : Integer;
+  R_calc, G_calc, B_calc : Byte;
 BEGIN
   GotoXY(1, StatusLineY); ClrEol; Write('Calculating and rendering progressively...');
   FOR LocalPy := 0 TO ViewPixelHeight - 1 DO BEGIN
+    c_im := MaxIm - (LocalPy * ScaleIm);
+    MandelbrotRow(MinRe, ScaleRe, c_im, MandelMaxIterations, ViewPixelWidth - 1, RowIterations);
     FOR LocalPx := 0 TO ViewPixelWidth - 1 DO BEGIN
-      x0 := MinRe + (LocalPx * ScaleRe); y0 := MaxIm - (LocalPy * ScaleIm);
-      zx := 0.0; zy := 0.0; Iteration := 0;
-      WHILE (zx*zx + zy*zy <= 4.0) AND (Iteration < MandelMaxIterations) DO
-      BEGIN zxTemp := zx*zx - zy*zy + x0; zy := 2*zx*zy + y0; zx := zxTemp; Iteration := Iteration + 1; END;
+      Iteration := RowIterations[LocalPx];
       IF Iteration = MandelMaxIterations THEN BEGIN R_calc := 0; G_calc := 0; B_calc := 0; END
       ELSE BEGIN
-        R_calc := ((Iteration * 12) MOD 256 + 256) MOD 256; G_calc := ((Iteration * 8 + 80) MOD 256 + 256) MOD 256; B_calc := ((Iteration * 5 + 160) MOD 256 + 256) MOD 256;
+        R_calc := ((Iteration * 12) MOD 256 + 256) MOD 256;
+        G_calc := ((Iteration * 8 + 80) MOD 256 + 256) MOD 256;
+        B_calc := ((Iteration * 5 + 160) MOD 256 + 256) MOD 256;
       END;
       BufferBaseIdx := (LocalPy * ViewPixelWidth + LocalPx) * MandelBytesPerPixel;
-      PixelData[BufferBaseIdx + 0] := R_calc; PixelData[BufferBaseIdx + 1] := G_calc; PixelData[BufferBaseIdx + 2] := B_calc; PixelData[BufferBaseIdx + 3] := 255;
+      PixelData[BufferBaseIdx + 0] := R_calc;
+      PixelData[BufferBaseIdx + 1] := G_calc;
+      PixelData[BufferBaseIdx + 2] := B_calc;
+      PixelData[BufferBaseIdx + 3] := 255;
     END; // Px
     PercentDone := Trunc( (LocalPy + 1) * 100.0 / ViewPixelHeight );
     GotoXY(1, StatusLineY); ClrEol; Write('Processing: Row ', LocalPy + 1, '/', ViewPixelHeight, '. ~', PercentDone, '%');


### PR DESCRIPTION
## Summary
- Simplify SDLInteractiveMandelbrot example by calling `MandelbrotRow` builtin to compute iteration counts
- Remove manual iteration variables and add brief note about builtin usage

## Testing
- `bash Tests/run_pascal_tests.sh` *(fails: pascal binary not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab31401378832aa1a61181aa1b4bc1