### PR TITLE
Fix fillrect usage in clike Space Game demo

### DIFF
--- a/Docs/Pscal_VM_Builtins.md
+++ b/Docs/Pscal_VM_Builtins.md
@@ -164,8 +164,8 @@ These built-ins are available when Pscal is built with SDL support.
 | setalphablend | (enable: Boolean) | void | Configure alpha blending. |
 | putpixel | (x: Integer, y: Integer) | void | Draw pixel. |
 | drawline | (x1: Integer, y1: Integer, x2: Integer, y2: Integer) | void | Draw line. |
-| drawrect | (x: Integer, y: Integer, w: Integer, h: Integer) | void | Draw rectangle. |
-| fillrect | (x: Integer, y: Integer, w: Integer, h: Integer) | void | Filled rectangle. |
+| drawrect | (x1: Integer, y1: Integer, x2: Integer, y2: Integer) | void | Draw rectangle. |
+| fillrect | (x1: Integer, y1: Integer, x2: Integer, y2: Integer) | void | Filled rectangle. |
 | drawcircle | (x: Integer, y: Integer, r: Integer) | void | Draw circle. |
 | fillcircle | (x: Integer, y: Integer, r: Integer) | void | Filled circle. |
 | drawpolygon | (points: Array) | void | Draw polygon. |

--- a/Examples/clike/sdl_galaxian
+++ b/Examples/clike/sdl_galaxian
@@ -168,16 +168,17 @@ int main() {
 
         cleardevice();
         setrgbcolor(0, 255, 0);
-        fillrect(PlayerX, PlayerY, PlayerW, PlayerH);
+        /* fillrect expects top-left and bottom-right coordinates */
+        fillrect(PlayerX, PlayerY, PlayerX + PlayerW - 1, PlayerY + PlayerH - 1);
         if (BulletActive) {
             setrgbcolor(255, 255, 0);
-            fillrect(BulletX, BulletY, BulletW, BulletH);
+            fillrect(BulletX, BulletY, BulletX + BulletW - 1, BulletY + BulletH - 1);
         }
         setrgbcolor(255, 0, 0);
         i = 1;
         while (i <= AlienRows * AlienCols) {
             if (AlienAlive[i]) {
-                fillrect(AlienX[i], AlienY[i], AlienW, AlienH);
+                fillrect(AlienX[i], AlienY[i], AlienX[i] + AlienW - 1, AlienY[i] + AlienH - 1);
             }
             i = i + 1;
         }


### PR DESCRIPTION
## Summary
- correct `fillrect` calls in the CLike Space Game demo so rectangles use bottom-right coordinates
- document coordinate-based parameters for `drawrect` and `fillrect`

## Testing
- `./run_clike_tests.sh` *(fails: clike binary not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9fbd25ac832a8fed9183be23eb74