### PR TITLE
Fix upcase builtin char type handling

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -348,11 +348,22 @@ Value vmBuiltinSucc(VM* vm, int arg_count, Value* args) {
 }
 
 Value vmBuiltinUpcase(VM* vm, int arg_count, Value* args) {
-    if (arg_count != 1 || args[0].type != TYPE_CHAR) {
+    if (arg_count != 1) {
         runtimeError(vm, "Upcase expects 1 char argument.");
         return makeChar('\0');
     }
-    return makeChar(toupper(args[0].c_val));
+
+    Value arg = args[0];
+    char c;
+    if (arg.type == TYPE_CHAR) {
+        c = arg.c_val;
+    } else if (IS_INTLIKE(arg)) {
+        c = (char)AS_INTEGER(arg);
+    } else {
+        runtimeError(vm, "Upcase expects 1 char argument.");
+        return makeChar('\0');
+    }
+    return makeChar((char)toupper((unsigned char)c));
 }
 
 Value vmBuiltinPos(VM* vm, int arg_count, Value* args) {


### PR DESCRIPTION
## Summary
- allow `upcase` builtin to accept integer arguments by converting to char
- fixes crash when demos call `upcase` with non-char values

## Testing
- `cmake -S . -B build -DSDL=OFF`
- `cmake --build build`
- `cd Tests && ./run_all_tests`

------
https://chatgpt.com/codex/tasks/task_e_68af41536940832ab3b462fb160d3192