### PR TITLE
Fix duplicated type enums after merge

### DIFF
--- a/src/core/types.h
+++ b/src/core/types.h
@@ -46,12 +46,10 @@ typedef enum {
     TYPE_UINT8,
     TYPE_INT16,
     TYPE_UINT16,
-    TYPE_INT32,
     TYPE_UINT32,
     TYPE_INT64,
     TYPE_UINT64,
     TYPE_FLOAT,
-    TYPE_DOUBLE,
     TYPE_LONG_DOUBLE,
     TYPE_NIL
 } VarType;

--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -38,12 +38,10 @@ const char *varTypeToString(VarType type) {
         case TYPE_UINT8:        return "UINT8";
         case TYPE_INT16:        return "INT16";
         case TYPE_UINT16:       return "UINT16";
-        case TYPE_INT32:        return "INT32";
         case TYPE_UINT32:       return "UINT32";
         case TYPE_INT64:        return "INT64";
         case TYPE_UINT64:       return "UINT64";
         case TYPE_FLOAT:        return "FLOAT";
-        case TYPE_DOUBLE:       return "DOUBLE";
         case TYPE_LONG_DOUBLE:  return "LONG_DOUBLE";
         case TYPE_NIL:          return "NIL";
         default:                return "UNKNOWN_VAR_TYPE";
@@ -1587,10 +1585,14 @@ void printValueToStream(Value v, FILE *stream) {
         case TYPE_INT32:
             fprintf(stream, "%lld", v.i_val);
             break;
-        case TYPE_REAL:
-            fprintf(stream, "%Lf", v.r_val);
+        case TYPE_FLOAT:
+            fprintf(stream, "%f", v.f32_val);
+            break;
         case TYPE_DOUBLE:
-            fprintf(stream, "%f", v.r_val);
+            fprintf(stream, "%f", v.d_val);
+            break;
+        case TYPE_LONG_DOUBLE:
+            fprintf(stream, "%Lf", v.r_val);
             break;
         case TYPE_BOOLEAN:
             fprintf(stream, "%s", v.i_val ? "TRUE" : "FALSE"); // Boolean still uses i_val

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -57,7 +57,6 @@ static const int pscalToAnsiBase[8] = {
 
 static inline bool is_intlike_type(VarType t) {
     switch (t) {
-        case TYPE_INTEGER:
         case TYPE_WORD:
         case TYPE_BYTE:
         case TYPE_INT8:
@@ -76,7 +75,6 @@ static inline bool is_intlike_type(VarType t) {
 
 static inline bool is_real_type(VarType t) {
     switch (t) {
-        case TYPE_REAL:
         case TYPE_FLOAT:
         case TYPE_DOUBLE:
         case TYPE_LONG_DOUBLE:
@@ -84,8 +82,6 @@ static inline bool is_real_type(VarType t) {
         default:
             return false;
     }
-
-    return t == TYPE_INT32 || t == TYPE_WORD || t == TYPE_BYTE;
 }
 
 static inline bool is_ordinal_type(VarType t) {
@@ -103,7 +99,6 @@ static inline long long coerce_to_i64(const Value* v, VM* vm, const char* who) {
         case TYPE_WORD:
         case TYPE_BYTE:
             return (long long)v->u_val;
-        case TYPE_INTEGER:
         case TYPE_INT64:
         case TYPE_INT32:
         case TYPE_INT16:
@@ -141,8 +136,7 @@ static inline long double as_ld(Value v) {
         switch (v.type) {
             case TYPE_FLOAT:       return v.f32_val;
             case TYPE_DOUBLE:      return v.d_val;
-            case TYPE_LONG_DOUBLE:
-            case TYPE_REAL:        return v.r_val;
+            case TYPE_LONG_DOUBLE: return v.r_val;
             default:               return v.r_val;
         }
     }


### PR DESCRIPTION
## Summary
- de-duplicate VarType enum and keep explicit INT32/DOUBLE entries
- update utility helpers to match new enum layout and handle floats precisely

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd Tests && make test`

------
https://chatgpt.com/codex/tasks/task_e_68ae17e36a68832a923833685145bb74