### PR TITLE
Fix CaseStatementSuite test output to remove stray escape sequence

### DIFF
--- a/Tests/Pascal/CaseStatementSuite.out
+++ b/Tests/Pascal/CaseStatementSuite.out
@@ -1,4 +1,4 @@
-]10;?--- Testing CASE Statements with Verification ---
+--- Testing CASE Statements with Verification ---
 
 Testing INTEGER CASE:
 START: Integer Case (i=0): PASS


### PR DESCRIPTION
## Summary
- remove stray escape sequence from `CaseStatementSuite.out` so test output matches actual interpreter behavior

## Testing
- `cmake -B build`
- `cmake --build build`
- `diff -u Tests/Pascal/CaseStatementSuite.out /tmp/case.out.clean | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68b0919f7a98832a8bce3cca645e4413