### PR TITLE
Fix Dos GetTime example and update builtins documentation

### DIFF
--- a/Docs/pscal_vm_builtins.md
+++ b/Docs/pscal_vm_builtins.md
@@ -141,8 +141,8 @@ VM. For instructions on adding your own routines, see
 | dos_rmdir / rmdir | (path: String) | Integer | Remove directory. |
 | dos_findfirst / findfirst | (pattern: String, attr: Integer) | Integer | Begin directory search. |
 | dos_findnext / findnext | () | Integer | Continue directory search. |
-| dos_getdate / getdate | () | Integer | Get system date packed as long. |
-| dos_gettime / gettime | () | Integer | Get system time packed as long. |
+| dos_getdate / getdate | (var Year, Month, Day, Dow: Word) | void | Retrieve system date components. |
+| dos_gettime / gettime | (var Hour, Minute, Second, Sec100: Word) | void | Retrieve system time components. |
 | dos_getfattr / getfattr | (path: String) | Integer | Get file attributes. |
 
 ## Networking

--- a/Examples/Pascal/DosExample
+++ b/Examples/Pascal/DosExample
@@ -3,11 +3,11 @@ program DosExample;
 uses dos;
 var
   Year, Month, Day, DayOfWeek : Word;
-  Hour, Min, Sec, Sec100 : Word;
+  Hour, Minute, Sec, Sec100 : Word;
 begin
   GetDate(Year, Month, Day, DayOfWeek);
-  GetTime(Hour, Min, Sec, Sec100);
+  GetTime(Hour, Minute, Sec, Sec100);
   writeln('Today is: ', Month, '/', Day, '/', Year);
-  writeln('Current time is: ', Hour, ':', Min, ':', Sec);
+  writeln('Current time is: ', Hour, ':', Minute, ':', Sec);
   writeln('PATH environment variable is: ', GetEnv('PATH'));
 end.

--- a/Examples/clike/builtins.h
+++ b/Examples/clike/builtins.h
@@ -52,6 +52,8 @@ int dos_getfattr();
 int dos_gettime();
 int dos_mkdir();
 int dos_rmdir();
+int getdate();
+int gettime();
 int drawcircle();
 int drawline();
 int drawpolygon();

--- a/lib/pascal/dos.pl
+++ b/lib/pascal/dos.pl
@@ -51,6 +51,16 @@ begin
   GetEnv := dos_getenv(VarName);
 end;
 
+procedure GetDate(var Year, Month, Day, Dow: word);
+begin
+  dos_getdate(Year, Month, Day, Dow);
+end;
+
+procedure GetTime(var Hour, Minute, Second, Sec100: word);
+begin
+  dos_gettime(Hour, Minute, Second, Sec100);
+end;
+
 function Exec(Path, Cmd: string): integer;
 begin
   Exec := dos_exec(Path, Cmd);


### PR DESCRIPTION
## Summary
- Avoid Pascal builtin name collision in DosExample
- Implement GetDate/GetTime wrappers in Pascal DOS unit
- Clarify dos_getdate/dos_gettime signatures and expose CLike prototypes

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd Tests && ./run_all_tests`

------
https://chatgpt.com/codex/tasks/task_e_68ade7f47b50832abf8ce45bee52ead4