### PR TITLE
Fix sort_string example to sort through pointer

### DIFF
--- a/Docs/clike_overview.md
+++ b/Docs/clike_overview.md
@@ -10,10 +10,11 @@ Pscal virtual machine.
 - **String indexing is 1-based** – Characters in a `str` start at index 1
   (`s[1]` is the first character). Accessing `s[0]` returns the length of the
   string as an integer.
-- **`str` values are pointers** – A `str` variable already evaluates to a
-  pointer to its character buffer.  Pass the variable directly to
-  functions; taking an additional address yields a pointer-to-pointer and
-  confuses element access.
+- **String literals are immutable** – Use `copy` to obtain a writable
+  string before modifying characters in place.
+- **`str` values are copied on call** – Strings are passed by value. To
+  mutate a caller's string, pass a pointer (e.g. `str*`) and write back to
+  it after making changes.
 - **Concatenation with `+`** – The `+` operator joins strings, e.g.
   `buffer = mstreambuffer(ms) + "\n";`.
 - **Standard string helpers** – Built-ins such as `strlen`, `copy` and
@@ -38,9 +39,10 @@ to the VM:
 ## Example: Sorting a String
 
 ```clike
-void sort_string(str s) {
+void sort_string(str* sp) {
     int i, j, len;
     char tmp;
+    str s = *sp;
     len = strlen(s);
     i = 1;
     while (i <= len) {
@@ -55,10 +57,12 @@ void sort_string(str s) {
         }
         i++;
     }
+    *sp = s;
 }
 
-str guessed = "ST";
-sort_string(guessed);  // pass the string value, not its address
+str guessed = copy("ST", 1, 2);  // make a writable copy
+sort_string(&guessed);            // sorts in place
+printf("%s\n", guessed);
 ```
 
 ## Example: Building a Linked List

--- a/Examples/clike/README.md
+++ b/Examples/clike/README.md
@@ -27,6 +27,7 @@ build/bin/clike Examples/Clike/<program>
 - `sdl_multibouncingballs.cl` – SDL multi bouncing balls demo ported from Pascal.
 - `sdl_mandelbrot_row` – SDL Mandelbrot renderer using the MandelbrotRow builtin; left click to zoom in, right click to zoom out.
 - `show_pid` – Uses an extended builtin function to show the process ID
+- `sort_string` – Shows how to copy and sort a string via a `str*` parameter
 
 The clike front end resolves imports by first checking the directory in the
 `CLIKE_LIB_DIR` environment variable and falling back to

--- a/Examples/clike/sort_string.cl
+++ b/Examples/clike/sort_string.cl
@@ -1,0 +1,27 @@
+void sort_string(str* sp) {
+    int i, j, len;
+    char tmp;
+    str s = *sp;
+    len = strlen(s); // strings index from one
+    i = 1;
+    while (i <= len) {
+        j = i + 1;
+        while (j <= len) {
+            if (s[i] > s[j]) {
+                tmp = s[i];
+                s[i] = s[j];
+                s[j] = tmp;
+            }
+            j++;
+        }
+        i++;
+    }
+    *sp = s;
+}
+
+void main() {
+    // String literals are immutable; make a writable copy first.
+    str sort = copy("This is a string", 1, strlen("This is a string"));
+    sort_string(&sort);
+    printf("Sorted String is %s\n", sort);
+}


### PR DESCRIPTION
## Summary
- Make `sort_string` accept a `str*` and write the sorted string back so callers see the change
- Clarify in the clike overview that strings are passed by value and show pointer-based sorting
- Mention the `str*` parameter in the clike examples README

## Testing
- `./Tests/run_clike_tests.sh`
- `build/bin/clike Examples/clike/sort_string.cl`


------
https://chatgpt.com/codex/tasks/task_e_68ad2a495d70832ab0f99dc8605ec3d7