### PR TITLE
Fix integer ++/-- promoting to float

### DIFF
--- a/src/clike/parser.c
+++ b/src/clike/parser.c
@@ -46,7 +46,7 @@ static VarType literalTokenToVarType(ClikeTokenType t) {
     switch (t) {
         case CLIKE_TOKEN_FLOAT_LITERAL: return TYPE_DOUBLE;
         case CLIKE_TOKEN_CHAR_LITERAL:  return TYPE_CHAR;
-        default:                        return TYPE_INT64;
+        default:                        return TYPE_INT32;
     }
 }
 
@@ -1131,7 +1131,8 @@ static ASTNodeClike* unary(ParserClike *p) {
         ClikeToken op = p->current; advanceParser(p);
         ASTNodeClike *operand = unary(p);
         ClikeToken oneTok = op; oneTok.type = CLIKE_TOKEN_NUMBER; oneTok.lexeme = "1"; oneTok.length = 1; oneTok.int_val = 1LL;
-        ASTNodeClike *one = newASTNodeClike(TCAST_NUMBER, oneTok); one->var_type = TYPE_INT64;
+        ASTNodeClike *one = newASTNodeClike(TCAST_NUMBER, oneTok);
+        one->var_type = TYPE_INT32;
         ClikeToken opTok = op; opTok.type = (op.type == CLIKE_TOKEN_PLUS_PLUS) ? CLIKE_TOKEN_PLUS : CLIKE_TOKEN_MINUS; opTok.lexeme = (op.type == CLIKE_TOKEN_PLUS_PLUS)?"+":"-"; opTok.length = 1;
         ASTNodeClike *bin = newASTNodeClike(TCAST_BINOP, opTok);
         setLeftClike(bin, cloneASTClike(operand));
@@ -1272,7 +1273,8 @@ static ASTNodeClike* postfix(ParserClike *p, ASTNodeClike *node) {
     if (p->current.type == CLIKE_TOKEN_PLUS_PLUS || p->current.type == CLIKE_TOKEN_MINUS_MINUS) {
         ClikeToken op = p->current; advanceParser(p);
         ClikeToken oneTok = op; oneTok.type = CLIKE_TOKEN_NUMBER; oneTok.lexeme = "1"; oneTok.length = 1; oneTok.int_val = 1LL;
-        ASTNodeClike *one = newASTNodeClike(TCAST_NUMBER, oneTok); one->var_type = TYPE_INT64;
+        ASTNodeClike *one = newASTNodeClike(TCAST_NUMBER, oneTok);
+        one->var_type = TYPE_INT32;
         ClikeToken opTok = op; opTok.type = (op.type == CLIKE_TOKEN_PLUS_PLUS)?CLIKE_TOKEN_PLUS:CLIKE_TOKEN_MINUS; opTok.lexeme = (op.type==CLIKE_TOKEN_PLUS_PLUS)?"+":"-"; opTok.length = 1;
         ASTNodeClike *bin = newASTNodeClike(TCAST_BINOP, opTok);
         setLeftClike(bin, cloneASTClike(node));


### PR DESCRIPTION
## Summary
- keep integer literals as 32-bit values and use them for ++/--
- restore Mandelbrot demo loops to standard ++ syntax

## Testing
- `cmake ..`
- `make -j2`
- `Tests/run_all_tests`
- `build/bin/clike Examples/clike/sdl_mandelbrot_row` *(fails: call to undefined SDL functions)*

------
https://chatgpt.com/codex/tasks/task_e_68afb7ae4964832aaa97c32eedfda750