### PR TITLE
Refactor VM for expanded numeric types

### DIFF
--- a/Examples/clike/chudnovsky_ext
+++ b/Examples/clike/chudnovsky_ext
@@ -3,6 +3,6 @@ int main() {
     long n;
     printf("Please enter an integer value for iterations: ");
     scanf(n);
-    printf("pi: %.15f\n", chudnovsky(n));
+    printf("pi: %.31f\n", chudnovsky(n));
     return 0;
 }

--- a/Examples/clike/chudnovsky_native
+++ b/Examples/clike/chudnovsky_native
@@ -1,11 +1,11 @@
 #!/usr/bin/env clike
 double chudnovsky_native(long n) {
-    double C3 = 262537412640768000.0; // 640320^3
+    const double C3 = 262537412640768000.0; // 640320^3
     double sum = 13591409.0;
-    double term = sum;
+    double term = 1.0;
     for (long k = 1; k < n; k++) {
         double k_d = (double)k;
-        term = term * -(6.0 * k_d - 5.0) * (2.0 * k_d - 1.0) * (6.0 * k_d - 1.0);
+        term = term * -(6.0 * k_d - 5.0) * (2.0 * k_d - 1.0) * (6.0 * k_d - 1.0) * 24.0;
         term = term / (k_d * k_d * k_d * C3);
         sum = sum + term * (13591409.0 + 545140134.0 * k_d);
     }
@@ -16,6 +16,6 @@ int main() {
     long n;
     printf("Please enter an integer value for iterations: ");
     scanf(n);
-    printf("pi: %.15f\n", chudnovsky_native(n));
+    printf("pi: %.31f\n", chudnovsky_native(n));
     return 0;
 }

--- a/src/Pascal/parser.c
+++ b/src/Pascal/parser.c
@@ -1362,8 +1362,16 @@ AST *typeSpecifier(Parser *parser, int allowAnonymous) {
         } else {
             VarType basicType = TYPE_VOID;
             // ... (checks for integer, real, char, etc.) ...
-             if (strcasecmp(typeNameCopy, "integer") == 0 || strcasecmp(typeNameCopy, "longint") == 0 || strcasecmp(typeNameCopy, "cardinal") == 0) basicType = TYPE_INTEGER;
-             else if (strcasecmp(typeNameCopy, "real") == 0) basicType = TYPE_REAL;
+             if (strcasecmp(typeNameCopy, "integer") == 0) basicType = TYPE_INT32;
+             else if (strcasecmp(typeNameCopy, "longint") == 0) basicType = TYPE_INT64;
+             else if (strcasecmp(typeNameCopy, "cardinal") == 0) basicType = TYPE_UINT32;
+             else if (strcasecmp(typeNameCopy, "shortint") == 0) basicType = TYPE_INT8;
+             else if (strcasecmp(typeNameCopy, "smallint") == 0) basicType = TYPE_INT16;
+             else if (strcasecmp(typeNameCopy, "int64") == 0) basicType = TYPE_INT64;
+             else if (strcasecmp(typeNameCopy, "single") == 0) basicType = TYPE_FLOAT;
+             else if (strcasecmp(typeNameCopy, "double") == 0) basicType = TYPE_DOUBLE;
+             else if (strcasecmp(typeNameCopy, "extended") == 0) basicType = TYPE_LONG_DOUBLE;
+             else if (strcasecmp(typeNameCopy, "real") == 0) basicType = TYPE_DOUBLE;
              else if (strcasecmp(typeNameCopy, "char") == 0) basicType = TYPE_CHAR;
              else if (strcasecmp(typeNameCopy, "byte") == 0) basicType = TYPE_BYTE;
              else if (strcasecmp(typeNameCopy, "word") == 0) basicType = TYPE_WORD;

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -474,7 +474,7 @@ Value vmBuiltinRealtostr(VM* vm, int arg_count, Value* args) {
         return makeString("");
     }
     char buffer[128];
-    snprintf(buffer, sizeof(buffer), "%f", AS_REAL(args[0]));
+    snprintf(buffer, sizeof(buffer), "%Lf", AS_REAL(args[0]));
     return makeString(buffer);
 }
 
@@ -2635,7 +2635,7 @@ Value vmBuiltinStr(VM* vm, int arg_count, Value* args) {
             snprintf(buffer, sizeof(buffer), "%lld", val.i_val);
             break;
         case TYPE_REAL:
-            snprintf(buffer, sizeof(buffer), "%f", val.r_val);
+            snprintf(buffer, sizeof(buffer), "%Lf", val.r_val);
             break;
         case TYPE_CHAR:
             snprintf(buffer, sizeof(buffer), "%c", val.c_val);

--- a/src/clike/opt.c
+++ b/src/clike/opt.c
@@ -1,11 +1,12 @@
 #include "clike/opt.h"
 #include "clike/lexer.h"
 #include "core/types.h"
+#include "core/utils.h"
 #include <stdlib.h>
 
 static int isConst(ASTNodeClike* n, double* out, int* is_float) {
     if (!n || n->type != TCAST_NUMBER) return 0;
-    if (n->var_type == TYPE_REAL) {
+    if (is_real_type(n->var_type)) {
         if (out) *out = n->token.float_val;
         if (is_float) *is_float = 1;
     } else {
@@ -56,7 +57,7 @@ static ASTNodeClike* foldBinary(ASTNodeClike* node) {
         t.float_val = res;
     }
     ASTNodeClike* newNode = newASTNodeClike(TCAST_NUMBER, t);
-    newNode->var_type = result_is_float ? TYPE_REAL : TYPE_INTEGER;
+    newNode->var_type = result_is_float ? TYPE_DOUBLE : TYPE_INT32;
     freeASTClike(node);
     return newNode;
 }
@@ -77,7 +78,7 @@ static ASTNodeClike* foldUnary(ASTNodeClike* node) {
     t.type = CLIKE_TOKEN_NUMBER; t.int_val = (long long)res; t.float_val = res;
     }
     ASTNodeClike* newNode = newASTNodeClike(TCAST_NUMBER, t);
-    newNode->var_type = is_float ? TYPE_REAL : TYPE_INTEGER;
+    newNode->var_type = is_float ? TYPE_DOUBLE : TYPE_INT32;
     freeASTClike(node);
     return newNode;
 }

--- a/src/clike/parser.c
+++ b/src/clike/parser.c
@@ -8,35 +8,26 @@
 
 VarType clike_tokenTypeToVarType(ClikeTokenType t) {
     switch (t) {
-        case CLIKE_TOKEN_INT:
-        case CLIKE_TOKEN_LONG:
-            return TYPE_INTEGER;
-        case CLIKE_TOKEN_FLOAT:
-        case CLIKE_TOKEN_DOUBLE:
-            return TYPE_REAL;
-        case CLIKE_TOKEN_STR:
-            return TYPE_STRING;
-        case CLIKE_TOKEN_TEXT:
-            return TYPE_FILE;
-        case CLIKE_TOKEN_MSTREAM:
-            return TYPE_MEMORYSTREAM;
-        case CLIKE_TOKEN_VOID:
-            return TYPE_VOID;
-        case CLIKE_TOKEN_CHAR:
-            return TYPE_CHAR;
-        case CLIKE_TOKEN_BYTE:
-            return TYPE_BYTE;
-        default:
-            return TYPE_UNKNOWN;
+        case CLIKE_TOKEN_INT:        return TYPE_INT32;
+        case CLIKE_TOKEN_LONG:       return TYPE_INT64;
+        case CLIKE_TOKEN_FLOAT:      return TYPE_FLOAT;
+        case CLIKE_TOKEN_DOUBLE:     return TYPE_DOUBLE;
+        case CLIKE_TOKEN_STR:        return TYPE_STRING;
+        case CLIKE_TOKEN_TEXT:       return TYPE_FILE;
+        case CLIKE_TOKEN_MSTREAM:    return TYPE_MEMORYSTREAM;
+        case CLIKE_TOKEN_VOID:       return TYPE_VOID;
+        case CLIKE_TOKEN_CHAR:       return TYPE_CHAR;
+        case CLIKE_TOKEN_BYTE:       return TYPE_UINT8;
+        default:                     return TYPE_UNKNOWN;
     }
 }
 
 const char *clike_tokenTypeToTypeName(ClikeTokenType t) {
     switch (t) {
-        case CLIKE_TOKEN_INT:
-        case CLIKE_TOKEN_LONG:   return "integer";
-        case CLIKE_TOKEN_FLOAT:
-        case CLIKE_TOKEN_DOUBLE: return "real";
+        case CLIKE_TOKEN_INT:    return "int";
+        case CLIKE_TOKEN_LONG:   return "long";
+        case CLIKE_TOKEN_FLOAT:  return "float";
+        case CLIKE_TOKEN_DOUBLE: return "double";
         case CLIKE_TOKEN_STR:    return "string";
         case CLIKE_TOKEN_TEXT:   return "text";
         case CLIKE_TOKEN_MSTREAM:return "mstream";
@@ -49,9 +40,9 @@ const char *clike_tokenTypeToTypeName(ClikeTokenType t) {
 
 static VarType literalTokenToVarType(ClikeTokenType t) {
     switch (t) {
-        case CLIKE_TOKEN_FLOAT_LITERAL: return TYPE_REAL;
-        case CLIKE_TOKEN_CHAR_LITERAL: return TYPE_CHAR;
-        default: return TYPE_INTEGER;
+        case CLIKE_TOKEN_FLOAT_LITERAL: return TYPE_DOUBLE;
+        case CLIKE_TOKEN_CHAR_LITERAL:  return TYPE_CHAR;
+        default:                        return TYPE_INT32;
     }
 }
 

--- a/src/compiler/bytecode.c
+++ b/src/compiler/bytecode.c
@@ -258,7 +258,7 @@ int disassembleInstruction(BytecodeChunk* chunk, int offset, HashTable* procedur
             Value constantValue = chunk->constants[constant_index];
             switch(constantValue.type) {
                 case TYPE_INTEGER: printf("%lld", constantValue.i_val); break;
-                case TYPE_REAL:    printf("%f", constantValue.r_val); break;
+                case TYPE_REAL:    printf("%Lf", constantValue.r_val); break;
                 case TYPE_STRING:  printf("%s", constantValue.s_val ? constantValue.s_val : "NULL_STR"); break;
                 case TYPE_CHAR:    printf("%c", constantValue.c_val); break;
                 case TYPE_BOOLEAN: printf("%s", constantValue.i_val ? "true" : "false"); break;
@@ -279,7 +279,7 @@ int disassembleInstruction(BytecodeChunk* chunk, int offset, HashTable* procedur
             Value constantValue = chunk->constants[constant_index];
             switch(constantValue.type) {
                 case TYPE_INTEGER: printf("%lld", constantValue.i_val); break;
-                case TYPE_REAL:    printf("%f", constantValue.r_val); break;
+                case TYPE_REAL:    printf("%Lf", constantValue.r_val); break;
                 case TYPE_STRING:  printf("%s", constantValue.s_val ? constantValue.s_val : "NULL_STR"); break;
                 case TYPE_CHAR:    printf("%c", constantValue.c_val); break;
                 case TYPE_BOOLEAN: printf("%s", constantValue.i_val ? "true" : "false"); break;
@@ -691,7 +691,7 @@ void disassembleBytecodeChunk(BytecodeChunk* chunk, const char* name, HashTable*
             Value constantValue = chunk->constants[i];
             switch(constantValue.type) {
                 case TYPE_INTEGER: printf("INT   %lld\n", constantValue.i_val); break;
-                case TYPE_REAL:    printf("REAL  %f\n", constantValue.r_val); break;
+                case TYPE_REAL:    printf("REAL  %Lf\n", constantValue.r_val); break;
                 case TYPE_STRING:  printf("STR   \"%s\"\n", constantValue.s_val ? constantValue.s_val : "NULL_STR"); break;
                 case TYPE_CHAR:    printf("CHAR  '%c'\n", constantValue.c_val); break;
                 case TYPE_BOOLEAN: printf("BOOL  %s\n", constantValue.i_val ? "true" : "false"); break;

--- a/src/core/types.c
+++ b/src/core/types.c
@@ -1,4 +1,5 @@
 #include "types.h"
+#include "utils.h"
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -16,8 +17,8 @@ void setTypeValue(Value *val, VarType type) {
 // Infer the type of a binary operation based on operand types
 VarType inferBinaryOpType(VarType left, VarType right) {
     if (left == TYPE_STRING || right == TYPE_STRING) return TYPE_STRING;
-    if (left == TYPE_REAL || right == TYPE_REAL) return TYPE_REAL;
-    if (left == TYPE_INTEGER && right == TYPE_INTEGER) return TYPE_INTEGER;
+    if (is_real_type(left) || is_real_type(right)) return TYPE_REAL;
+    if (is_intlike_type(left) && is_intlike_type(right)) return TYPE_INTEGER;
     if (left == TYPE_BOOLEAN && right == TYPE_BOOLEAN) return TYPE_BOOLEAN;
     if (left == TYPE_CHAR && right == TYPE_CHAR) return TYPE_STRING; // for '+'
     return TYPE_VOID; // fallback

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -8,6 +8,7 @@
 #include <ctype.h>
 #include <math.h>
 #include <time.h>
+#include <stdint.h>
 #include "list.h"
 #include <stdbool.h>
 
@@ -40,6 +41,18 @@ typedef enum {
     TYPE_MEMORYSTREAM,
     TYPE_SET,
     TYPE_POINTER,
+    /* Extended integer and floating-point types */
+    TYPE_INT8,
+    TYPE_UINT8,
+    TYPE_INT16,
+    TYPE_UINT16,
+    TYPE_INT32,
+    TYPE_UINT32,
+    TYPE_INT64,
+    TYPE_UINT64,
+    TYPE_FLOAT,
+    TYPE_DOUBLE,
+    TYPE_LONG_DOUBLE,
     TYPE_NIL
 } VarType;
 
@@ -64,7 +77,10 @@ typedef struct ValueStruct {
     Type *enum_meta;
     union {
         long long i_val;
-        double r_val;
+        unsigned long long u_val;
+        float f32_val;
+        double d_val;
+        long double r_val;
         char *s_val;
         int c_val;
         FieldValue *record_val;

--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -34,6 +34,17 @@ const char *varTypeToString(VarType type) {
         case TYPE_MEMORYSTREAM: return "MEMORY_STREAM";
         case TYPE_SET:          return "SET";
         case TYPE_POINTER:      return "POINTER";
+        case TYPE_INT8:         return "INT8";
+        case TYPE_UINT8:        return "UINT8";
+        case TYPE_INT16:        return "INT16";
+        case TYPE_UINT16:       return "UINT16";
+        case TYPE_INT32:        return "INT32";
+        case TYPE_UINT32:       return "UINT32";
+        case TYPE_INT64:        return "INT64";
+        case TYPE_UINT64:       return "UINT64";
+        case TYPE_FLOAT:        return "FLOAT";
+        case TYPE_DOUBLE:       return "DOUBLE";
+        case TYPE_LONG_DOUBLE:  return "LONG_DOUBLE";
         case TYPE_NIL:          return "NIL";
         default:                return "UNKNOWN_VAR_TYPE";
     }
@@ -327,7 +338,7 @@ Value makeInt(long long val) {
     return v;
 }
 
-Value makeReal(double val) {
+Value makeReal(long double val) {
     Value v;
     memset(&v, 0, sizeof(Value));
     v.type = TYPE_REAL;
@@ -555,7 +566,7 @@ Value makeValueForType(VarType type, AST *type_def_param, Symbol* context_symbol
 
     switch(type) {
         case TYPE_INTEGER: v.i_val = 0; break;
-        case TYPE_REAL:    v.r_val = 0.0; break;
+        case TYPE_REAL:    v.r_val = 0.0L; break;
         case TYPE_STRING: {
             v.s_val = NULL;
             v.max_length = -1;
@@ -1085,7 +1096,7 @@ void dumpSymbol(Symbol *sym) {
                 printf("%lld", sym->value->i_val);
                 break;
             case TYPE_REAL:
-                printf("%f", sym->value->r_val);
+                printf("%Lf", sym->value->r_val);
                 break;
             case TYPE_STRING:
                 printf("\"%s\"", sym->value->s_val ? sym->value->s_val : "(null)");
@@ -1577,7 +1588,7 @@ void printValueToStream(Value v, FILE *stream) {
             fprintf(stream, "%lld", v.i_val);
             break;
         case TYPE_REAL:
-            fprintf(stream, "%f", v.r_val);
+            fprintf(stream, "%Lf", v.r_val);
             break;
         case TYPE_BOOLEAN:
             fprintf(stream, "%s", v.i_val ? "TRUE" : "FALSE"); // Boolean still uses i_val

--- a/src/ext_builtins/chudnovsky.c
+++ b/src/ext_builtins/chudnovsky.c
@@ -5,31 +5,31 @@
 static Value vmBuiltinChudnovsky(struct VM_s* vm, int arg_count, Value* args) {
     if (arg_count != 1) {
         runtimeError(vm, "Chudnovsky expects exactly 1 argument.");
-        return makeReal(0.0);
+        return makeReal(0.0L);
     }
     if (args[0].type != TYPE_INTEGER) {
         runtimeError(vm, "Chudnovsky argument must be an integer.");
-        return makeReal(0.0);
+        return makeReal(0.0L);
     }
     long n = args[0].i_val;
     if (n <= 0) {
         runtimeError(vm, "Chudnovsky argument must be positive.");
-        return makeReal(0.0);
+        return makeReal(0.0L);
     }
 
     const long double C3 = 262537412640768000.0L; // 640320^3
     long double sum = 13591409.0L;
-    long double term = sum;
+    long double term = 1.0L;
 
     for (long k = 1; k < n; ++k) {
         long double k_d = (long double)k;
-        term *= -(6.0L * k_d - 5.0L) * (2.0L * k_d - 1.0L) * (6.0L * k_d - 1.0L);
+        term *= -(6.0L * k_d - 5.0L) * (2.0L * k_d - 1.0L) * (6.0L * k_d - 1.0L) * 24.0L;
         term /= k_d * k_d * k_d * C3;
         sum += term * (13591409.0L + 545140134.0L * k_d);
     }
 
     long double pi = 426880.0L * sqrtl(10005.0L) / sum;
-    return makeReal((double)pi);
+    return makeReal(pi);
 }
 
 void registerChudnovskyBuiltin(void) {

--- a/src/symbol/symbol.c
+++ b/src/symbol/symbol.c
@@ -725,8 +725,8 @@ void updateSymbol(const char *name, Value val) {
 
         case TYPE_REAL:
             if (val.type == TYPE_REAL) sym->value->r_val = val.r_val;
-            else if (val.type == TYPE_INTEGER) sym->value->r_val = (double)val.i_val;
-            else if (val.type == TYPE_CHAR) sym->value->r_val = (double)val.c_val;
+            else if (val.type == TYPE_INTEGER) sym->value->r_val = (long double)val.i_val;
+            else if (val.type == TYPE_CHAR) sym->value->r_val = (long double)val.c_val;
             break;
 
         case TYPE_BYTE:

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -721,9 +721,9 @@ InterpretResult interpretBytecode(VM* vm, BytecodeChunk* chunk, HashTable* globa
         if (!op_is_handled) { \
             if (IS_NUMERIC(a_val_popped) && IS_NUMERIC(b_val_popped)) { \
                 if (IS_REAL(a_val_popped) || IS_REAL(b_val_popped)) { \
-                    double fa = as_f64(a_val_popped); \
-                    double fb = as_f64(b_val_popped); \
-                    if (current_instruction_code == OP_DIVIDE && fb == 0.0) { \
+                    long double fa = as_ld(a_val_popped); \
+                    long double fb = as_ld(b_val_popped); \
+                    if (current_instruction_code == OP_DIVIDE && fb == 0.0L) { \
                         runtimeError(vm, "Runtime Error: Division by zero."); \
                         freeValue(&a_val_popped); freeValue(&b_val_popped); \
                         return INTERPRET_RUNTIME_ERROR; \
@@ -759,7 +759,7 @@ InterpretResult interpretBytecode(VM* vm, BytecodeChunk* chunk, HashTable* globa
                             overflow = __builtin_mul_overflow(ia, ib, &iresult); \
                             break; \
                         case OP_DIVIDE: \
-                            result_val = makeReal((double)ia / (double)ib); \
+                            result_val = makeReal((long double)ia / (long double)ib); \
                             break; \
                         default: \
                             runtimeError(vm, "Runtime Error: Invalid arithmetic opcode %d for integers.", current_instruction_code); \
@@ -1124,8 +1124,8 @@ InterpretResult interpretBytecode(VM* vm, BytecodeChunk* chunk, HashTable* globa
                 // Numeric comparison (Integers and Reals)
                 else if (IS_NUMERIC(a_val) && IS_NUMERIC(b_val)) {
                     if (a_val.type == TYPE_REAL || b_val.type == TYPE_REAL) {
-                        double fa = as_f64(a_val);
-                        double fb = as_f64(b_val);
+                        long double fa = as_ld(a_val);
+                        long double fb = as_ld(b_val);
                         switch (instruction_val) {
                             case OP_EQUAL:         result_val = makeBoolean(fa == fb); break;
                             case OP_NOT_EQUAL:     result_val = makeBoolean(fa != fb); break;
@@ -1668,7 +1668,7 @@ comparison_error_label:
                         }
                     }
                     else if (target_lvalue_ptr->type == TYPE_REAL && value_to_set.type == TYPE_INTEGER) {
-                        target_lvalue_ptr->r_val = (double)value_to_set.i_val;
+                        target_lvalue_ptr->r_val = (long double)value_to_set.i_val;
                     }
                     else if (target_lvalue_ptr->type == TYPE_BYTE && value_to_set.type == TYPE_INTEGER) {
                         if (value_to_set.i_val < 0 || value_to_set.i_val > 255) {
@@ -2469,9 +2469,9 @@ comparison_error_label:
 
                 if (raw_val.type == TYPE_REAL) {
                     if (precision >= 0) {
-                        snprintf(buf, sizeof(buf), "%*.*f", width, precision, raw_val.r_val);
+                        snprintf(buf, sizeof(buf), "%*.*Lf", width, precision, raw_val.r_val);
                     } else {
-                        snprintf(buf, sizeof(buf), "%*.*E", width, PASCAL_DEFAULT_FLOAT_PRECISION, raw_val.r_val);
+                        snprintf(buf, sizeof(buf), "%*.*LE", width, PASCAL_DEFAULT_FLOAT_PRECISION, raw_val.r_val);
                     }
                 } else if (raw_val.type == TYPE_INTEGER || raw_val.type == TYPE_BYTE || raw_val.type == TYPE_WORD) {
                     snprintf(buf, sizeof(buf), "%*lld", width, raw_val.i_val);


### PR DESCRIPTION
## Summary
- add explicit VarType identifiers and value slots for 8–64 bit integers and 32/64/80-bit floats
- provide helpers to classify integer and floating point kinds across the runtime
- teach C-like and Pascal front-ends to map common type keywords to the new VarTypes and update code generation/semantics accordingly

## Testing
- `cmake --build build -j$(nproc)`
- `cd Tests && ./run_all_tests` *(fails: ArgumentOrderMismatch, ArgumentTypeMismatch, ArrayArgumentMismatch, BitwiseAndExprSuite, BytecodeVerificationTest, CaseStatementSuite, CommandLineParamTest)*

------
https://chatgpt.com/codex/tasks/task_e_68adf6dddb58832a83484ca2852993f2