### PR TITLE
Enable multithreaded VM scheduler

### DIFF
--- a/Docs/pscal_vm_overview.md
+++ b/Docs/pscal_vm_overview.md
@@ -19,7 +19,7 @@ The VM's architecture is defined by the `VM` struct in `src/vm/vm.h` and consist
     * **`vmGlobalSymbols`:** A `HashTable` for runtime storage and lookup of global variables.
     * **`procedureTable`:** A `HashTable` that stores information about all compiled procedures and functions, which is used for disassembly and resolving calls.
 * **Bytecode Chunk:** A pointer (`chunk`) to the `BytecodeChunk` being executed. This chunk contains the bytecode instructions (`code`), the constant pool (`constants`), and line number information for debugging (`lines`).
-* **Thread Table:** Lightweight threads are stored in a `threads` array; each thread has its own instruction pointer, stack, and call frames. A cooperative scheduler cycles through active threads.
+* **Thread Table:** The VM spawns real OS-level threads via `pthread`. Each entry in the `threads` array holds a native thread and its own `VM` instance, allowing bytecode routines to execute in parallel.
 
 #### **Execution Flow**
 

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -2121,11 +2121,13 @@ Value vmBuiltinEof(VM* vm, int arg_count, Value* args) {
 
     if (arg_count == 0) {
         if (vm->vmGlobalSymbols) {
+            pthread_mutex_lock(&globals_mutex);
             Symbol* inputSym = hashTableLookup(vm->vmGlobalSymbols, "input");
             if (inputSym && inputSym->value &&
                 inputSym->value->type == TYPE_FILE) {
                 stream = inputSym->value->f_val;
             }
+            pthread_mutex_unlock(&globals_mutex);
         }
         if (!stream) {
             // No default input file has been opened; treat as EOF

--- a/src/clike/main.c
+++ b/src/clike/main.c
@@ -159,7 +159,7 @@ int main(int argc, char **argv) {
     }
 
     VM vm; initVM(&vm);
-    InterpretResult result = interpretBytecode(&vm, &chunk, globalSymbols, procedure_table);
+    InterpretResult result = interpretBytecode(&vm, &chunk, globalSymbols, procedure_table, 0);
     freeVM(&vm);
     freeBytecodeChunk(&chunk);
     freeASTClike(prog);

--- a/src/clike/repl.c
+++ b/src/clike/repl.c
@@ -141,7 +141,7 @@ int main(void) {
         if (clike_error_count == 0) {
             BytecodeChunk chunk; clike_compile(prog, &chunk);
             VM vm; initVM(&vm);
-            interpretBytecode(&vm, &chunk, globalSymbols, procedure_table);
+            interpretBytecode(&vm, &chunk, globalSymbols, procedure_table, 0);
             freeVM(&vm);
             freeBytecodeChunk(&chunk);
         }

--- a/src/main.c
+++ b/src/main.c
@@ -128,7 +128,7 @@ int runProgram(const char *source, const char *programName, int dump_ast_json_fl
             if (compilation_ok_for_vm) {
                 VM vm;
                 initVM(&vm);
-                InterpretResult result_vm = interpretBytecode(&vm, &chunk, globalSymbols, procedure_table);
+                InterpretResult result_vm = interpretBytecode(&vm, &chunk, globalSymbols, procedure_table, 0);
                 freeVM(&vm);
                 globalSymbols = NULL;
                 if (result_vm == INTERPRET_OK) {

--- a/src/vm/vm_main.c
+++ b/src/vm/vm_main.c
@@ -57,7 +57,7 @@ int main(int argc, char* argv[]) {
 
     VM vm;
     initVM(&vm);
-    InterpretResult result = interpretBytecode(&vm, &chunk, globalSymbols, procedure_table);
+    InterpretResult result = interpretBytecode(&vm, &chunk, globalSymbols, procedure_table, 0);
     freeVM(&vm);
     freeBytecodeChunk(&chunk);
     if (globalSymbols) freeHashTable(globalSymbols);


### PR DESCRIPTION
## Summary
- Replace cooperative VM scheduler with POSIX-threaded execution
- Allow interpretBytecode to start at an arbitrary entry point for thread routines
- Document OS-thread based execution model

## Testing
- `cmake --build . -j2`
- `./run_all_tests` *(fails: ThreadSpawnJoinTest, ThreadJoinArrayExpr, ThreadSpawnJoin, ThreadSpawnJoinCase)*

------
https://chatgpt.com/codex/tasks/task_e_68b23c75f710832aa05a916fdef6d593