### PR TITLE
Fix dynamic array in mandelbrot_row example

### DIFF
--- a/Docs/pscal_vm_overview.md
+++ b/Docs/pscal_vm_overview.md
@@ -196,7 +196,7 @@ This sequence uses `OP_JUMP_IF_FALSE` to exit the loop and `OP_JUMP` to repeat.
     * **Action:** Pushes a pointer to the specified upvalue's `Value` struct.
 * **`OP_INIT_LOCAL_ARRAY`**, **`OP_INIT_LOCAL_FILE`**, **`OP_INIT_LOCAL_POINTER`**:
     * **Operands:** Variable-length, including a slot index and type metadata.
-    * **Action:** Initializes a local variable of a complex type (array, file, or pointer) at the specified slot.
+    * **Action:** Initializes a local variable of a complex type (array, file, or pointer) at the specified slot. For arrays, any dimension using the sentinel bound index `0xFFFF` will pop its size from the stack (treated as an upper bound plus one) and assume a lower bound of `0`.
 * **`OP_GET_FIELD_ADDRESS`** / **`OP_GET_FIELD_ADDRESS16`**:
     * **Operands:** Constant index for the field's name.
     * **Action:** Pops a record or a pointer to a record from the stack and pushes a pointer to the specified field's `Value` struct.

--- a/Examples/clike/mandelbrot_row
+++ b/Examples/clike/mandelbrot_row
@@ -12,7 +12,7 @@ int main() {
     double maxIm = minIm + (maxRe - minRe) * height / width;
     double reFactor = (maxRe - minRe) / (width - 1);
     double imFactor = (maxIm - minIm) / (height - 1);
-    int row[height];
+    int row[width];
     for (int y = 0; y < height; y++) {
         double c_im = maxIm - y * imFactor;
         mandelbrotrow(minRe, reFactor, c_im, maxIterations, width - 1, &row);

--- a/src/clike/ast.h
+++ b/src/clike/ast.h
@@ -44,6 +44,7 @@ typedef struct ASTNodeClike {
     int is_array;           // Non-zero if this declaration is an array
     int array_size;         // Size of array for single-dimensional arrays
     int *array_dims;        // Sizes for each dimension in multi-dimensional arrays
+    struct ASTNodeClike **array_dim_exprs; // Expressions for dimension sizes (optional)
     int dim_count;          // Number of dimensions if this node represents an array
     VarType element_type;   // Element type if this node represents an array
     int is_const;           // Non-zero if this declaration is const-qualified


### PR DESCRIPTION
## Summary
- allow clike arrays to use runtime integer sizes via optional dimension expressions
- handle dynamic array bounds in the VM and compiler
- restore mandelbrot_row example to allocate its row using computed width

## Testing
- `cmake -S . -B build`
- `cmake --build build --target clike`
- `./Tests/run_clike_tests.sh`
- `build/bin/clike Examples/clike/mandelbrot_row`


------
https://chatgpt.com/codex/tasks/task_e_68af1436de40832a803b4f578bc732b6