### PR TITLE
Fix MandelbrotRow initialization so SDLInteractiveMandelbrot displays

### DIFF
--- a/src/ext_builtins/mandelbrot.c
+++ b/src/ext_builtins/mandelbrot.c
@@ -58,8 +58,8 @@ static Value vmBuiltinMandelbrotRow(struct VM_s* vm, int arg_count, Value* args)
     double c_re = minRe;
     Value *outPtr = outArr;
     for (int x = 0; x <= maxX; ++x, c_re += reFactor, ++outPtr) {
-        double Z_re = c_re;
-        double Z_im = c_im;
+        double Z_re = 0.0;
+        double Z_im = 0.0;
         int n = 0;
         while (n < maxIterations) {
             double Z_re2 = Z_re * Z_re;


### PR DESCRIPTION
## Summary
- initialize MandelbrotRow iterations at z=0 so Mandelbrot example renders correctly

## Testing
- `cmake -DSDL=OFF ..`
- `make -j$(nproc)`
- `./run_all_tests`


------
https://chatgpt.com/codex/tasks/task_e_68ab36e7b950832aa3719ee97a1284cd