### PR TITLE
Differentiate cached byte code message

### DIFF
--- a/Tests/run_pascal_tests.sh
+++ b/Tests/run_pascal_tests.sh
@@ -61,7 +61,7 @@ for src in "$SCRIPT_DIR"/Pascal/*.p; do
 
   perl -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]//g; s/\e\][^\a]*\a//g' "$actual_out" > "$actual_out.clean" && mv "$actual_out.clean" "$actual_out"
   perl -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]//g; s/\e\][^\a]*\a//g' "$actual_err" > "$actual_err.clean" && mv "$actual_err.clean" "$actual_err"
-  perl -0 -pe 's/^Compilation successful.*\n//m' "$actual_err" > "$actual_err.clean" && mv "$actual_err.clean" "$actual_err"
+  perl -0 -pe 's/^Compilation successful.*\n//m; s/^Loaded cached byte code.*\n//m' "$actual_err" > "$actual_err.clean" && mv "$actual_err.clean" "$actual_err"
   head -n 2 "$actual_err" > "$actual_err.trim" && mv "$actual_err.trim" "$actual_err"
   perl -pe 's/pid=[0-9]+/pid=<PID>/g' "$actual_out" > "$actual_out.clean" && mv "$actual_out.clean" "$actual_out"
   perl -ne 'print unless /^[0-9]{4}/' "$actual_out" > "$actual_out.clean" && mv "$actual_out.clean" "$actual_out"

--- a/src/main.c
+++ b/src/main.c
@@ -111,15 +111,18 @@ int runProgram(const char *source, const char *programName, int dump_ast_json_fl
                 if (compilation_ok_for_vm) {
                     finalizeBytecode(&chunk);
                     saveBytecodeToCache(programName, &chunk);
-                    fprintf(stderr, "Compilation successful. Bytecode size: %d bytes, Constants: %d\n", chunk.count, chunk.constants_count);
+                    fprintf(stderr, "Compilation successful. Byte code size: %d bytes, Constants: %d\n", chunk.count, chunk.constants_count);
                     if (dump_bytecode_flag) {
                         disassembleBytecodeChunk(&chunk, programName ? programName : "CompiledChunk", procedure_table);
                         fprintf(stderr, "\n--- Executing Program with VM ---\n");
                     }
                 }
-            } else if (dump_bytecode_flag) {
-                disassembleBytecodeChunk(&chunk, programName ? programName : "CompiledChunk", procedure_table);
-                fprintf(stderr, "\n--- Executing Program with VM (cached) ---\n");
+            } else {
+                fprintf(stderr, "Loaded cached byte code. Byte code size: %d bytes, Constants: %d\n", chunk.count, chunk.constants_count);
+                if (dump_bytecode_flag) {
+                    disassembleBytecodeChunk(&chunk, programName ? programName : "CompiledChunk", procedure_table);
+                    fprintf(stderr, "\n--- Executing Program with VM (cached) ---\n");
+                }
             }
 
             if (compilation_ok_for_vm) {


### PR DESCRIPTION
## Summary
- add distinct message when loading cached byte code
- rename messages to use "Byte code"
- strip new cached message from test stderr

## Testing
- `cmake ..`
- `make -j4`
- `./Tests/run_pascal_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ab422cc590832aa12b223698af2889