### PR TITLE
Overload min/max to preserve integer results

### DIFF
--- a/Examples/Pascal/weather
+++ b/Examples/Pascal/weather
@@ -67,12 +67,6 @@ end;
 // --- END ReadApiKeyFromFile ---
 
 
-// --- Min function ---
-function Min(a, b: integer): integer;
-begin
-  if a < b then Min := a else Min := b;
-end;
-
 // --- Helper function ExtractStringValue ---
 function ExtractStringValue(jsonString: string; key: string; startSearchPos: integer): string;
 var
@@ -81,15 +75,17 @@ var
 begin
   ExtractStringValue := '';
   searchPattern := '"' + key + '":"';
-  // Use Min to prevent overflow if startSearchPos is near end of jsonString
-  subStr := copy(jsonString, startSearchPos, Min(length(jsonString) - startSearchPos + 1, MAX_SUBSTR_LEN));
+  // Use min to prevent overflow if startSearchPos is near end of jsonString
+  subStr := copy(jsonString, startSearchPos,
+                 min(length(jsonString) - startSearchPos + 1, MAX_SUBSTR_LEN));
   keyPos := pos(searchPattern, subStr);
 
   if keyPos > 0 then
   begin
     valueStartPos := startSearchPos + keyPos + length(searchPattern) - 1;
-    // Use Min again for safety when looking for the closing quote
-    subStr := copy(jsonString, valueStartPos, Min(length(jsonString) - valueStartPos + 1, MAX_SUBSTR_LEN));
+    // Use min again for safety when looking for the closing quote
+    subStr := copy(jsonString, valueStartPos,
+                   min(length(jsonString) - valueStartPos + 1, MAX_SUBSTR_LEN));
     relEndPos := pos('"', subStr);
     if relEndPos > 0 then
     begin
@@ -106,8 +102,9 @@ var
 begin
   ExtractNumericValueStr := '';
   searchPattern := '"' + key + '":';
-  // Use Min for safety
-  subStr := copy(jsonString, startSearchPos, Min(length(jsonString) - startSearchPos + 1, MAX_SUBSTR_LEN));
+  // Use min for safety
+  subStr := copy(jsonString, startSearchPos,
+                 min(length(jsonString) - startSearchPos + 1, MAX_SUBSTR_LEN));
   keyPos := pos(searchPattern, subStr);
 
   if keyPos > 0 then
@@ -119,14 +116,15 @@ begin
        inc(valueStartPos);
     end;
 
-    // Use Min for safety when searching for end delimiter
-    subStr := copy(jsonString, valueStartPos, Min(length(jsonString) - valueStartPos + 1, MAX_SUBSTR_LEN));
+    // Use min for safety when searching for end delimiter
+    subStr := copy(jsonString, valueStartPos,
+                   min(length(jsonString) - valueStartPos + 1, MAX_SUBSTR_LEN));
     relCommaPos := pos(',', subStr);
     relBracePos := pos('}', subStr);
 
     // Determine end position robustly
     if (relCommaPos > 0) and (relBracePos > 0) then
-        relEndPos := Min(relCommaPos, relBracePos)
+        relEndPos := min(relCommaPos, relBracePos)
     else if relCommaPos > 0 then
         relEndPos := relCommaPos
     else if relBracePos > 0 then

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -1417,17 +1417,37 @@ Value vmBuiltinTanh(VM* vm, int arg_count, Value* args) {
 }
 
 Value vmBuiltinMax(VM* vm, int arg_count, Value* args) {
-    if (arg_count != 2) { runtimeError(vm, "max expects 2 arguments."); return makeReal(0.0); }
-    double a = IS_INTLIKE(args[0]) ? (double)AS_INTEGER(args[0]) : (double)AS_REAL(args[0]);
-    double b = IS_INTLIKE(args[1]) ? (double)AS_INTEGER(args[1]) : (double)AS_REAL(args[1]);
-    return makeReal((a > b) ? a : b);
+    if (arg_count != 2) { runtimeError(vm, "max expects 2 arguments."); return makeInt(0); }
+
+    bool aInt = IS_INTLIKE(args[0]);
+    bool bInt = IS_INTLIKE(args[1]);
+
+    if (aInt && bInt) {
+        long long a = AS_INTEGER(args[0]);
+        long long b = AS_INTEGER(args[1]);
+        return makeInt((a > b) ? a : b);
+    } else {
+        double a = aInt ? (double)AS_INTEGER(args[0]) : AS_REAL(args[0]);
+        double b = bInt ? (double)AS_INTEGER(args[1]) : AS_REAL(args[1]);
+        return makeReal((a > b) ? a : b);
+    }
 }
 
 Value vmBuiltinMin(VM* vm, int arg_count, Value* args) {
-    if (arg_count != 2) { runtimeError(vm, "min expects 2 arguments."); return makeReal(0.0); }
-    double a = IS_INTLIKE(args[0]) ? (double)AS_INTEGER(args[0]) : (double)AS_REAL(args[0]);
-    double b = IS_INTLIKE(args[1]) ? (double)AS_INTEGER(args[1]) : (double)AS_REAL(args[1]);
-    return makeReal((a < b) ? a : b);
+    if (arg_count != 2) { runtimeError(vm, "min expects 2 arguments."); return makeInt(0); }
+
+    bool aInt = IS_INTLIKE(args[0]);
+    bool bInt = IS_INTLIKE(args[1]);
+
+    if (aInt && bInt) {
+        long long a = AS_INTEGER(args[0]);
+        long long b = AS_INTEGER(args[1]);
+        return makeInt((a < b) ? a : b);
+    } else {
+        double a = aInt ? (double)AS_INTEGER(args[0]) : AS_REAL(args[0]);
+        double b = bInt ? (double)AS_INTEGER(args[1]) : AS_REAL(args[1]);
+        return makeReal((a < b) ? a : b);
+    }
 }
 
 Value vmBuiltinFloor(VM* vm, int arg_count, Value* args) {


### PR DESCRIPTION
## Summary
- Make built-in min and max return integers when both inputs are integers, falling back to real for mixed or real arguments
- Simplify weather example to use built-in min now that integer results are supported

## Testing
- `cd Tests; ./run_all_tests` *(fails: pascal, clike, and pscalvm binaries missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b04fee3754832a9dc4d7db1ae17be3