### PR TITLE
Fix char range and numeric mixing in Pascal VM

### DIFF
--- a/src/Pascal/lexer.c
+++ b/src/Pascal/lexer.c
@@ -450,7 +450,12 @@ Token *getNextToken(Lexer *lexer) {
             // The parser's `evaluateCompileTimeValue` will see a STRING_CONST of length 1
             // and correctly convert it to a CHAR value.
             char char_buf[2];
-            char_buf[0] = (char)val;
+            /* Store the numeric character code using an unsigned cast so that
+             * values 128..255 are preserved instead of sign-extending to
+             * negative numbers on platforms where 'char' is signed.  The
+             * parser later interprets single-character string tokens as CHAR
+             * constants. */
+            char_buf[0] = (unsigned char)val;
             char_buf[1] = '\0';
             return newToken(TOKEN_STRING_CONST, char_buf, start_line, start_column);
         }

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -316,7 +316,7 @@ Value vmBuiltinChr(VM* vm, int arg_count, Value* args) {
         return makeChar('\0');
     }
     long long code = AS_INTEGER(args[0]);
-    if (code < 0 || code > UNICODE_MAX) {
+    if (code < 0 || code > PASCAL_CHAR_MAX) {
         runtimeError(vm, "Chr argument out of range.");
         return makeChar('\0');
     }
@@ -334,7 +334,7 @@ Value vmBuiltinSucc(VM* vm, int arg_count, Value* args) {
     }
     switch(arg.type) {
         case TYPE_CHAR:
-            if (arg.c_val >= UNICODE_MAX) {
+            if (arg.c_val >= PASCAL_CHAR_MAX) {
                 runtimeError(vm, "Succ char overflow.");
                 return makeVoid();
             }
@@ -1588,7 +1588,7 @@ Value vmBuiltinInc(VM* vm, int arg_count, Value* args) {
 
         case TYPE_CHAR: {
             long long next = target->c_val + delta;
-            if (next < 0 || next > UNICODE_MAX) {
+            if (next < 0 || next > PASCAL_CHAR_MAX) {
                 runtimeError(vm, "Warning: Range check error incrementing CHAR to %lld.", next);
             }
             target->c_val = (int)next;
@@ -1654,7 +1654,7 @@ Value vmBuiltinDec(VM* vm, int arg_count, Value* args) {
 
         case TYPE_CHAR: {
             long long next = target->c_val - delta;
-            if (next < 0 || next > UNICODE_MAX) {
+            if (next < 0 || next > PASCAL_CHAR_MAX) {
                 runtimeError(vm, "Warning: Range check error decrementing CHAR to %lld.", next);
             }
             target->c_val = (int)next;
@@ -1769,7 +1769,7 @@ Value vmBuiltinHigh(VM* vm, int arg_count, Value* args) {
 
     switch (t) {
         case TYPE_INTEGER: return makeInt(2147483647);
-        case TYPE_CHAR:    return makeChar(UNICODE_MAX);
+        case TYPE_CHAR:    return makeChar(PASCAL_CHAR_MAX);
         case TYPE_BOOLEAN: return makeBoolean(true);
         case TYPE_BYTE:    return makeInt(255);
         case TYPE_WORD:    return makeInt(65535);

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -592,7 +592,8 @@ Value evaluateCompileTimeValue(AST* node) {
             }
             break;
         case AST_STRING:
-            if (node->token && strlen(node->token->value) == 1) return makeChar(node->token->value[0]);
+            if (node->token && strlen(node->token->value) == 1)
+                return makeChar((unsigned char)node->token->value[0]);
             if (node->token) return makeString(node->token->value);
             break;
         case AST_BOOLEAN:
@@ -2337,7 +2338,10 @@ static void compileRValue(AST* node, BytecodeChunk* chunk, int current_line_appr
 
             // If the string literal has a length of 1, treat it as a character constant
             if (strlen(node_token->value) == 1) {
-                Value val = makeChar(node_token->value[0]);
+                /* Single-character string literals represent CHAR constants.
+                 * Cast through unsigned char so values in the 128..255 range
+                 * are preserved correctly. */
+                Value val = makeChar((unsigned char)node_token->value[0]);
                 int constIndex = addConstantToChunk(chunk, &val);
                 emitConstant(chunk, constIndex, line);
                 // The temporary char value `val` does not need `freeValue`

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -26,7 +26,14 @@
 
 #include "types.h"
 
+// Pascal traditionally models the CHAR type as an 8-bit ordinal with a
+// maximum value of 255.  The VM previously exposed the full Unicode range,
+// which caused functions such as High(char) and Ord(High(char)) to report a
+// maximum of 0x10FFFF.  This broke expectations of legacy Pascal code and the
+// regression test suite.  Define an explicit maximum for Pascal CHAR values so
+// the runtime can enforce classic 0..255 semantics.
 #define UNICODE_MAX 0x10FFFF
+#define PASCAL_CHAR_MAX 255
 // Bytecode related stuff
 // Make sure Value and VarType are defined before these.
 #define IS_BOOLEAN(value) ((value).type == TYPE_BOOLEAN)

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -707,12 +707,7 @@ InterpretResult interpretBytecode(VM* vm, BytecodeChunk* chunk, HashTable* globa
             if (IS_NUMERIC(a_val_popped) && IS_NUMERIC(b_val_popped)) { \
                 bool a_real = IS_REAL(a_val_popped); \
                 bool b_real = IS_REAL(b_val_popped); \
-                if (a_real != b_real) { \
-                    runtimeError(vm, "Runtime Error: Mixing real and integer operands is not allowed."); \
-                    freeValue(&a_val_popped); freeValue(&b_val_popped); \
-                    return INTERPRET_RUNTIME_ERROR; \
-                } \
-                if (a_real) { \
+                if (a_real || b_real) { \
                     long double fa = as_ld(a_val_popped); \
                     long double fb = as_ld(b_val_popped); \
                     if (current_instruction_code == OP_DIVIDE && fb == 0.0L) { \
@@ -753,6 +748,9 @@ InterpretResult interpretBytecode(VM* vm, BytecodeChunk* chunk, HashTable* globa
                             break; \
                         case OP_DIVIDE: \
                             result_val = makeReal((long double)ia / (long double)ib); \
+                            break; \
+                        case OP_MOD: \
+                            iresult = ib == 0 ? 0 : ia % ib; \
                             break; \
                         default: \
                             runtimeError(vm, "Runtime Error: Invalid arithmetic opcode %d for integers.", current_instruction_code); \


### PR DESCRIPTION
## Summary
- Limit Pascal CHAR to classic 0..255 range and update built-ins accordingly
- Parse `#nnn` character codes as unsigned values
- Allow arithmetic between integers and reals in the VM

## Testing
- `cmake --build build`
- `../build/bin/pascal Pascal/TypeTestSuite`


------
https://chatgpt.com/codex/tasks/task_e_68b0956828d0832aa48b34e9163b8d14