### PR TITLE
Update threaded SDL Mandelbrot example to render incrementally

### DIFF
--- a/Examples/clike/sdl_mandelbrot_threaded
+++ b/Examples/clike/sdl_mandelbrot_threaded
@@ -25,6 +25,9 @@ int MaxY;
 
 int threadCount = 4;
 
+// Track completion of individual rows
+int rowDone[768];
+
 // Precomputed row ranges for each thread
 int threadStart[4];
 int threadEnd[4];
@@ -64,6 +67,7 @@ void computeRows(int startY, int endY) {
             pixelData[bufferBaseIdx + 2] = B;
             pixelData[bufferBaseIdx + 3] = 255;
         }
+        rowDone[y] = 1;
     }
 }
 
@@ -79,12 +83,15 @@ int main() {
     int tid3;
     int quit;
 
+    printf("Calculating Mandelbrot set. The window will update as rows are drawn...\n");
     initgraph(WindowWidth, WindowHeight, "Threaded Mandelbrot in CLike");
     textureID = createtexture(WindowWidth, WindowHeight);
     if (textureID < 0) {
         printf("Error: unable to create texture.\n");
         halt();
     }
+    cleardevice();
+    updatescreen();
 
     MaxX = getmaxx();
     MaxY = getmaxy();
@@ -114,6 +121,21 @@ int main() {
     tid1 = spawn computeRowsThread1();
     tid2 = spawn computeRowsThread2();
     tid3 = spawn computeRowsThread3();
+
+    // Display rows as they are computed
+    int nextRow = 0;
+    while (nextRow <= MaxY) {
+        if (rowDone[nextRow]) {
+            updatetexture(textureID, pixelData);
+            cleardevice();
+            rendercopy(textureID);
+            updatescreen();
+            graphloop(0);
+            nextRow = nextRow + 1;
+        } else {
+            graphloop(16); // yield time for worker threads and handle events
+        }
+    }
 
     // Join each thread using the stored ids
     join tid0;

--- a/Examples/clike/sdl_mandelbrot_threaded
+++ b/Examples/clike/sdl_mandelbrot_threaded
@@ -130,6 +130,7 @@ int main() {
             cleardevice();
             rendercopy(textureID);
             updatescreen();
+            printf("Completed row %d\n", nextRow);
             graphloop(0);
             nextRow = nextRow + 1;
         } else {

--- a/Examples/clike/sdl_mandelbrot_threaded
+++ b/Examples/clike/sdl_mandelbrot_threaded
@@ -77,10 +77,8 @@ int main() {
     int endY;
     int rowsPerThread;
     int extra;
-    int tid0;
-    int tid1;
-    int tid2;
-    int tid3;
+    int threadId[4];
+    int threadJoined[4];
     int quit;
 
     printf("Calculating Mandelbrot set. The window will update as rows are drawn...\n");
@@ -117,10 +115,13 @@ int main() {
     }
 
     // Spawn one worker per precomputed range.
-    tid0 = spawn computeRowsThread0();
-    tid1 = spawn computeRowsThread1();
-    tid2 = spawn computeRowsThread2();
-    tid3 = spawn computeRowsThread3();
+    threadId[0] = spawn computeRowsThread0();
+    threadId[1] = spawn computeRowsThread1();
+    threadId[2] = spawn computeRowsThread2();
+    threadId[3] = spawn computeRowsThread3();
+    for (i = 0; i < threadCount; i++) {
+        threadJoined[i] = 0;
+    }
 
     // Display rows as they are computed
     int nextRow = 0;
@@ -131,18 +132,28 @@ int main() {
             rendercopy(textureID);
             updatescreen();
             printf("Completed row %d\n", nextRow);
+
+            // Join any thread whose last row just finished
+            for (i = 0; i < threadCount; i++) {
+                if (!threadJoined[i] && nextRow == threadEnd[i]) {
+                    join threadId[i];
+                    threadJoined[i] = 1;
+                }
+            }
+
             graphloop(0);
             nextRow = nextRow + 1;
         } else {
-            graphloop(16); // yield time for worker threads and handle events
+            graphloop(1); // short yield for worker threads and event handling
         }
     }
 
-    // Join each thread using the stored ids
-    join tid0;
-    join tid1;
-    join tid2;
-    join tid3;
+    // Ensure all threads are joined
+    for (i = 0; i < threadCount; i++) {
+        if (!threadJoined[i]) {
+            join threadId[i];
+        }
+    }
 
     updatetexture(textureID, pixelData);
     cleardevice();


### PR DESCRIPTION
## Summary
- Track per-row completion in threaded Mandelbrot renderer
- Refresh texture whenever a completed row is detected for progressive display

## Testing
- `./Tests/run_clike_tests.sh` *(fails: clike binary not found at /workspace/pscal/build/bin/clike)*

------
https://chatgpt.com/codex/tasks/task_e_68b12b81f678832a98986f7807d6b4ce