### PR TITLE
Allow mixed numeric comparisons in VM

### DIFF
--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1119,12 +1119,8 @@ InterpretResult interpretBytecode(VM* vm, BytecodeChunk* chunk, HashTable* globa
                 else if (IS_NUMERIC(a_val) && IS_NUMERIC(b_val)) {
                     bool a_real = is_real_type(a_val.type);
                     bool b_real = is_real_type(b_val.type);
-                    if (a_real != b_real) {
-                        runtimeError(vm, "Runtime Error: Cannot compare real and integer values.");
-                        freeValue(&a_val); freeValue(&b_val);
-                        return INTERPRET_RUNTIME_ERROR;
-                    }
-                    if (a_real) {
+
+                    if (a_real || b_real) {
                         long double fa = as_ld(a_val);
                         long double fb = as_ld(b_val);
                         switch (instruction_val) {


### PR DESCRIPTION
## Summary
- promote integer operands to real during numeric comparisons
- simplify RandCheck variance calculation

## Testing
- `PASCAL_LIB_DIR=lib/pascal build/bin/pascal Examples/Pascal/RandCheck`
- `(cd Tests && ./run_all_tests)`

------
https://chatgpt.com/codex/tasks/task_e_68b0a2a9ceb8832ab15e876fa3ea71cf