### PR TITLE
Document multithreading support across VM and frontends

### DIFF
--- a/Docs/clike_language_reference.md
+++ b/Docs/clike_language_reference.md
@@ -202,6 +202,20 @@ int* p = &x;
 * **`#import`:** Includes another source file.
 * **`#ifdef`, `#ifndef`, `#else`, `#elif`, `#endif`:** For conditional compilation based on whether a symbol is defined.
 
+### **Threading**
+
+The language provides lightweight concurrency through two statements:
+
+* `spawn` – starts a new thread executing a parameterless function and pushes its integer thread identifier.
+* `join` – waits for the thread with the given identifier to finish execution.
+
+Example:
+
+```c
+int tid = spawn worker();
+join tid;
+```
+
 ### **Built-in Functions**
 
 The C-like front end has access to the rich set of built-in functions provided by the PSCAL VM, including file I/O, string manipulation, mathematical functions, and more. Some common C library functions are also mapped to their Pascal equivalents (e.g., `strlen` is mapped to `length`).

--- a/Docs/clike_overview.md
+++ b/Docs/clike_overview.md
@@ -36,6 +36,7 @@ to the VM:
   parameters allow pass‑by‑reference semantics.
 - **Structs and pointers** – `struct` aggregates fields. `new(&node)` allocates
   dynamic storage and `->` dereferences pointer fields.
+- **Threading** – `spawn` launches a parameterless function in a new thread and returns its id; `join` waits for a thread to complete.
 
 ## Example: Sorting a String
 

--- a/Docs/pascal_language_reference.md
+++ b/Docs/pascal_language_reference.md
@@ -226,6 +226,8 @@ The Pascal front end supports lightweight concurrency using two keywords:
 * `spawn` – starts a new thread executing a parameterless procedure and returns a thread identifier.
 * `join` – waits for the thread whose identifier is given to finish execution.
 
+Threads share global variables and are scheduled cooperatively; a `join` yields control until the target thread completes.
+
 Example:
 
 ```pascal

--- a/Docs/pascal_overview.md
+++ b/Docs/pascal_overview.md
@@ -21,6 +21,7 @@ Pscal implements a substantial subset of classic Pascal:
 * **Control flow** – `if`, `case`, `for`, `while`, `repeat…until`, and `break`.
 * **Subroutines** – functions and procedures with local variables and parameters.
 * **Units** – separate compilation modules that export types, variables and routines.
+* **Threading** – `spawn` starts a parameterless procedure in a new thread and returns its id; `join` waits for that thread to finish.
 
 Example program:
 

--- a/Docs/project_overview.md
+++ b/Docs/project_overview.md
@@ -40,6 +40,7 @@ The project follows a classic compiler and virtual machine design:
     * Math (`sin`, `cos`, `sqrt`, `factorial`, `fibonacci`, `chudnovsky`).
     * String manipulation (`copy`, `pos`, `length`).
     * System interaction (`getpid`, `dos_exec`).
+* **Multithreading**: Lightweight threads can be created with `spawn` and synchronized with `join` for concurrent execution within the VM.
 * **Bytecode Caching**: To speed up subsequent runs, the compiler can cache bytecode for source files that have not been modified. Cached bytecode carries a version tag; programs can query `VMVersion` and `BytecodeVersion` to decide how to handle mismatches. Set `PSCAL_STRICT_VM=1` to have the VM abort when bytecode targets a newer VM.
   Example programs demonstrating these builtins are `Examples/Pascal/VMVersionDemo`
   and `Examples/clike/vm_version_demo`.

--- a/Docs/pscal_vm_overview.md
+++ b/Docs/pscal_vm_overview.md
@@ -19,6 +19,7 @@ The VM's architecture is defined by the `VM` struct in `src/vm/vm.h` and consist
     * **`vmGlobalSymbols`:** A `HashTable` for runtime storage and lookup of global variables.
     * **`procedureTable`:** A `HashTable` that stores information about all compiled procedures and functions, which is used for disassembly and resolving calls.
 * **Bytecode Chunk:** A pointer (`chunk`) to the `BytecodeChunk` being executed. This chunk contains the bytecode instructions (`code`), the constant pool (`constants`), and line number information for debugging (`lines`).
+* **Thread Table:** Lightweight threads are stored in a `threads` array; each thread has its own instruction pointer, stack, and call frames. A cooperative scheduler cycles through active threads.
 
 #### **Execution Flow**
 
@@ -281,6 +282,15 @@ MyFunction(a, b);
         * **`<address>`:** The bytecode address of the first instruction of `MyFunction`. The VM jumps to this address.
         * **`<arg_count>`:** The number of arguments (2 in this case). The VM knows to use the top 2 values on the stack as the arguments for the new function's stack frame.
 ---
+
+#### **Threading Opcodes**
+
+* **`OP_THREAD_CREATE`**:
+    * **Operands:** 2-byte bytecode address.
+    * **Action:** Starts a new thread at the given instruction and pushes its thread identifier.
+* **`OP_THREAD_JOIN`**:
+    * **Operands:** None.
+    * **Action:** Pops a thread identifier and waits for that thread to finish, yielding control if it is still running.
 
 #### **I/O and Miscellaneous Opcodes**
 


### PR DESCRIPTION
## Summary
- Note lightweight thread support in project overview
- Document spawn/join usage in C-like and Pascal front-end docs
- Describe VM thread table and OP_THREAD_CREATE/OP_THREAD_JOIN opcodes

## Testing
- `cd Tests; ./run_all_tests` *(fails: pascal binary not found at /workspace/pscal/build/bin/pascal)*

------
https://chatgpt.com/codex/tasks/task_e_68b20851792c832abbf42e25da83abba