### PR TITLE
Fix CLike array tests by allowing numeric promotion

### DIFF
--- a/src/clike/semantics.c
+++ b/src/clike/semantics.c
@@ -275,13 +275,10 @@ static VarType analyzeExpr(ASTNodeClike *node, ScopeStack *scopes) {
         case TCAST_BINOP: {
             VarType lt = analyzeExpr(node->left, scopes);
             VarType rt = analyzeExpr(node->right, scopes);
-            if ((is_real_type(lt) && is_intlike_type(rt)) ||
-                (is_real_type(rt) && is_intlike_type(lt))) {
-                fprintf(stderr,
-                        "Type error: cannot mix real and integer in expression at line %d, column %d\n",
-                        node->token.line, node->token.column);
-                clike_error_count++;
-                node->var_type = TYPE_UNKNOWN;
+            if (is_real_type(lt) && is_intlike_type(rt)) {
+                node->var_type = lt;
+            } else if (is_real_type(rt) && is_intlike_type(lt)) {
+                node->var_type = rt;
             } else if (is_real_type(lt) && is_real_type(rt)) {
                 if (lt == TYPE_LONG_DOUBLE || rt == TYPE_LONG_DOUBLE) node->var_type = TYPE_LONG_DOUBLE;
                 else if (lt == TYPE_DOUBLE || rt == TYPE_DOUBLE) node->var_type = TYPE_DOUBLE;
@@ -300,13 +297,10 @@ static VarType analyzeExpr(ASTNodeClike *node, ScopeStack *scopes) {
             analyzeExpr(node->left, scopes);
             VarType rt = analyzeExpr(node->right, scopes);
             VarType ft = analyzeExpr(node->third, scopes);
-            if ((is_real_type(rt) && is_intlike_type(ft)) ||
-                (is_real_type(ft) && is_intlike_type(rt))) {
-                fprintf(stderr,
-                        "Type error: cannot mix real and integer in expression at line %d, column %d\n",
-                        node->token.line, node->token.column);
-                clike_error_count++;
-                node->var_type = TYPE_UNKNOWN;
+            if (is_real_type(rt) && is_intlike_type(ft)) {
+                node->var_type = rt;
+            } else if (is_real_type(ft) && is_intlike_type(rt)) {
+                node->var_type = ft;
             } else if (is_real_type(rt) && is_real_type(ft)) {
                 if (rt == TYPE_LONG_DOUBLE || ft == TYPE_LONG_DOUBLE) node->var_type = TYPE_LONG_DOUBLE;
                 else if (rt == TYPE_DOUBLE || ft == TYPE_DOUBLE) node->var_type = TYPE_DOUBLE;


### PR DESCRIPTION
## Summary
- permit implicit promotion from integers to real types in CLike semantic analysis for binary and ternary expressions
- this enables mixed int/real arithmetic in array initialisation and other expressions

## Testing
- `build/bin/clike Tests/clike/MdArraySuite.cl > /tmp/MdArraySuite.out 2> /tmp/MdArraySuite.err && perl -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]|\e\][^\a]*(?:\a|\e\\)//g' /tmp/MdArraySuite.out > /tmp/MdArraySuite.clean && diff -u Tests/clike/MdArraySuite.out /tmp/MdArraySuite.clean`
- `Tests/run_clike_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b09e3f566c832abb818c6448cc0655