### PR TITLE
Check initializer types in variable declarations

### DIFF
--- a/Tests/clike/InitTypeError.cl
+++ b/Tests/clike/InitTypeError.cl
@@ -1,0 +1,6 @@
+void foo() {}
+
+int main() {
+    int x = foo();
+    return 0;
+}

--- a/Tests/clike/InitTypeError.err
+++ b/Tests/clike/InitTypeError.err
@@ -1,0 +1,2 @@
+Type error: cannot assign VOID to INTEGER at line 4, column 13
+Compilation halted with 1 error(s).


### PR DESCRIPTION
## Summary
- validate initializer expressions against declared types in clike front end
- add regression test for invalid initializer type

## Testing
- `Tests/run_clike_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ad23edb21c832aaed6e65cb103ef58