### PR TITLE
Add interactive zoom to SDL MandelbrotRow demo

### DIFF
--- a/Examples/clike/README.md
+++ b/Examples/clike/README.md
@@ -25,7 +25,7 @@ build/bin/clike Examples/Clike/<program>
 - `module_demo` – demonstrates importing `math_utils.cl` from the clike
    library search path.
 - `sdl_multibouncingballs.cl` – SDL multi bouncing balls demo ported from Pascal.
-- `sdl_mandelbrot_row` – SDL Mandelbrot renderer using the MandelbrotRow builtin.
+- `sdl_mandelbrot_row` – SDL Mandelbrot renderer using the MandelbrotRow builtin; left click to zoom in, right click to zoom out.
 - `show_pid` – Uses an extended builtin function to show the process ID
 
 The clike front end resolves imports by first checking the directory in the

--- a/Examples/clike/sdl_mandelbrot_row
+++ b/Examples/clike/sdl_mandelbrot_row
@@ -1,7 +1,7 @@
 #!/usr/bin/env clike
 /*
  * SDL Mandelbrot renderer using the MandelbrotRow builtin.
- * Press Q in the console to quit after rendering.
+ * Left click to zoom in, right click to zoom out, Q to quit.
  */
 
 int main() {
@@ -11,15 +11,21 @@ int main() {
     double minRe = -2.0;
     double maxRe = 1.0;
     double minIm = -1.2;
-    double maxIm = minIm + (maxRe - minRe) * height / width;
-    double reFactor = (maxRe - minRe) / (width - 1);
-    double imFactor = (maxIm - minIm) / (height - 1);
+    double maxIm;
+    double reFactor;
+    double imFactor;
+    double zoomFactor = 2.0;
 
     int bytesPerPixel = 4;
     int row[width];
     byte pixelData[width * height * bytesPerPixel];
     int textureID;
     int screenUpdateInterval = 16; // update screen every 16 rows
+    int quit = 0;
+    int redraw = 1;
+    int mouseX = 0, mouseY = 0, mouseButtons = 0, prevButtons = 0;
+    int ButtonLeft = 1;
+    int ButtonRight = 4;
 
     printf("Calculating Mandelbrot set. The window will update as rows are drawn...\n");
     initgraph(width, height, "Mandelbrot in CLike (builtin)");
@@ -33,51 +39,79 @@ int main() {
 
     int n,R,G,B;
 
-    for (int y = 0; y < height; y++) {
-        double c_im = maxIm - y * imFactor;
-        mandelbrotrow(minRe, reFactor, c_im, maxIterations, width - 1, &row);
-        int idx = y * width * bytesPerPixel;
-        for (int x = 0; x < width; x++) {
-            n = row[x];
-            if (n == maxIterations) {
-                R = 0;
-                G = 0;
-                B = 0;
-            } else {
-                R = (n * 5) % 256;
-                G = (n * 7 + 85) % 256;
-                B = (n * 11 + 170) % 256;
+    while (!quit) {
+        if (redraw) {
+            maxIm = minIm + (maxRe - minRe) * height / width;
+            reFactor = (maxRe - minRe) / (width - 1);
+            imFactor = (maxIm - minIm) / (height - 1);
+            for (int y = 0; y < height; y++) {
+                double c_im = maxIm - y * imFactor;
+                mandelbrotrow(minRe, reFactor, c_im, maxIterations, width - 1, &row);
+                int idx = y * width * bytesPerPixel;
+                for (int x = 0; x < width; x++) {
+                    n = row[x];
+                    if (n == maxIterations) {
+                        R = 0;
+                        G = 0;
+                        B = 0;
+                    } else {
+                        R = (n * 5) % 256;
+                        G = (n * 7 + 85) % 256;
+                        B = (n * 11 + 170) % 256;
+                    }
+                    pixelData[idx + 0] = R;
+                    pixelData[idx + 1] = G;
+                    pixelData[idx + 2] = B;
+                    pixelData[idx + 3] = 255;
+                    idx += bytesPerPixel;
+                }
+                if (((y + 1) % screenUpdateInterval) == 0 || y == height - 1) {
+                    updatetexture(textureID, pixelData);
+                    cleardevice();
+                    rendercopy(textureID);
+                    updatescreen();
+                    graphloop(0);
+                }
             }
-            pixelData[idx + 0] = R;
-            pixelData[idx + 1] = G;
-            pixelData[idx + 2] = B;
-            pixelData[idx + 3] = 255;
-            idx += bytesPerPixel;
-        }
-        if (((y + 1) % screenUpdateInterval) == 0 || y == height - 1) {
             updatetexture(textureID, pixelData);
             cleardevice();
             rendercopy(textureID);
             updatescreen();
-            graphloop(0);
+            redraw = 0;
         }
-    }
 
-    updatetexture(textureID, pixelData);
-    cleardevice();
-    rendercopy(textureID);
-    updatescreen();
-    printf("Mandelbrot rendered. Press Q in the console to quit.\n");
-    int quit = 0;
-    while (!quit) {
         if (keypressed()) {
             char c = readkey();
             if (upcase(c) == 'Q') {
                 quit = 1;
             }
         }
+
+        getmousestate(&mouseX, &mouseY, &mouseButtons);
+        if ((mouseButtons & ButtonLeft) && !(prevButtons & ButtonLeft)) {
+            double centerRe = minRe + mouseX * reFactor;
+            double centerIm = maxIm - mouseY * imFactor;
+            double newWidth = (maxRe - minRe) / zoomFactor;
+            double newHeight = (maxIm - minIm) / zoomFactor;
+            minRe = centerRe - newWidth / 2.0;
+            maxRe = centerRe + newWidth / 2.0;
+            minIm = centerIm - newHeight / 2.0;
+            redraw = 1;
+        } else if ((mouseButtons & ButtonRight) && !(prevButtons & ButtonRight)) {
+            double centerRe = minRe + mouseX * reFactor;
+            double centerIm = maxIm - mouseY * imFactor;
+            double newWidth = (maxRe - minRe) * zoomFactor;
+            double newHeight = (maxIm - minIm) * zoomFactor;
+            minRe = centerRe - newWidth / 2.0;
+            maxRe = centerRe + newWidth / 2.0;
+            minIm = centerIm - newHeight / 2.0;
+            redraw = 1;
+        }
+        prevButtons = mouseButtons;
+
         graphloop(16);
     }
+
     destroytexture(textureID);
     closegraph();
     return 0;


### PR DESCRIPTION
## Summary
- Allow left-click zoom in and right-click zoom out in the SDL MandelbrotRow example.
- Document new mouse controls in the Clike examples README.

## Testing
- `cmake -S . -B build`
- `cmake --build build -j 8`
- `./Tests/run_clike_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ab8ad4b1ec832a8e5a5e7e6543588b