### PR TITLE
Add basic VM threading support with scheduler

### DIFF
--- a/src/compiler/bytecode.h
+++ b/src/compiler/bytecode.h
@@ -96,7 +96,11 @@ typedef enum {
                       // Operands: 2-byte name_idx, 2-byte address, 1-byte arg count
     OP_HALT,          // Stop the VM (though OP_RETURN from main might suffice)
     OP_EXIT,          // Early exit from the current function without halting the VM
-    OP_FORMAT_VALUE   // Format the value on top of the stack. Operands: width (byte), precision (byte)
+    OP_FORMAT_VALUE,  // Format the value on top of the stack. Operands: width (byte), precision (byte)
+
+    // --- Threading Opcodes ---
+    OP_THREAD_CREATE, // Create a new lightweight thread. Operand: 2-byte entry offset
+    OP_THREAD_JOIN    // Join on a thread. Operand: none (pops thread id from stack)
 
 } OpCode;
 

--- a/src/globals.c
+++ b/src/globals.c
@@ -3,6 +3,7 @@
 
 // Include the globals header file, which declares the global variables.
 #include "globals.h" // This now includes symbol.h and defines HashTable
+#include <pthread.h>
 
 
 // --- Global Variable Definitions and Initialization ---
@@ -67,3 +68,6 @@ Symbol *current_function_symbol = NULL; // Define the global variable here.
 
 // Note: Other global SDL/Audio variables declared in globals.h are typically
 // defined and initialized in their respective .c files (sdl.c, audio.c).
+
+// Mutex definition guarding shared global tables
+pthread_mutex_t globals_mutex = PTHREAD_MUTEX_INITIALIZER;

--- a/src/globals.h
+++ b/src/globals.h
@@ -4,6 +4,7 @@
 
 #include <stdio.h>  // For fprintf, stderr
 #include <stdlib.h> // For exit, EXIT_FAILURE
+#include <pthread.h> // For mutex guarding of global tables
 
 #include "types.h" // Provides TypeEntry, Value, List, AST forward decl etc.
 #ifdef SDL
@@ -74,6 +75,9 @@ extern List *inserted_global_names;
 
 extern int break_requested;
 extern int exit_requested; // Flag set by builtin 'exit' to unwind the current routine
+
+// Mutex protecting shared global tables
+extern pthread_mutex_t globals_mutex;
 
 #define DEFAULT_STRING_CAPACITY 255
 

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include <stdbool.h> // For bool, true, false
+#include <pthread.h>
 
 #include "vm/vm.h"
 #include "compiler/bytecode.h"
@@ -30,6 +31,61 @@
 // --- VM Helper Functions ---
 static void resetStack(VM* vm) {
     vm->stackTop = vm->stack;
+}
+
+// --- Thread Scheduler Helpers ---
+static void saveThreadContext(VM* vm) {
+    Thread* t = &vm->threads[vm->currentThread];
+    t->chunk = vm->chunk;
+    t->ip = vm->ip;
+    t->stackSize = (int)(vm->stackTop - vm->stack);
+    memcpy(t->stack, vm->stack, sizeof(Value) * t->stackSize);
+    t->frameCount = vm->frameCount;
+    memcpy(t->frames, vm->frames, sizeof(CallFrame) * t->frameCount);
+}
+
+static void loadThreadContext(VM* vm, int idx) {
+    Thread* t = &vm->threads[idx];
+    vm->chunk = t->chunk;
+    vm->ip = t->ip;
+    memcpy(vm->stack, t->stack, sizeof(Value) * t->stackSize);
+    vm->stackTop = vm->stack + t->stackSize;
+    vm->frameCount = t->frameCount;
+    memcpy(vm->frames, t->frames, sizeof(CallFrame) * t->frameCount);
+}
+
+static void switchThread(VM* vm) {
+    if (vm->threadCount <= 1) return;
+    saveThreadContext(vm);
+    int start = vm->currentThread;
+    for (int i = 1; i <= vm->threadCount; i++) {
+        int idx = (start + i) % vm->threadCount;
+        if (vm->threads[idx].active) {
+            vm->currentThread = idx;
+            loadThreadContext(vm, idx);
+            return;
+        }
+    }
+}
+
+static int createThread(VM* vm, uint16_t entry) {
+    if (vm->threadCount >= VM_MAX_THREADS) return -1;
+    Thread* t = &vm->threads[vm->threadCount];
+    t->chunk = vm->chunk;
+    t->ip = vm->chunk->code + entry;
+    t->stackSize = 0;
+    t->frameCount = 0;
+    t->active = true;
+    int id = vm->threadCount;
+    vm->threadCount++;
+    return id;
+}
+
+static void joinThread(VM* vm, int id) {
+    if (id < 0 || id >= vm->threadCount) return;
+    while (vm->threads[id].active) {
+        switchThread(vm);
+    }
 }
 
 // Internal function shared by stack dump helpers
@@ -284,6 +340,12 @@ void initVM(VM* vm) { // As in all.txt, with frameCount
     vm->frameCount = 0; // <--- INITIALIZE frameCount
 
     vm->exit_requested = false;
+
+    vm->threadCount = 0;
+    vm->currentThread = 0;
+    for (int i = 0; i < VM_MAX_THREADS; i++) {
+        vm->threads[i].active = false;
+    }
 
     for (int i = 0; i < MAX_HOST_FUNCTIONS; i++) {
         vm->host_functions[i] = NULL;
@@ -557,6 +619,16 @@ InterpretResult interpretBytecode(VM* vm, BytecodeChunk* chunk, HashTable* globa
     vm->vmGlobalSymbols = globals;    // Store globals table (ensure this is the intended one)
     vm->procedureTable = procedures; // <--- STORED procedureTable
 
+    // Initialize main thread context
+    vm->threadCount = 1;
+    vm->currentThread = 0;
+    Thread* mainThread = &vm->threads[0];
+    mainThread->chunk = chunk;
+    mainThread->ip = vm->ip;
+    mainThread->stackSize = 0;
+    mainThread->frameCount = 0;
+    mainThread->active = true;
+
     // Initialize default file variables if present but not yet opened.
     if (vm->vmGlobalSymbols) {
         Symbol* inputSym = hashTableLookup(vm->vmGlobalSymbols, "input");
@@ -806,14 +878,26 @@ InterpretResult interpretBytecode(VM* vm, BytecodeChunk* chunk, HashTable* globa
                 bool halted = false;
                 InterpretResult res = returnFromCall(vm, &halted);
                 if (res != INTERPRET_OK) return res;
-                if (halted) return INTERPRET_OK;
+                if (halted) {
+                    vm->threads[vm->currentThread].active = false;
+                    bool any = false;
+                    for (int i = 0; i < vm->threadCount; i++) if (vm->threads[i].active) { any = true; break; }
+                    if (!any) return INTERPRET_OK;
+                    switchThread(vm);
+                }
                 break;
             }
             case OP_EXIT: {
                 bool halted = false;
                 InterpretResult res = returnFromCall(vm, &halted);
                 if (res != INTERPRET_OK) return res;
-                if (halted) return INTERPRET_OK;
+                if (halted) {
+                    vm->threads[vm->currentThread].active = false;
+                    bool any = false;
+                    for (int i = 0; i < vm->threadCount; i++) if (vm->threads[i].active) { any = true; break; }
+                    if (!any) return INTERPRET_OK;
+                    switchThread(vm);
+                }
                 break;
             }
             case OP_CONSTANT: {
@@ -881,7 +965,9 @@ InterpretResult interpretBytecode(VM* vm, BytecodeChunk* chunk, HashTable* globa
                     return INTERPRET_RUNTIME_ERROR;
                 }
 
+                pthread_mutex_lock(&globals_mutex);
                 Symbol* sym = hashTableLookup(vm->vmGlobalSymbols, name_val->s_val);
+                pthread_mutex_unlock(&globals_mutex);
                 if (!sym || !sym->value) {
                     runtimeError(vm, "Runtime Error: Global '%s' not found in symbol table.", name_val->s_val);
                     return INTERPRET_RUNTIME_ERROR;
@@ -903,7 +989,9 @@ InterpretResult interpretBytecode(VM* vm, BytecodeChunk* chunk, HashTable* globa
                     return INTERPRET_RUNTIME_ERROR;
                 }
 
+                pthread_mutex_lock(&globals_mutex);
                 Symbol* sym = hashTableLookup(vm->vmGlobalSymbols, name_val->s_val);
+                pthread_mutex_unlock(&globals_mutex);
                 if (!sym || !sym->value) {
                     runtimeError(vm, "Runtime Error: Global '%s' not found in symbol table.", name_val->s_val);
                     return INTERPRET_RUNTIME_ERROR;
@@ -1836,13 +1924,17 @@ comparison_error_label:
              }
             case OP_DEFINE_GLOBAL: {
                 Value varNameVal = READ_CONSTANT();
+                pthread_mutex_lock(&globals_mutex);
                 InterpretResult r = handleDefineGlobal(vm, varNameVal);
+                pthread_mutex_unlock(&globals_mutex);
                 if (r != INTERPRET_OK) return r;
                 break;
             }
             case OP_DEFINE_GLOBAL16: {
                 Value varNameVal = READ_CONSTANT16();
+                pthread_mutex_lock(&globals_mutex);
                 InterpretResult r = handleDefineGlobal(vm, varNameVal);
+                pthread_mutex_unlock(&globals_mutex);
                 if (r != INTERPRET_OK) return r;
                 break;
             }
@@ -1859,7 +1951,9 @@ comparison_error_label:
                     return INTERPRET_RUNTIME_ERROR;
                 }
 
+                pthread_mutex_lock(&globals_mutex);
                 Symbol* sym = hashTableLookup(vm->vmGlobalSymbols, name_val->s_val);
+                pthread_mutex_unlock(&globals_mutex);
                 if (!sym || !sym->value) {
                     runtimeError(vm, "Runtime Error: Undefined global variable '%s'.", name_val->s_val);
                     return INTERPRET_RUNTIME_ERROR;
@@ -1881,7 +1975,9 @@ comparison_error_label:
                     return INTERPRET_RUNTIME_ERROR;
                 }
 
+                pthread_mutex_lock(&globals_mutex);
                 Symbol* sym = hashTableLookup(vm->vmGlobalSymbols, name_val->s_val);
+                pthread_mutex_unlock(&globals_mutex);
                 if (!sym || !sym->value) {
                     runtimeError(vm, "Runtime Error: Undefined global variable '%s'.", name_val->s_val);
                     return INTERPRET_RUNTIME_ERROR;
@@ -1903,9 +1999,11 @@ comparison_error_label:
                     return INTERPRET_RUNTIME_ERROR;
                 }
 
+                pthread_mutex_lock(&globals_mutex);
                 Symbol* sym = hashTableLookup(vm->vmGlobalSymbols, name_val->s_val);
                 if (!sym) {
                     runtimeError(vm, "Runtime Error: Global variable '%s' not defined for assignment.", name_val->s_val);
+                    pthread_mutex_unlock(&globals_mutex);
                     return INTERPRET_RUNTIME_ERROR;
                 }
 
@@ -1920,7 +2018,7 @@ comparison_error_label:
 
                 Value value_from_stack = pop(vm);
                 updateSymbol(name_val->s_val, value_from_stack);
-
+                pthread_mutex_unlock(&globals_mutex);
                 break;
             }
             case OP_SET_GLOBAL16: {
@@ -1936,9 +2034,11 @@ comparison_error_label:
                     return INTERPRET_RUNTIME_ERROR;
                 }
 
+                pthread_mutex_lock(&globals_mutex);
                 Symbol* sym = hashTableLookup(vm->vmGlobalSymbols, name_val->s_val);
                 if (!sym) {
                     runtimeError(vm, "Runtime Error: Global variable '%s' not defined for assignment.", name_val->s_val);
+                    pthread_mutex_unlock(&globals_mutex);
                     return INTERPRET_RUNTIME_ERROR;
                 }
 
@@ -1953,6 +2053,7 @@ comparison_error_label:
 
                 Value value_from_stack = pop(vm);
                 updateSymbol(name_val->s_val, value_from_stack);
+                pthread_mutex_unlock(&globals_mutex);
                 break;
             }
             case OP_GET_LOCAL: {
@@ -2343,7 +2444,9 @@ comparison_error_label:
                 VmBuiltinFn handler = getVmBuiltinHandler(builtin_name_lower); // Pass the lowercase name
 
                 if (handler) {
+                    pthread_mutex_lock(&globals_mutex);
                     Value result = handler(vm, arg_count, args);
+                    pthread_mutex_unlock(&globals_mutex);
 
                     // Pop arguments from the stack and free their contents
                     // This is crucial to prevent stack corruption.
@@ -2461,7 +2564,14 @@ comparison_error_label:
             }
 
             case OP_HALT:
-                return INTERPRET_OK;
+                vm->threads[vm->currentThread].active = false;
+                {
+                    bool any = false;
+                    for (int i = 0; i < vm->threadCount; i++) if (vm->threads[i].active) { any = true; break; }
+                    if (!any) return INTERPRET_OK;
+                    switchThread(vm);
+                    break;
+                }
             case OP_CALL_HOST: {
                 HostFunctionID host_id = READ_HOST_ID();
                 if (host_id >= HOST_FN_COUNT || vm->host_functions[host_id] == NULL) {
@@ -2469,8 +2579,32 @@ comparison_error_label:
                     return INTERPRET_RUNTIME_ERROR;
                 }
                 HostFn func = vm->host_functions[host_id];
+                pthread_mutex_lock(&globals_mutex);
                 Value result = func(vm);
+                pthread_mutex_unlock(&globals_mutex);
                 push(vm, result);
+                break;
+            }
+            case OP_THREAD_CREATE: {
+                uint16_t entry = READ_SHORT(vm);
+                int id = createThread(vm, entry);
+                if (id < 0) {
+                    runtimeError(vm, "Thread limit exceeded.");
+                    return INTERPRET_RUNTIME_ERROR;
+                }
+                push(vm, makeInt(id));
+                break;
+            }
+            case OP_THREAD_JOIN: {
+                Value tidVal = pop(vm);
+                if (!IS_INTLIKE(tidVal)) {
+                    runtimeError(vm, "Thread id must be integer.");
+                    freeValue(&tidVal);
+                    return INTERPRET_RUNTIME_ERROR;
+                }
+                int tid = (int)tidVal.i_val;
+                freeValue(&tidVal);
+                joinThread(vm, tid);
                 break;
             }
             case OP_FORMAT_VALUE: {
@@ -2529,6 +2663,7 @@ comparison_error_label:
                 runtimeError(vm, "VM Error: Unknown opcode %d.", instruction_val);
                 return INTERPRET_RUNTIME_ERROR;
         }
+        switchThread(vm);
         next_instruction:;
     }
     return INTERPRET_OK;

--- a/src/vm/vm.h
+++ b/src/vm/vm.h
@@ -19,6 +19,7 @@
 #define MAX_HOST_FUNCTIONS 4096
 
 #define VM_CALL_STACK_MAX 4096
+#define VM_MAX_THREADS 16
 
 // Forward declaration
 struct VM_s;
@@ -51,8 +52,22 @@ typedef struct {
     Value** upvalues;
 } CallFrame;
 
+// Thread structure representing a lightweight VM thread
+typedef struct {
+    BytecodeChunk* chunk;       // Bytecode being executed
+    uint8_t* ip;                // Instruction pointer for this thread
+
+    Value stack[VM_STACK_MAX];  // Operand stack for the thread
+    int stackSize;              // Number of active values on the stack
+
+    CallFrame frames[VM_CALL_STACK_MAX];
+    int frameCount;             // Active call frames
+
+    bool active;                // Whether this thread is runnable
+} Thread;
+
 // --- Virtual Machine Structure ---
-typedef struct VM_s { 
+typedef struct VM_s {
     BytecodeChunk* chunk;     // The chunk of bytecode to execute
     uint8_t* ip;              // Instruction Pointer: points to the *next* byte to be read
 
@@ -69,6 +84,11 @@ typedef struct VM_s {
     int frameCount;
 
     bool exit_requested;      // Indicates a builtin requested early exit from the current frame
+
+    // Threading support
+    Thread threads[VM_MAX_THREADS];
+    int threadCount;
+    int currentThread;
 
 } VM;
 

--- a/src/vm/vm.h
+++ b/src/vm/vm.h
@@ -56,11 +56,11 @@ typedef struct {
 typedef struct {
     BytecodeChunk* chunk;       // Bytecode being executed
     uint8_t* ip;                // Instruction pointer for this thread
-
-    Value stack[VM_STACK_MAX];  // Operand stack for the thread
+    
+    Value* stack;               // Operand stack for the thread
     int stackSize;              // Number of active values on the stack
 
-    CallFrame frames[VM_CALL_STACK_MAX];
+    CallFrame* frames;          // Call frames for this thread
     int frameCount;             // Active call frames
 
     bool active;                // Whether this thread is runnable


### PR DESCRIPTION
## Summary
- Introduce `Thread` struct and VM fields for managing lightweight threads
- Implement cooperative thread scheduler with create/join opcodes
- Protect shared global tables and host/builtin calls with a mutex

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_68b0c22fcfc8832ab7675b09ec668b9c