### PR TITLE
Fix Chudnovsky term initialization and recurrence

### DIFF
--- a/Examples/clike/chudnovsky_ext
+++ b/Examples/clike/chudnovsky_ext
@@ -3,6 +3,6 @@ int main() {
     long n;
     printf("Please enter an integer value for iterations: ");
     scanf(n);
-    printf("pi: %.15f\n", chudnovsky(n));
+    printf("pi: %.17f\n", chudnovsky(n));
     return 0;
 }

--- a/Examples/clike/chudnovsky_native
+++ b/Examples/clike/chudnovsky_native
@@ -1,11 +1,11 @@
 #!/usr/bin/env clike
 double chudnovsky_native(long n) {
-    double C3 = 262537412640768000.0; // 640320^3
+    const double C3 = 262537412640768000.0; // 640320^3
     double sum = 13591409.0;
-    double term = sum;
+    double term = 1.0;
     for (long k = 1; k < n; k++) {
         double k_d = (double)k;
-        term = term * -(6.0 * k_d - 5.0) * (2.0 * k_d - 1.0) * (6.0 * k_d - 1.0);
+        term = term * -(6.0 * k_d - 5.0) * (2.0 * k_d - 1.0) * (6.0 * k_d - 1.0) * 24.0;
         term = term / (k_d * k_d * k_d * C3);
         sum = sum + term * (13591409.0 + 545140134.0 * k_d);
     }
@@ -16,6 +16,6 @@ int main() {
     long n;
     printf("Please enter an integer value for iterations: ");
     scanf(n);
-    printf("pi: %.15f\n", chudnovsky_native(n));
+    printf("pi: %.17f\n", chudnovsky_native(n));
     return 0;
 }

--- a/src/ext_builtins/chudnovsky.c
+++ b/src/ext_builtins/chudnovsky.c
@@ -19,11 +19,11 @@ static Value vmBuiltinChudnovsky(struct VM_s* vm, int arg_count, Value* args) {
 
     const long double C3 = 262537412640768000.0L; // 640320^3
     long double sum = 13591409.0L;
-    long double term = sum;
+    long double term = 1.0L;
 
     for (long k = 1; k < n; ++k) {
         long double k_d = (long double)k;
-        term *= -(6.0L * k_d - 5.0L) * (2.0L * k_d - 1.0L) * (6.0L * k_d - 1.0L);
+        term *= -(6.0L * k_d - 5.0L) * (2.0L * k_d - 1.0L) * (6.0L * k_d - 1.0L) * 24.0L;
         term /= k_d * k_d * k_d * C3;
         sum += term * (13591409.0L + 545140134.0L * k_d);
     }


### PR DESCRIPTION
## Summary
- initialize Chudnovsky term at 1.0 and apply recurrence factor including 24 multiplier
- accumulate series terms correctly before computing π
- request higher-precision output in chudnovsky_ext and chudnovsky_native examples

## Testing
- `cmake --build build -j$(nproc)`
- `cd Tests && ./run_all_tests`
- `echo 1 | build/bin/clike Examples/clike/chudnovsky_native`
- `echo 1 | build/bin/clike Examples/clike/chudnovsky_ext`
- `gcc -std=c11 /tmp/chudnovsky_verify.c -lm -o /tmp/chud_verify && /tmp/chud_verify`


------
https://chatgpt.com/codex/tasks/task_e_68adf6dddb58832a83484ca2852993f2