### PR TITLE
Add math and DOS builtins; adjust unit linking

### DIFF
--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -108,6 +108,19 @@ Value vmBuiltinLn(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinCos(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinSin(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinTan(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinArctan(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinArcsin(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinArccos(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinCotan(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinPower(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinLog10(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinSinh(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinCosh(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinTanh(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinMax(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinMin(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinFloor(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinCeil(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinTrunc(struct VM_s* vm, int arg_count, Value* args);
 
 /* VM-native random functions */

--- a/src/clike/builtins.c
+++ b/src/clike/builtins.c
@@ -25,4 +25,30 @@ void clike_register_builtins(void) {
     registerBuiltinFunction("mstreamsavetofile", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("mstreamfree", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("mstreambuffer", AST_FUNCTION_DECL, NULL);
+
+    /* DOS/OS helpers */
+    registerBuiltinFunction("exec", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("findfirst", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("findnext", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("getfattr", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("mkdir", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("rmdir", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("getenv", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("getdate", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("gettime", AST_FUNCTION_DECL, NULL);
+
+    /* Math helpers */
+    registerBuiltinFunction("arctan", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("arcsin", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("arccos", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("cotan", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("power", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("log10", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("sinh", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("cosh", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("tanh", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("max", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("min", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("floor", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("ceil", AST_FUNCTION_DECL, NULL);
 }


### PR DESCRIPTION
## Summary
- Compile Pascal units before linking to ensure implementation bytecode is available
- Expose DOS helpers and math functions as VM builtins
- Update MathLibTest to cover supported operations
- Restore floor and ceil math tests

## Testing
- `PASCAL_LIB_DIR=lib/pascal PSCAL_LIB_DIR=lib/pascal ./build/bin/pascal Tests/Pascal/MathLibTest.p`
- `cd Tests && ./run_pascal_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ab4ba89d1c832aa1649c11a16159d0