### PR TITLE
Add documentation index to Docs directory

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -1,0 +1,23 @@
+# Pscal Documentation Index
+
+Start here to explore the available guides and references in this directory.
+
+## Project overview
+- [project_overview.md](project_overview.md): high-level architecture, features, and build instructions.
+
+## Pascal front end
+- [pascal_overview.md](pascal_overview.md): architecture and language features of the Pascal-style compiler.
+- [pascal_language_reference.md](pascal_language_reference.md): full specification of the Pascal-like language.
+
+## C-like front end
+- [clike_overview.md](clike_overview.md): semantics and capabilities of the compact C-style language.
+- [clike_language_reference.md](clike_language_reference.md): detailed specification of the C-like language.
+- [clike_tutorial.md](clike_tutorial.md): build and run the C-like compiler.
+- [clike_repl_tutorial.md](clike_repl_tutorial.md): interact with the language through the REPL.
+
+## Virtual machine
+- [pscal_vm_overview.md](pscal_vm_overview.md): stack-based VM architecture and opcode reference.
+- [pscal_vm_builtins.md](pscal_vm_builtins.md): catalog of built-in functions provided by the VM.
+- [extending_builtins.md](extending_builtins.md): how to add custom built-in routines.
+- [standalone_vm_frontends.md](standalone_vm_frontends.md): writing external frontends that emit Pscal bytecode.
+


### PR DESCRIPTION
## Summary
- add central documentation index for easier navigation of project guides

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68acac1b16a8832ab9152e6764eb29a0