### PR TITLE
Handle paramcount as wide integer

### DIFF
--- a/Examples/clike/hangman5
+++ b/Examples/clike/hangman5
@@ -351,7 +351,8 @@ int main() {
     int playing, result, padding;
     str input, word_file, scoreMsg, promptMsg;
 
-    if (paramcount() >= 1) word_file = paramstr(1); else word_file = "etc/words";
+    // Use the first command line argument as the word list if provided.
+    if (paramcount() > 0) word_file = paramstr(1); else word_file = "etc/words";
     words = load_words(word_file, &word_count, 6, 9, 2048);
     if (word_count == 0) { printf("No words loaded.\n"); return 0; }
 

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -505,9 +505,15 @@ Value vmBuiltinRealtostr(VM* vm, int arg_count, Value* args) {
 Value vmBuiltinParamcount(VM* vm, int arg_count, Value* args) {
     if (arg_count != 0) {
         runtimeError(vm, "ParamCount expects 0 arguments.");
-        return makeInt(0);
+        return makeInt64(0);
     }
-    return makeInt(gParamCount);
+    /*
+     * ParamCount should reflect the number of command line parameters as an
+     * integer.  Since the VM now supports multiple integer widths, use the
+     * widest standard signed integer to avoid inadvertent promotion to a
+     * floating type or other category.
+     */
+    return makeInt64(gParamCount);
 }
 
 Value vmBuiltinParamstr(VM* vm, int arg_count, Value* args) {

--- a/src/clike/semantics.c
+++ b/src/clike/semantics.c
@@ -27,11 +27,15 @@ static VarType builtinReturnType(const char* name) {
 
     if (strcasecmp(name, "chudnovsky") == 0) return TYPE_LONG_DOUBLE;
 
+    if (strcasecmp(name, "paramcount") == 0) {
+        /* Return a wide integer to match the builtin implementation. */
+        return TYPE_INT64;
+    }
+
     if (strcasecmp(name, "round")     == 0 ||
         strcasecmp(name, "trunc")     == 0 ||
         strcasecmp(name, "random")    == 0 ||
         strcasecmp(name, "ioresult")  == 0 ||
-        strcasecmp(name, "paramcount")== 0 ||
         strcasecmp(name, "length")    == 0 ||
         strcasecmp(name, "strlen")    == 0 ||
         strcasecmp(name, "pos")       == 0 ||


### PR DESCRIPTION
## Summary
- return paramcount as a 64-bit integer in VM builtin
- update clike frontend to treat paramcount as 64-bit
- simplify hangman example to rely on the builtin directly

## Testing
- `cd Tests && ./run_all_tests`

------
https://chatgpt.com/codex/tasks/task_e_68afa038eed0832a89f91c349b72d7c5