### PR TITLE
Fix linked list example for CLike front end

### DIFF
--- a/Docs/clike_overview.md
+++ b/Docs/clike_overview.md
@@ -76,26 +76,26 @@ struct Node {
     struct Node* next;
 };
 
-void push(struct Node** head, int value) {
+struct Node* push(struct Node* head, int value) {
     struct Node* n;
     new(&n);
     n->value = value;
-    n->next = *head;
-    *head = n;
+    n->next = head;
+    return n;
 }
 
 void print(struct Node* head) {
     while (head) {
-        write(head->value, " ");
+        printf("%d ", head->value);
         head = head->next;
     }
-    writeln();
+    printf("\n");
 }
 
 struct Node* list = NULL;
-push(&list, 3);
-push(&list, 1);
-push(&list, 4);
+list = push(list, 3);
+list = push(list, 1);
+list = push(list, 4);
 print(list);           // 4 1 3
 ```
 


### PR DESCRIPTION
## Summary
- Correct `push` to return a new list head instead of using double pointers.
- Replace Pascal-style `write`/`writeln` calls with `printf` in linked list example.
- Update example usage to use the returned head.

## Testing
- `./Tests/run_clike_tests.sh` (fails: clike binary not found)


------
https://chatgpt.com/codex/tasks/task_e_68ad3dca2338832ab99980f210938df1