### PR TITLE
Fix boolean check in SDL Mandelbrot example

### DIFF
--- a/Examples/clike/sdl_mandelbrot_row
+++ b/Examples/clike/sdl_mandelbrot_row
@@ -88,7 +88,7 @@ int main() {
         }
 
         getmousestate(&mouseX, &mouseY, &mouseButtons);
-        if ((mouseButtons & ButtonLeft) && !(prevButtons & ButtonLeft)) {
+        if (((mouseButtons & ButtonLeft) != 0) && ((prevButtons & ButtonLeft) == 0)) {
             double centerRe = minRe + mouseX * reFactor;
             double centerIm = maxIm - mouseY * imFactor;
             double newWidth = (maxRe - minRe) / zoomFactor;
@@ -97,7 +97,7 @@ int main() {
             maxRe = centerRe + newWidth / 2.0;
             minIm = centerIm - newHeight / 2.0;
             redraw = 1;
-        } else if ((mouseButtons & ButtonRight) && !(prevButtons & ButtonRight)) {
+        } else if (((mouseButtons & ButtonRight) != 0) && ((prevButtons & ButtonRight) == 0)) {
             double centerRe = minRe + mouseX * reFactor;
             double centerIm = maxIm - mouseY * imFactor;
             double newWidth = (maxRe - minRe) * zoomFactor;


### PR DESCRIPTION
## Summary
- use explicit comparisons in `sdl_mandelbrot_row` so both operands to `&&` are boolean

## Testing
- `Tests/run_all_tests` *(fails: Test produced unexpected stdout: CacheStalenessTest)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8db592a4832aa56544b45b6d2cc6