### PR TITLE
Handle small terminals in MandelbrotRow example

### DIFF
--- a/Examples/clike/mandelbrot_row
+++ b/Examples/clike/mandelbrot_row
@@ -5,6 +5,11 @@
 int main() {
     int width = ScreenCols() - 1;
     int height = ScreenRows() - 2;
+    if (width < 1 || height < 1) {
+        printf("Terminal too small for Mandelbrot.\n");
+        return 1;
+    }
+    clrscr();
     int maxIterations = 1000;
     double minRe = -2.25;
     double maxRe = 1.25;


### PR DESCRIPTION
## Summary
- Add terminal size check and clear the screen before rendering

## Testing
- `Examples/clike/mandelbrot_row | head -n 20` *(fails: /usr/bin/env: ‘clike’: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af324bd21c832a8a013be77a0db6b6