### PR TITLE
Fix char comparison in switch

### DIFF
--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -469,6 +469,8 @@ Value makeChar(char c) {
     memset(&v, 0, sizeof(Value));
     v.type = TYPE_CHAR;
     v.c_val = c;
+    unsigned char uc = (unsigned char)c;
+    SET_INT_VALUE(&v, uc); // Keep numeric fields in sync for ordinal ops
     v.max_length = 1; // Character has a fixed length of 1
     return v;
 }


### PR DESCRIPTION
## Summary
- keep integer fields in character values synchronized so comparisons use actual code point

## Testing
- `build/bin/clike Tests/clike/tcs.cl | perl -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]|\e\][^\a]*(?:\a|\e\\)//g' > /tmp/tcs.clean`
- `diff -u Tests/clike/tcs.out /tmp/tcs.clean`


------
https://chatgpt.com/codex/tasks/task_e_68af8ef90b7c832a82ac4bf1c1d6cd8e