### PR TITLE
Fix type coercion and float read handling

### DIFF
--- a/Tests/Pascal/SDLFeaturesTest.out
+++ b/Tests/Pascal/SDLFeaturesTest.out
@@ -1,0 +1,1 @@
+Test program finished.

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -477,10 +477,7 @@ Value vmBuiltinRealtostr(VM* vm, int arg_count, Value* args) {
         return makeString("");
     }
     char buffer[128];
-    if (args[0].type == TYPE_FLOAT)
-        snprintf(buffer, sizeof(buffer), "%f", args[0].f32_val);
-    else
-        snprintf(buffer, sizeof(buffer), "%Lf", AS_REAL(args[0]));
+    snprintf(buffer, sizeof(buffer), "%Lf", AS_REAL(args[0]));
     return makeString(buffer);
 }
 
@@ -2059,8 +2056,6 @@ Value vmBuiltinRead(VM* vm, int arg_count, Value* args) {
                 errno = 0;
                 float v = strtof(buffer, NULL);
                 if (errno == ERANGE) { last_io_error = 1; v = 0.0f; }
-                dst->f32_val = v;
-                dst->d_val = v;
                 dst->r_val = v;
                 break;
             }
@@ -2069,7 +2064,6 @@ Value vmBuiltinRead(VM* vm, int arg_count, Value* args) {
                 double v = strtod(buffer, NULL);
                 if (errno == ERANGE) { last_io_error = 1; v = 0.0; }
                 dst->r_val = v;
-                dst->d_val = v;
                 break;
             }
             case TYPE_BOOLEAN: {
@@ -2184,8 +2178,6 @@ Value vmBuiltinReadln(VM* vm, int arg_count, Value* args) {
                 char* endp = NULL;
                 float v = strtof(p, &endp);
                 if (endp == p || errno == ERANGE) { last_io_error = 1; v = 0.0f; }
-                dst->f32_val = v;
-                dst->d_val = v;
                 dst->r_val = v;
                 p = endp ? endp : p;
                 break;
@@ -2196,7 +2188,6 @@ Value vmBuiltinReadln(VM* vm, int arg_count, Value* args) {
                 double v = strtod(p, &endp);
                 if (endp == p || errno == ERANGE) { last_io_error = 1; v = 0.0; }
                 dst->r_val = v;
-                dst->d_val = v;
                 p = endp ? endp : p;
                 break;
             }
@@ -2335,14 +2326,7 @@ Value vmBuiltinVal(VM* vm, int arg_count, Value* args) {
         if (errno != 0 || (endptr && *endptr != '\0')) {
             *code = makeInt((int)((endptr ? endptr : s) - s) + 1);
         } else {
-            if (dst->type == TYPE_FLOAT) {
-                dst->f32_val = (float)r;
-                dst->d_val = (float)r;
-                dst->r_val = (float)r;
-            } else {
-                dst->r_val = r;
-                dst->d_val = r;
-            }
+            dst->r_val = r;
             *code = makeInt(0);
         }
     } else {
@@ -2747,9 +2731,8 @@ Value vmBuiltinStr(VM* vm, int arg_count, Value* args) {
             snprintf(buffer, sizeof(buffer), "%lld", val.i_val);
             break;
         case TYPE_FLOAT:
-            snprintf(buffer, sizeof(buffer), "%f", val.f32_val);
-            break;
         case TYPE_REAL:
+        case TYPE_LONG_DOUBLE:
             snprintf(buffer, sizeof(buffer), "%Lf", val.r_val);
             break;
         case TYPE_CHAR:

--- a/src/clike/codegen.c
+++ b/src/clike/codegen.c
@@ -525,8 +525,6 @@ static void compileStatement(ASTNodeClike *node, BytecodeChunk *chunk, FuncConte
                     Value init;
                     if (is_real_type(node->var_type)) {
                         init = makeReal(0.0);
-                        if (node->var_type == TYPE_FLOAT) init.f32_val = 0.0f;
-                else if (node->var_type == TYPE_DOUBLE) init.d_val = 0.0;
                         init.type = node->var_type;
                     } else {
                         switch (node->var_type) {
@@ -611,7 +609,6 @@ static void compileExpression(ASTNodeClike *node, BytecodeChunk *chunk, FuncCont
             Value v;
             if (node->token.type == CLIKE_TOKEN_FLOAT_LITERAL) {
                 v = makeReal(node->token.float_val);
-                v.d_val = node->token.float_val;
                 v.type = TYPE_DOUBLE;
             } else if (node->token.type == CLIKE_TOKEN_CHAR_LITERAL ||
                        node->var_type == TYPE_CHAR) {

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -237,6 +237,17 @@ static bool typesMatch(AST* param_type, AST* arg_node, bool allow_coercion) {
                  arg_vt == TYPE_ENUM    || arg_vt == TYPE_CHAR)) {
                 return true;
             }
+            // Permit wider integer arguments (e.g. LONGINT/INT64, CARDINAL/UINT32)
+            // to match INTEGER parameters.  Traditional Pascal routinely allows
+            // these values to be passed to routines expecting INTEGER so long as
+            // the caller explicitly requests it.  Our VM stores the value's
+            // actual type in the Value struct, so the callee will still receive
+            // the full precision.
+            if (param_actual->var_type == TYPE_INTEGER &&
+                (arg_vt == TYPE_INT64 || arg_vt == TYPE_UINT64 ||
+                 arg_vt == TYPE_UINT32)) {
+                return true;
+            }
             return false;
         }
     } else if (!arg_actual) {

--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -340,7 +340,6 @@ Value makeReal(long double val) {
     Value v;
     memset(&v, 0, sizeof(Value));
     v.type = TYPE_DOUBLE;
-    v.d_val = (double)val;
     v.r_val = val;
     return v;
 }
@@ -565,9 +564,14 @@ Value makeValueForType(VarType type, AST *type_def_param, Symbol* context_symbol
 
     switch(type) {
         case TYPE_INT32:  v.i_val = 0;   break;
-        case TYPE_FLOAT:  v.f32_val = 0.0f; v.d_val = 0.0; v.r_val = 0.0; break;
-        case TYPE_DOUBLE: v.d_val = 0.0; v.r_val = 0.0; break;
-        case TYPE_LONG_DOUBLE: v.r_val = 0.0L; v.d_val = 0.0; break;
+        case TYPE_INT64:  v.i_val = 0;   break;
+        case TYPE_UINT32: v.u_val = 0;   break;
+        case TYPE_UINT64: v.u_val = 0;   break;
+        case TYPE_FLOAT:
+        case TYPE_DOUBLE:
+        case TYPE_LONG_DOUBLE:
+            v.r_val = 0.0L;
+            break;
         case TYPE_STRING: {
             v.s_val = NULL;
             v.max_length = -1;
@@ -1096,8 +1100,12 @@ void dumpSymbol(Symbol *sym) {
             case TYPE_INT32:
                 printf("%lld", sym->value->i_val);
                 break;
+            case TYPE_FLOAT:
             case TYPE_DOUBLE:
-                printf("%f", sym->value->r_val);
+                printf("%f", (double)sym->value->r_val);
+                break;
+            case TYPE_LONG_DOUBLE:
+                printf("%Lf", sym->value->r_val);
                 break;
             case TYPE_STRING:
                 printf("\"%s\"", sym->value->s_val ? sym->value->s_val : "(null)");
@@ -1589,10 +1597,8 @@ void printValueToStream(Value v, FILE *stream) {
             fprintf(stream, "%lld", v.i_val);
             break;
         case TYPE_FLOAT:
-            fprintf(stream, "%f", v.f32_val);
-            break;
         case TYPE_DOUBLE:
-            fprintf(stream, "%f", v.d_val);
+            fprintf(stream, "%f", (double)v.r_val);
             break;
         case TYPE_LONG_DOUBLE:
             fprintf(stream, "%Lf", v.r_val);

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -133,12 +133,7 @@ static inline long long as_i64(Value v) {
 }
 static inline long double as_ld(Value v) {
     if (is_real_type(v.type)) {
-        switch (v.type) {
-            case TYPE_FLOAT:       return v.f32_val;
-            case TYPE_DOUBLE:      return v.d_val;
-            case TYPE_LONG_DOUBLE: return v.r_val;
-            default:               return v.r_val;
-        }
+        return v.r_val;
     }
     return (long double)as_i64(v);
 }

--- a/src/symbol/symbol.c
+++ b/src/symbol/symbol.c
@@ -726,16 +726,10 @@ void updateSymbol(const char *name, Value val) {
         case TYPE_REAL:
             if (is_real_type(val.type)) {
                 sym->value->r_val = val.r_val;
-                sym->value->d_val = val.d_val;
-                sym->value->f32_val = val.f32_val;
             } else if (val.type == TYPE_INTEGER) {
                 sym->value->r_val = (long double)val.i_val;
-                sym->value->d_val = (double)val.i_val;
-                sym->value->f32_val = (float)val.i_val;
             } else if (val.type == TYPE_CHAR) {
                 sym->value->r_val = (long double)val.c_val;
-                sym->value->d_val = (double)val.c_val;
-                sym->value->f32_val = (float)val.c_val;
             }
             break;
 


### PR DESCRIPTION
## Summary
- allow INT64/UINT32 parameters where INTEGER is expected
- correct `readln` float parsing to preserve 32-bit float values
- initialize additional integer types and add SDL features test output
- normalize real storage to use long double consistently and simplify real parsing

## Testing
- `./run_pascal_tests.sh`
- `./run_clike_tests.sh`
- `./run_tiny_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ae29acfff4832a943717665fa4bcb6