### PR TITLE
Fix byte array handling for SDL demos

### DIFF
--- a/src/clike/parser.c
+++ b/src/clike/parser.c
@@ -19,7 +19,7 @@ VarType clike_tokenTypeToVarType(ClikeTokenType t) {
         case CLIKE_TOKEN_MSTREAM:    return TYPE_MEMORYSTREAM;
         case CLIKE_TOKEN_VOID:       return TYPE_VOID;
         case CLIKE_TOKEN_CHAR:       return TYPE_CHAR;
-        case CLIKE_TOKEN_BYTE:       return TYPE_UINT8;
+        case CLIKE_TOKEN_BYTE:       return TYPE_BYTE;
         default:                     return TYPE_UNKNOWN;
     }
 }

--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -643,10 +643,18 @@ Value makeValueForType(VarType type, AST *type_def_param, Symbol* context_symbol
     }
 
     switch(type) {
-        case TYPE_INT32:  SET_INT_VALUE(&v, 0);   break;
-        case TYPE_INT64:  SET_INT_VALUE(&v, 0);   break;
-        case TYPE_UINT32: SET_INT_VALUE(&v, 0);   break;
-        case TYPE_UINT64: SET_INT_VALUE(&v, 0);   break;
+        case TYPE_INT8:
+        case TYPE_UINT8:
+        case TYPE_BYTE:
+        case TYPE_WORD:
+        case TYPE_INT16:
+        case TYPE_UINT16:
+        case TYPE_INT32:
+        case TYPE_UINT32:
+        case TYPE_INT64:
+        case TYPE_UINT64:
+            SET_INT_VALUE(&v, 0);
+            break;
         case TYPE_FLOAT:
         case TYPE_DOUBLE:
         case TYPE_LONG_DOUBLE:
@@ -837,8 +845,6 @@ Value makeValueForType(VarType type, AST *type_def_param, Symbol* context_symbol
              if (!v.enum_val.enum_name) { /* Malloc error */ EXIT_FAILURE_HANDLER(); }
              v.base_type_node = actual_type_def;
              break;
-        case TYPE_BYTE:    v.i_val = 0; break;
-        case TYPE_WORD:    v.i_val = 0; break;
         case TYPE_SET:     v.set_val.set_size = 0; v.set_val.set_values = NULL; v.max_length = 0; break;
         case TYPE_POINTER:
             v.ptr_val = NULL;


### PR DESCRIPTION
## Summary
- Map `byte` tokens to the VM's `TYPE_BYTE` so SDL `UpdateTexture` sees the expected element type
- Initialize 8- and 16-bit integer types in `makeValueForType` to avoid "unhandled type" warnings

## Testing
- `cmake ..`
- `make -j2`
- `./run_all_tests`


------
https://chatgpt.com/codex/tasks/task_e_68af39322f60832aa4b5202aeb8dcb4b