### PR TITLE
Use extended real types in Chudnovsky demos and builtin

### DIFF
--- a/Examples/clike/chudnovsky_ext
+++ b/Examples/clike/chudnovsky_ext
@@ -3,7 +3,8 @@ int main() {
     long n;
     printf("Please enter an integer value for iterations: ");
     scanf(n);
-    
-    printf("pi: %.31f\n", chudnovsky(n));
+
+    long double pi = chudnovsky(n);
+    printf("pi: %.31Lf\n", pi);
     return 0;
 }

--- a/Examples/clike/chudnovsky_native
+++ b/Examples/clike/chudnovsky_native
@@ -1,15 +1,15 @@
 #!/usr/bin/env clike
-double chudnovsky_native(long n) {
-    const double C3 = 262537412640768000.0; // 640320^3
-    double sum = 13591409.0;
-    double term = 1.0;
+long double chudnovsky_native(long n) {
+    const long double C3 = 262537412640768000.0L; // 640320^3
+    long double sum = 13591409.0L;
+    long double term = 1.0L;
     for (long k = 1; k < n; k++) {
-        double k_d = (double)k;
-        term = term * -(6.0 * k_d - 5.0) * (2.0 * k_d - 1.0) * (6.0 * k_d - 1.0) * 24.0;
-        term = term / (k_d * k_d * k_d * C3);
-        sum = sum + term * (13591409.0 + 545140134.0 * k_d);
+        long double k_d = (long double)k;
+        term *= -(6.0L * k_d - 5.0L) * (2.0L * k_d - 1.0L) * (6.0L * k_d - 1.0L) * 24.0L;
+        term /= (k_d * k_d * k_d * C3);
+        sum += term * (13591409.0L + 545140134.0L * k_d);
     }
-    return 426880.0 * sqrt(10005.0) / sum;
+    return 426880.0L * sqrtl(10005.0L) / sum;
 }
 
 int main() {
@@ -17,7 +17,8 @@ int main() {
     printf("Please enter an integer value for iterations: ");
     scanf(n);
 
-    printf("pi: %.31f\n", chudnovsky_native(n));
+    long double pi = chudnovsky_native(n);
+    printf("pi: %.31Lf\n", pi);
 
     return 0;
 }

--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -344,6 +344,86 @@ Value makeReal(long double val) {
     return v;
 }
 
+Value makeFloat(float val) {
+    Value v;
+    memset(&v, 0, sizeof(Value));
+    v.type = TYPE_FLOAT;
+    v.f32_val = val;
+    return v;
+}
+
+Value makeDouble(double val) {
+    Value v;
+    memset(&v, 0, sizeof(Value));
+    v.type = TYPE_DOUBLE;
+    v.d_val = val;
+    return v;
+}
+
+Value makeLongDouble(long double val) {
+    Value v;
+    memset(&v, 0, sizeof(Value));
+    v.type = TYPE_LONG_DOUBLE;
+    v.r_val = val;
+    return v;
+}
+
+Value makeInt8(int8_t val) {
+    Value v;
+    memset(&v, 0, sizeof(Value));
+    v.type = TYPE_INT8;
+    v.i_val = val;
+    return v;
+}
+
+Value makeUInt8(uint8_t val) {
+    Value v;
+    memset(&v, 0, sizeof(Value));
+    v.type = TYPE_UINT8;
+    v.u_val = val;
+    return v;
+}
+
+Value makeInt16(int16_t val) {
+    Value v;
+    memset(&v, 0, sizeof(Value));
+    v.type = TYPE_INT16;
+    v.i_val = val;
+    return v;
+}
+
+Value makeUInt16(uint16_t val) {
+    Value v;
+    memset(&v, 0, sizeof(Value));
+    v.type = TYPE_UINT16;
+    v.u_val = val;
+    return v;
+}
+
+Value makeUInt32(uint32_t val) {
+    Value v;
+    memset(&v, 0, sizeof(Value));
+    v.type = TYPE_UINT32;
+    v.u_val = val;
+    return v;
+}
+
+Value makeInt64(long long val) {
+    Value v;
+    memset(&v, 0, sizeof(Value));
+    v.type = TYPE_INT64;
+    v.i_val = val;
+    return v;
+}
+
+Value makeUInt64(unsigned long long val) {
+    Value v;
+    memset(&v, 0, sizeof(Value));
+    v.type = TYPE_UINT64;
+    v.u_val = val;
+    return v;
+}
+
 Value makeByte(unsigned char val) {
     Value v;
     memset(&v, 0, sizeof(Value));

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -154,6 +154,16 @@ void freeFieldValue(FieldValue *fv);
 // Value constructors
 Value makeInt(long long val);
 Value makeReal(long double val);
+Value makeFloat(float val);
+Value makeDouble(double val);
+Value makeLongDouble(long double val);
+Value makeInt8(int8_t val);
+Value makeUInt8(uint8_t val);
+Value makeInt16(int16_t val);
+Value makeUInt16(uint16_t val);
+Value makeUInt32(uint32_t val);
+Value makeInt64(long long val);
+Value makeUInt64(unsigned long long val);
 Value makeByte(unsigned char val);
 Value makeWord(unsigned int val);
 Value makeNil(void);

--- a/src/ext_builtins/math/chudnovsky.c
+++ b/src/ext_builtins/math/chudnovsky.c
@@ -5,16 +5,16 @@
 static Value vmBuiltinChudnovsky(struct VM_s* vm, int arg_count, Value* args) {
     if (arg_count != 1) {
         runtimeError(vm, "Chudnovsky expects exactly 1 argument.");
-        return makeReal(0.0L);
+        return makeLongDouble(0.0L);
     }
-    if (args[0].type != TYPE_INTEGER) {
+    if (!is_intlike_type(args[0].type)) {
         runtimeError(vm, "Chudnovsky argument must be an integer.");
-        return makeReal(0.0L);
+        return makeLongDouble(0.0L);
     }
-    long n = args[0].i_val;
+    long n = (long)args[0].i_val;
     if (n <= 0) {
         runtimeError(vm, "Chudnovsky argument must be positive.");
-        return makeReal(0.0L);
+        return makeLongDouble(0.0L);
     }
 
     const long double C3 = 262537412640768000.0L; // 640320^3
@@ -29,7 +29,7 @@ static Value vmBuiltinChudnovsky(struct VM_s* vm, int arg_count, Value* args) {
     }
 
     long double pi = 426880.0L * sqrtl(10005.0L) / sum;
-    return makeReal(pi);
+    return makeLongDouble(pi);
 }
 
 void registerChudnovskyBuiltin(void) {


### PR DESCRIPTION
## Summary
- Update CLike Chudnovsky demos to use `long double` precision
- Extend value constructors for new integer and floating-point types
- Return `long double` from Chudnovsky VM builtin

## Testing
- `cd Tests && ./run_all_tests` *(fails: pascal binary not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3488accc832a857c51c19eeb24f5