### PR TITLE
Fix forward function calls in CLike compiler

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -2835,8 +2835,8 @@ void finalizeBytecode(BytecodeChunk* chunk) {
                 }
 
                 if (symbol_to_patch && symbol_to_patch->is_defined) {
-                    // Patch the address in place. The patch offset is offset + 2.
-                    patchShort(chunk, offset + 2, (uint16_t)symbol_to_patch->bytecode_address);
+                    // Patch the address in place. The address occupies bytes offset+3 and offset+4.
+                    patchShort(chunk, offset + 3, (uint16_t)symbol_to_patch->bytecode_address);
                 } else {
                     fprintf(stderr, "Compiler Error: Procedure '%s' was called but never defined.\n", proc_name);
                     compiler_had_error = true;


### PR DESCRIPTION
## Summary
- predeclare functions in CLike to resolve forward references
- patch OP_CALL instructions after compilation for forward-declared functions
- fix finalizeBytecode to patch call targets correctly

## Testing
- `cd build && make -j$(nproc)`
- `cd Tests && ./run_all_tests`
- `cat /tmp/fwd.log`

------
https://chatgpt.com/codex/tasks/task_e_68b126c82798832abf7218c4f9007407