### PR TITLE
Fix SetLength var parameter handling and add regression test

### DIFF
--- a/Tests/Pascal/UpperCaseTest
+++ b/Tests/Pascal/UpperCaseTest
@@ -1,0 +1,8 @@
+program UpperCaseTest;
+uses SysUtils;
+var
+  s: string;
+begin
+  s := UpperCase('file found');
+  writeln(s);
+end.

--- a/Tests/Pascal/UpperCaseTest.out
+++ b/Tests/Pascal/UpperCaseTest.out
@@ -1,0 +1,1 @@
+FILE FOUND

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -457,7 +457,9 @@ Value vmBuiltinSetlength(VM* vm, int arg_count, Value* args) {
     }
 
     if ((size_t)new_len > copy_len) {
-        memset(new_buf + copy_len, 0, (size_t)new_len - copy_len);
+        /* Fill remaining space with spaces so that strlen reflects the new length.
+           Using '\0' would terminate the string early and lead to length 0. */
+        memset(new_buf + copy_len, ' ', (size_t)new_len - copy_len);
     }
     new_buf[new_len] = '\0';
 

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -2108,7 +2108,7 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
                     is_var_param = true;
                 }
                 else if (calleeName && (
-                    (i == 0 && (strcasecmp(calleeName, "new") == 0 || strcasecmp(calleeName, "dispose") == 0 || strcasecmp(calleeName, "assign") == 0 || strcasecmp(calleeName, "reset") == 0 || strcasecmp(calleeName, "rewrite") == 0 || strcasecmp(calleeName, "close") == 0 || strcasecmp(calleeName, "inc") == 0 || strcasecmp(calleeName, "dec") == 0 || strcasecmp(calleeName, "mstreamloadfromfile") == 0 || strcasecmp(calleeName, "mstreamsavetofile") == 0 || strcasecmp(calleeName, "mstreamfree") == 0 || strcasecmp(calleeName, "eof") == 0 || strcasecmp(calleeName, "readkey") == 0)) ||
+                    (i == 0 && (strcasecmp(calleeName, "new") == 0 || strcasecmp(calleeName, "dispose") == 0 || strcasecmp(calleeName, "assign") == 0 || strcasecmp(calleeName, "reset") == 0 || strcasecmp(calleeName, "rewrite") == 0 || strcasecmp(calleeName, "close") == 0 || strcasecmp(calleeName, "inc") == 0 || strcasecmp(calleeName, "dec") == 0 || strcasecmp(calleeName, "setlength") == 0 || strcasecmp(calleeName, "mstreamloadfromfile") == 0 || strcasecmp(calleeName, "mstreamsavetofile") == 0 || strcasecmp(calleeName, "mstreamfree") == 0 || strcasecmp(calleeName, "eof") == 0 || strcasecmp(calleeName, "readkey") == 0)) ||
                     (strcasecmp(calleeName, "readln") == 0 && (i > 0 || (i == 0 && arg_node->var_type != TYPE_FILE))) ||
                     (strcasecmp(calleeName, "getmousestate") == 0) || // All params are VAR
                     (strcasecmp(calleeName, "gettextsize") == 0 && i > 0) // Width and Height are VAR


### PR DESCRIPTION
## Summary
- Treat SetLength's first argument as a VAR parameter during compilation
- Fill new strings with spaces in SetLength builtin so their length is tracked
- Add regression test exercising SysUtils.UpperCase to guard against SetLength regressions

## Testing
- `cmake --build build`
- `Tests/run_pascal_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ad1d4d0554832ab9293264c85fc79b