### PR TITLE
Orient Mandelbrot row example traditionally

### DIFF
--- a/Examples/clike/mandelbrot_row
+++ b/Examples/clike/mandelbrot_row
@@ -14,7 +14,7 @@ int main() {
     double imFactor = (maxIm - minIm) / (height - 1);
     int row[width];
     for (int y = 0; y < height; y++) {
-        double c_im = maxIm - y * imFactor;
+        double c_im = minIm + y * imFactor;
         mandelbrotrow(minRe, reFactor, c_im, maxIterations, width - 1, &row);
         for (int x = 0; x < width; x++) {
             if (row[x] < maxIterations) {


### PR DESCRIPTION
## Summary
- Render Mandelbrot rows using the traditional top-to-bottom scan direction

## Testing
- `./run_clike_tests.sh` *(fails: clike binary not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af1d621684832aa6c444807b9d043e