### PR TITLE
Fix CLike numeric literal constant lookup

### DIFF
--- a/Examples/clike/hangman5
+++ b/Examples/clike/hangman5
@@ -349,11 +349,14 @@ int main() {
     struct WordNode* words;
     int word_count;
     int playing, result, padding;
-    str input, word_file, scoreMsg, promptMsg;
+    str input, scoreMsg, promptMsg;
 
     // Use the first command line argument as the word list if provided.
-    if (paramcount() > 0) word_file = paramstr(1); else word_file = "etc/words";
-    words = load_words(word_file, &word_count, 6, 9, 2048);
+    if (paramcount() > 0) {
+        words = load_words(paramstr(1), &word_count, 6, 9, 2048);
+    } else {
+        words = load_words("etc/words", &word_count, 6, 9, 2048);
+    }
     if (word_count == 0) { printf("No words loaded.\n"); return 0; }
 
     randomize();

--- a/src/clike/codegen.c
+++ b/src/clike/codegen.c
@@ -646,18 +646,12 @@ static void compileExpression(ASTNodeClike *node, BytecodeChunk *chunk, FuncCont
             Value v;
             if (node->token.type == CLIKE_TOKEN_FLOAT_LITERAL) {
                 v = makeReal(node->token.float_val);
-                v.type = TYPE_DOUBLE;
-            } else if (node->token.type == CLIKE_TOKEN_CHAR_LITERAL ||
-                       node->var_type == TYPE_CHAR) {
-                // Treat character literals distinctly from integers so
-                // they are emitted as CHAR constants in the bytecode.
+            } else if (node->token.type == CLIKE_TOKEN_CHAR_LITERAL) {
+                // Emit character literals distinctly
                 v = makeChar((char)node->token.int_val);
             } else {
+                // Default to 64-bit integer regardless of inferred var_type
                 v = makeInt(node->token.int_val);
-                v.type = node->var_type;
-                if (is_intlike_type(v.type)) {
-                    v.u_val = (unsigned long long)node->token.int_val;
-                }
             }
             int idx = addConstantToChunk(chunk, &v);
             writeBytecodeChunk(chunk, OP_CONSTANT, node->token.line);


### PR DESCRIPTION
## Summary
- prevent numeric literals from inheriting incorrect var_type when emitting constants
- restore hangman example to use explicit `paramcount() > 0` check

## Testing
- `cd Tests && ./run_all_tests`

------
https://chatgpt.com/codex/tasks/task_e_68afa771853c832a875f18060237d2e9