### PR TITLE
Add explicit INT32/DOUBLE type support

### DIFF
--- a/src/core/types.h
+++ b/src/core/types.h
@@ -26,8 +26,8 @@ typedef struct FieldValue FieldValue;
 typedef enum {
     TYPE_UNKNOWN = 0,
     TYPE_VOID,
-    TYPE_INTEGER,
-    TYPE_REAL,
+    TYPE_INT32,
+    TYPE_DOUBLE,
     TYPE_STRING,
     TYPE_CHAR,
     TYPE_RECORD,
@@ -42,6 +42,21 @@ typedef enum {
     TYPE_POINTER,
     TYPE_NIL
 } VarType;
+
+/*
+ * Backwards compatibility aliases.
+ *
+ * Pascal traditionally exposes INTEGER and REAL as its fundamental numeric
+ * types.  The VM has been moving toward a more explicit naming scheme where
+ * the underlying sizes are part of the type name (e.g. INT32 and DOUBLE).
+ *
+ * To avoid a massive churn throughout the existing front‑ends we simply map
+ * the old identifiers to the new ones via macros.  This allows legacy code
+ * that still uses TYPE_INTEGER/TYPE_REAL to compile unchanged while the rest
+ * of the system can reason about the new INT32/DOUBLE symbols.
+ */
+#define TYPE_INTEGER TYPE_INT32
+#define TYPE_REAL    TYPE_DOUBLE
 
 typedef struct MStream {
     unsigned char *buffer;

--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -20,8 +20,8 @@
 const char *varTypeToString(VarType type) {
     switch (type) {
         case TYPE_VOID:         return "VOID";
-        case TYPE_INTEGER:      return "INTEGER";
-        case TYPE_REAL:         return "REAL";
+        case TYPE_INT32:        return "INTEGER";
+        case TYPE_DOUBLE:       return "REAL";
         case TYPE_STRING:       return "STRING";
         case TYPE_CHAR:         return "CHAR";
         case TYPE_RECORD:       return "RECORD";
@@ -322,7 +322,7 @@ void freeFieldValue(FieldValue *fv) {
 Value makeInt(long long val) {
     Value v;
     memset(&v, 0, sizeof(Value)); // Initialize all fields to 0/NULL
-    v.type = TYPE_INTEGER;
+    v.type = TYPE_INT32;
     v.i_val = val;
     return v;
 }
@@ -330,7 +330,7 @@ Value makeInt(long long val) {
 Value makeReal(double val) {
     Value v;
     memset(&v, 0, sizeof(Value));
-    v.type = TYPE_REAL;
+    v.type = TYPE_DOUBLE;
     v.r_val = val;
     return v;
 }
@@ -554,8 +554,8 @@ Value makeValueForType(VarType type, AST *type_def_param, Symbol* context_symbol
     }
 
     switch(type) {
-        case TYPE_INTEGER: v.i_val = 0; break;
-        case TYPE_REAL:    v.r_val = 0.0; break;
+        case TYPE_INT32:  v.i_val = 0;   break;
+        case TYPE_DOUBLE: v.r_val = 0.0; break;
         case TYPE_STRING: {
             v.s_val = NULL;
             v.max_length = -1;
@@ -576,7 +576,7 @@ Value makeValueForType(VarType type, AST *type_def_param, Symbol* context_symbol
                      #endif
                      Symbol *constSym = lookupSymbol(const_name);
 
-                     if (constSym && constSym->is_const && constSym->value && constSym->value->type == TYPE_INTEGER) {
+                    if (constSym && constSym->is_const && constSym->value && constSym->value->type == TYPE_INT32) {
                           parsed_len = constSym->value->i_val;
                           #ifdef DEBUG
                           fprintf(stderr, "[DEBUG makeValueForType] Found constant '%s' with value %lld.\n", const_name, parsed_len);
@@ -657,8 +657,8 @@ Value makeValueForType(VarType type, AST *type_def_param, Symbol* context_symbol
                        if (elemType == TYPE_VOID) {
                              if (elemTypeDefNode->type == AST_VARIABLE && elemTypeDefNode->token) {
                                  const char *tn = elemTypeDefNode->token->value;
-                                 if (strcasecmp(tn, "integer") == 0) elemType = TYPE_INTEGER;
-                                 else if (strcasecmp(tn, "real") == 0) elemType = TYPE_REAL;
+                                 if (strcasecmp(tn, "integer") == 0) elemType = TYPE_INT32;
+                                 else if (strcasecmp(tn, "real") == 0) elemType = TYPE_DOUBLE;
                                  else if (strcasecmp(tn, "char") == 0) elemType = TYPE_CHAR;
                                  else if (strcasecmp(tn, "boolean") == 0) elemType = TYPE_BOOLEAN;
                                  else if (strcasecmp(tn, "byte") == 0) elemType = TYPE_BYTE;
@@ -698,7 +698,7 @@ Value makeValueForType(VarType type, AST *type_def_param, Symbol* context_symbol
                          Value low_val = evaluateCompileTimeValue(subrange->left);
                          Value high_val = evaluateCompileTimeValue(subrange->right);
 
-                         if (low_val.type == TYPE_INTEGER && high_val.type == TYPE_INTEGER) {
+                        if (low_val.type == TYPE_INT32 && high_val.type == TYPE_INT32) {
                              lbs[i] = (int)low_val.i_val;
                              ubs[i] = (int)high_val.i_val;
                          } else {
@@ -893,8 +893,8 @@ void freeValue(Value *v) {
 //#endif
     switch (v->type) {
         case TYPE_VOID:
-        case TYPE_INTEGER:
-        case TYPE_REAL:
+        case TYPE_INT32:
+        case TYPE_DOUBLE:
         case TYPE_BOOLEAN:
         case TYPE_CHAR:
         case TYPE_BYTE:
@@ -1081,10 +1081,10 @@ void dumpSymbol(Symbol *sym) {
     if (sym->value) {
         printf(", Value: ");
         switch (sym->type) {
-            case TYPE_INTEGER:
+            case TYPE_INT32:
                 printf("%lld", sym->value->i_val);
                 break;
-            case TYPE_REAL:
+            case TYPE_DOUBLE:
                 printf("%f", sym->value->r_val);
                 break;
             case TYPE_STRING:
@@ -1573,10 +1573,10 @@ void printValueToStream(Value v, FILE *stream) {
     }
 
     switch (v.type) {
-        case TYPE_INTEGER:
+        case TYPE_INT32:
             fprintf(stream, "%lld", v.i_val);
             break;
-        case TYPE_REAL:
+        case TYPE_DOUBLE:
             fprintf(stream, "%f", v.r_val);
             break;
         case TYPE_BOOLEAN:

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -32,9 +32,9 @@
 #define AS_BOOLEAN(value) ((value).i_val != 0) // Assumes i_val stores 0 for false, 1 for true
 
 // Also useful:
-#define IS_INTEGER(value) ((value).type == TYPE_INTEGER)
+#define IS_INTEGER(value) ((value).type == TYPE_INT32)
 #define AS_INTEGER(value) ((value).i_val)
-#define IS_REAL(value)    ((value).type == TYPE_REAL)
+#define IS_REAL(value)    ((value).type == TYPE_DOUBLE)
 #define AS_REAL(value)    ((value).r_val)
 #define IS_STRING(value)  ((value).type == TYPE_STRING)
 #define AS_STRING(value)  ((value).s_val)
@@ -56,7 +56,7 @@ static const int pscalToAnsiBase[8] = {
 };
 
 static inline bool is_intlike_type(VarType t) {
-    return t == TYPE_INTEGER || t == TYPE_WORD || t == TYPE_BYTE;
+    return t == TYPE_INT32 || t == TYPE_WORD || t == TYPE_BYTE;
 }
 
 static inline bool is_ordinal_type(VarType t) {
@@ -89,7 +89,7 @@ static inline long long as_i64(Value v) {
     return v.i_val; // INTEGER, BYTE, WORD, BOOLEAN all use i_val
 }
 static inline double as_f64(Value v) {
-    return (v.type == TYPE_REAL) ? v.r_val : (double)v.i_val;
+    return (v.type == TYPE_DOUBLE) ? v.r_val : (double)v.i_val;
 }
 
 const char *varTypeToString(VarType type);


### PR DESCRIPTION
## Summary
- Introduce INT32 and DOUBLE into VarType and map legacy INTEGER/REAL aliases
- Update runtime helpers and constructors to work with new numeric tags
- Expose Pascal-facing names for new types in `varTypeToString`

## Testing
- `./run_pascal_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ae10f0e44c832a96e7c780e989b7c1