### PR TITLE
Support enum arithmetic in Pascal for loops

### DIFF
--- a/Tests/Pascal/EnumForLoop
+++ b/Tests/Pascal/EnumForLoop
@@ -1,0 +1,20 @@
+program EnumForLoop;
+
+type
+  Day = (Mon, Tue, Wed, Thu, Fri, Sat, Sun);
+  DaySet = set of Day;
+  Person = record
+    name: string;
+    busy: DaySet;
+  end;
+
+var
+  p: Person;
+  d: Day;
+begin
+  p.name := 'Alice';
+  p.busy := [Mon, Wed];
+  for d := Mon to Sun do
+    if d in p.busy then
+      writeln(p.name, ' is busy on ', d);
+end.

--- a/Tests/Pascal/EnumForLoop.out
+++ b/Tests/Pascal/EnumForLoop.out
@@ -1,0 +1,2 @@
+Alice is busy on ENUM(day, ord: 0)
+Alice is busy on ENUM(day, ord: 2)

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -668,6 +668,32 @@ InterpretResult interpretBytecode(VM* vm, BytecodeChunk* chunk, HashTable* globa
                 } \
             } \
         } \
+\
+        /* Enum +/- intlike */ \
+        if (!op_is_handled) { \
+            if (current_instruction_code == OP_ADD || current_instruction_code == OP_SUBTRACT) { \
+                bool a_enum_b_int = (a_val_popped.type == TYPE_ENUM && IS_INTLIKE(b_val_popped)); \
+                bool a_int_b_enum = (IS_INTLIKE(a_val_popped) && b_val_popped.type == TYPE_ENUM); \
+                if (a_enum_b_int || a_int_b_enum) { \
+                    Value enum_val = a_enum_b_int ? a_val_popped : b_val_popped; \
+                    Value int_val  = a_enum_b_int ? b_val_popped : a_val_popped; \
+                    long long delta = as_i64(int_val); \
+                    int new_ord = enum_val.enum_val.ordinal + \
+                        ((current_instruction_code == OP_ADD) ? (int)delta : -(int)delta); \
+                    if (enum_val.enum_meta && \
+                        (new_ord < 0 || new_ord >= enum_val.enum_meta->member_count)) { \
+                        runtimeError(vm, "Runtime Error: Enum '%s' out of range.", \
+                                     enum_val.enum_val.enum_name ? enum_val.enum_val.enum_name : "<anon>"); \
+                        freeValue(&a_val_popped); freeValue(&b_val_popped); \
+                        return INTERPRET_RUNTIME_ERROR; \
+                    } \
+                    result_val = makeEnum(enum_val.enum_val.enum_name, new_ord); \
+                    result_val.enum_meta = enum_val.enum_meta; \
+                    result_val.base_type_node = enum_val.base_type_node; \
+                    op_is_handled = true; \
+                } \
+            } \
+        } \
         \
         /* Set union/difference/intersection */ \
         if (!op_is_handled) { \


### PR DESCRIPTION
## Summary
- Allow VM arithmetic operations to handle enum values with integer offsets, enabling Pascal `for` loops over enumerations
- Add regression test covering enumeration-based for loops

## Testing
- `make -j$(nproc)`
- `cd Tests; ./run_pascal_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68acaf5b3750832a80d63b764d4b2ddd