### PR TITLE
Fix spawn lookup for camelCase functions

### DIFF
--- a/Tests/clike/ThreadSpawnJoinCase.cl
+++ b/Tests/clike/ThreadSpawnJoinCase.cl
@@ -1,0 +1,11 @@
+void WorkerThread() {
+    printf("child\n");
+}
+
+int main() {
+    int tid;
+    tid = spawn WorkerThread();
+    join tid;
+    printf("parent\n");
+    return 0;
+}

--- a/Tests/clike/ThreadSpawnJoinCase.out
+++ b/Tests/clike/ThreadSpawnJoinCase.out
@@ -1,0 +1,2 @@
+child
+parent

--- a/src/clike/codegen.c
+++ b/src/clike/codegen.c
@@ -1122,6 +1122,18 @@ static void compileFunction(ASTNodeClike *func, BytecodeChunk *chunk) {
 
     int address = chunk->count;
     char* fname = tokenToCString(func->token);
+    /*
+     * Symbol lookups are case-insensitive.  The symbol table stores all
+     * procedure names in lowercase, but the token text preserves the
+     * original casing.  This meant that procedures with mixed-case names
+     * (e.g. "computeRowsThread0") were inserted using their original case
+     * and later lookups using the lowercase form failed, causing instructions
+     * such as OP_THREAD_CREATE to be omitted.
+     *
+     * Normalize the function name to lowercase before inserting it into the
+     * procedure table so lookups succeed regardless of the original casing.
+     */
+    toLowerString(fname);
     Symbol* sym = malloc(sizeof(Symbol));
     memset(sym, 0, sizeof(Symbol));
     sym->name = strdup(fname);


### PR DESCRIPTION
## Summary
- normalize clike procedure names to lowercase when recording them in the procedure table so thread spawns of mixed-case functions resolve correctly
- add regression test ensuring spawn/join works with camelCase thread function names

## Testing
- `build/bin/clike Tests/clike/ThreadSpawnJoinCase.cl`
- `Tests/run_clike_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b124073344832a96a47fa595a00391