### PR TITLE
Center SDL Mandelbrot output

### DIFF
--- a/Examples/clike/sdl_mandelbrot
+++ b/Examples/clike/sdl_mandelbrot
@@ -12,6 +12,7 @@ int main() {
     float MaxRe;
     float MinIm;
     float MaxIm;
+    float ImRange;
     float ReFactor;
     float ImFactor;
     int MaxX;
@@ -40,7 +41,6 @@ int main() {
     MaxIterations = 128;
     MinRe = -2.0;
     MaxRe = 1.0;
-    MinIm = -1.2;
 
     ScreenUpdateInterval = 1;
     MandelBytesPerPixel = 4;
@@ -57,7 +57,9 @@ int main() {
     MaxX = getmaxx();
     MaxY = getmaxy();
 
-    MaxIm = MinIm + (MaxRe - MinRe) * MaxY / MaxX;
+    ImRange = (MaxRe - MinRe) * MaxY / MaxX;
+    MinIm = -ImRange / 2.0;
+    MaxIm = MinIm + ImRange;
     ReFactor = (MaxRe - MinRe) / (MaxX - 1);
     ImFactor = (MaxIm - MinIm) / (MaxY - 1);
 


### PR DESCRIPTION
## Summary
- ensure SDL Mandelbrot example centers fractal vertically by computing a symmetric imaginary range

## Testing
- `cd Tests;./run_all_tests` *(fails: pascal, clike, pscalvm binaries not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af40815c68832abc21d23aa243be8a