### PR TITLE
Use thread-local terminal state

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ if(APPLE AND PSCAL_USE_BREW_CURL)
 endif()
 
 find_package(CURL REQUIRED)
+find_package(Threads REQUIRED)
 if(TARGET CURL::libcurl)
     message(STATUS "CURL: using imported target CURL::libcurl")
 else()
@@ -219,6 +220,7 @@ function(add_pscal_executable target_name)
     endif()
 
     list(APPEND TARGET_LINK_LIBS m) # Math library
+    list(APPEND TARGET_LINK_LIBS Threads::Threads)
 
     # Specific options for dascal (ASan)
     if(${target_name} STREQUAL "dascal")
@@ -302,9 +304,9 @@ endif()
 
 add_executable(clike ${CLIKE_SOURCES})
 if(TARGET CURL::libcurl)
-    target_link_libraries(clike PRIVATE CURL::libcurl m)
+    target_link_libraries(clike PRIVATE CURL::libcurl m Threads::Threads)
 else()
-    target_link_libraries(clike PRIVATE ${CURL_LIBRARIES} m)
+    target_link_libraries(clike PRIVATE ${CURL_LIBRARIES} m Threads::Threads)
 endif()
 
 set(CLIKE_REPL_SOURCES ${CLIKE_SOURCES})
@@ -312,9 +314,9 @@ list(REMOVE_ITEM CLIKE_REPL_SOURCES src/clike/main.c)
 list(APPEND CLIKE_REPL_SOURCES src/clike/repl.c)
 add_executable(clike-repl ${CLIKE_REPL_SOURCES})
 if(TARGET CURL::libcurl)
-    target_link_libraries(clike-repl PRIVATE CURL::libcurl m)
+    target_link_libraries(clike-repl PRIVATE CURL::libcurl m Threads::Threads)
 else()
-    target_link_libraries(clike-repl PRIVATE ${CURL_LIBRARIES} m)
+    target_link_libraries(clike-repl PRIVATE ${CURL_LIBRARIES} m Threads::Threads)
 endif()
 
 # When SDL support is enabled, clike needs the same SDL include paths,

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -28,6 +28,7 @@
 #include <time.h>    // For date/time functions
 #include <sys/time.h> // For gettimeofday
 #include <stdio.h>   // For printf, fprintf
+#include <pthread.h>
 
 static DIR* dos_dir = NULL; // Used by dos_findfirst/findnext
 
@@ -566,11 +567,11 @@ Value vmBuiltinWherey(VM* vm, int arg_count, Value* args) {
 }
 
 // --- Terminal helper for VM input routines ---
-static struct termios vm_orig_termios;
-static int vm_raw_mode = 0;
-static int vm_termios_saved = 0;
-static int vm_restore_registered = 0;
-static int vm_alt_screen_depth = 0; // Track nested alternate screen buffers
+static _Thread_local struct termios vm_orig_termios;
+static _Thread_local int vm_raw_mode = 0;
+static _Thread_local int vm_termios_saved = 0;
+static _Thread_local int vm_restore_registered = 0;
+static _Thread_local int vm_alt_screen_depth = 0; // Track nested alternate screen buffers
 
 typedef struct {
     char fg[32];
@@ -579,8 +580,8 @@ typedef struct {
 } VmColorState;
 
 #define VM_COLOR_STACK_MAX 16
-static VmColorState vm_color_stack[VM_COLOR_STACK_MAX];
-static int vm_color_stack_depth = 0;
+static _Thread_local VmColorState vm_color_stack[VM_COLOR_STACK_MAX];
+static _Thread_local int vm_color_stack_depth = 0;
 
 static void vmEnableRawMode(void); // Forward declaration
 static void vmSetupTermHandlers(void);
@@ -588,6 +589,19 @@ static void vmPushColorState(void);
 static void vmPopColorState(void);
 static void vmRestoreColorState(void);
 static int vmQueryColor(const char *query, char *dest, size_t dest_size);
+static void vmAtExitCleanup(void);
+
+static pthread_key_t vm_thread_cleanup_key;
+static pthread_once_t vm_thread_cleanup_key_once = PTHREAD_ONCE_INIT;
+
+static void vmThreadCleanup(void *unused) {
+    (void)unused;
+    vmAtExitCleanup();
+}
+
+static void vmCreateThreadKey(void) {
+    pthread_key_create(&vm_thread_cleanup_key, vmThreadCleanup);
+}
 
 static void vmRestoreTerminal(void) {
     if (vm_termios_saved && vm_raw_mode) {
@@ -715,6 +729,9 @@ static void vmSignalHandler(int signum) {
 }
 
 static void vmSetupTermHandlers(void) {
+    pthread_once(&vm_thread_cleanup_key_once, vmCreateThreadKey);
+    pthread_setspecific(vm_thread_cleanup_key, (void *)1);
+
     if (!vm_termios_saved) {
         if (tcgetattr(STDIN_FILENO, &vm_orig_termios) == 0) {
             vm_termios_saved = 1;

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -567,10 +567,11 @@ Value vmBuiltinWherey(VM* vm, int arg_count, Value* args) {
 }
 
 // --- Terminal helper for VM input routines ---
-static _Thread_local struct termios vm_orig_termios;
+static struct termios vm_orig_termios;
+static int vm_termios_saved = 0;
+static pthread_mutex_t vm_term_mutex = PTHREAD_MUTEX_INITIALIZER;
+
 static _Thread_local int vm_raw_mode = 0;
-static _Thread_local int vm_termios_saved = 0;
-static _Thread_local int vm_restore_registered = 0;
 static _Thread_local int vm_alt_screen_depth = 0; // Track nested alternate screen buffers
 
 typedef struct {
@@ -585,6 +586,7 @@ static _Thread_local int vm_color_stack_depth = 0;
 
 static void vmEnableRawMode(void); // Forward declaration
 static void vmSetupTermHandlers(void);
+static void vmRegisterRestoreHandlers(void);
 static void vmPushColorState(void);
 static void vmPopColorState(void);
 static void vmRestoreColorState(void);
@@ -593,6 +595,7 @@ static void vmAtExitCleanup(void);
 
 static pthread_key_t vm_thread_cleanup_key;
 static pthread_once_t vm_thread_cleanup_key_once = PTHREAD_ONCE_INIT;
+static pthread_once_t vm_restore_once = PTHREAD_ONCE_INIT;
 
 static void vmThreadCleanup(void *unused) {
     (void)unused;
@@ -604,10 +607,12 @@ static void vmCreateThreadKey(void) {
 }
 
 static void vmRestoreTerminal(void) {
+    pthread_mutex_lock(&vm_term_mutex);
     if (vm_termios_saved && vm_raw_mode) {
         tcsetattr(STDIN_FILENO, TCSANOW, &vm_orig_termios);
         vm_raw_mode = 0;
     }
+    pthread_mutex_unlock(&vm_term_mutex);
 }
 
 // Query terminal for current color (OSC 10/11) and store result in dest
@@ -728,28 +733,32 @@ static void vmSignalHandler(int signum) {
     _exit(128 + signum);
 }
 
+static void vmRegisterRestoreHandlers(void) {
+    atexit(vmAtExitCleanup);
+    struct sigaction sa;
+    sa.sa_handler = vmSignalHandler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    sigaction(SIGINT, &sa, NULL);
+    sigaction(SIGTERM, &sa, NULL);
+    sigaction(SIGQUIT, &sa, NULL);
+    sigaction(SIGABRT, &sa, NULL);
+    sigaction(SIGSEGV, &sa, NULL);
+}
+
 static void vmSetupTermHandlers(void) {
     pthread_once(&vm_thread_cleanup_key_once, vmCreateThreadKey);
     pthread_setspecific(vm_thread_cleanup_key, (void *)1);
 
+    pthread_mutex_lock(&vm_term_mutex);
     if (!vm_termios_saved) {
         if (tcgetattr(STDIN_FILENO, &vm_orig_termios) == 0) {
             vm_termios_saved = 1;
         }
     }
-    if (!vm_restore_registered) {
-        atexit(vmAtExitCleanup);
-        struct sigaction sa;
-        sa.sa_handler = vmSignalHandler;
-        sigemptyset(&sa.sa_mask);
-        sa.sa_flags = 0;
-        sigaction(SIGINT, &sa, NULL);
-        sigaction(SIGTERM, &sa, NULL);
-        sigaction(SIGQUIT, &sa, NULL);
-        sigaction(SIGABRT, &sa, NULL);
-        sigaction(SIGSEGV, &sa, NULL);
-        vm_restore_registered = 1;
-    }
+    pthread_mutex_unlock(&vm_term_mutex);
+
+    pthread_once(&vm_restore_once, vmRegisterRestoreHandlers);
 }
 
 void vmInitTerminalState(void) {
@@ -795,8 +804,11 @@ int vmExitWithCleanup(int status) {
 
 static void vmEnableRawMode(void) {
     vmSetupTermHandlers();
-    if (vm_raw_mode)
+    pthread_mutex_lock(&vm_term_mutex);
+    if (vm_raw_mode) {
+        pthread_mutex_unlock(&vm_term_mutex);
         return;
+    }
 
     struct termios raw = vm_orig_termios;
     raw.c_lflag &= ~(ICANON | ECHO);
@@ -806,6 +818,7 @@ static void vmEnableRawMode(void) {
     if (tcsetattr(STDIN_FILENO, TCSANOW, &raw) == 0) {
         vm_raw_mode = 1;
     }
+    pthread_mutex_unlock(&vm_term_mutex);
 }
 
 // Restore the terminal to a canonical, line-buffered state suitable for


### PR DESCRIPTION
## Summary
- guard terminal state with thread-local variables and thread cleanup key
- register per-thread cleanup handlers and link against pthreads

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `./run_all_tests` *(fails: FormattingTestSuite stdout mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b2159c572c832a87d40c9e5d241824