### PR TITLE
Register SetLength builtin for Pascal

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -2874,6 +2874,7 @@ void registerAllBuiltins(void) {
     registerBuiltinFunction("IOResult", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("KeyPressed", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("Length", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("SetLength", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("Ln", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("Log10", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("Low", AST_FUNCTION_DECL, NULL);


### PR DESCRIPTION
## Summary
- register SetLength so it's recognized as a Pascal builtin procedure

## Testing
- `cd build && cmake ..`
- `make -j$(nproc)`
- `cd ../Tests && ./run_all_tests`


------
https://chatgpt.com/codex/tasks/task_e_68ad057a0720832a847682c26e15ae30