### PR TITLE
Add extended thread spawn/join debug test

### DIFF
--- a/Tests/clike/ThreadSpawnJoinDebug.cl
+++ b/Tests/clike/ThreadSpawnJoinDebug.cl
@@ -1,0 +1,28 @@
+void child1() {
+    printf("child1 start\n");
+    printf("child1 end\n");
+}
+
+void child2() {
+    printf("child2 start\n");
+    printf("child2 end\n");
+}
+
+int main() {
+    int tid1;
+    int tid2;
+    printf("parent start\n");
+
+    // Spawn and join first child
+    tid1 = spawn child1();
+    join tid1;
+    printf("joined child1\n");
+
+    // Spawn and join second child
+    tid2 = spawn child2();
+    join tid2;
+    printf("joined child2\n");
+
+    printf("parent end\n");
+    return 0;
+}

--- a/Tests/clike/ThreadSpawnJoinDebug.out
+++ b/Tests/clike/ThreadSpawnJoinDebug.out
@@ -1,0 +1,8 @@
+parent start
+child1 start
+child1 end
+joined child1
+child2 start
+child2 end
+joined child2
+parent end

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -84,6 +84,9 @@ static int createThread(VM* vm, uint16_t entry) {
 }
 
 static void joinThread(VM* vm, int id) {
+    // Thread IDs start at 1. ID 0 represents the main thread and cannot be
+    // joined through this helper. Only negative IDs or those beyond the
+    // current thread count are invalid.
     if (id <= 0 || id >= vm->threadCount) return;
     Thread* t = &vm->threads[id];
     if (t->active) {
@@ -438,7 +441,11 @@ static InterpretResult returnFromCall(VM* vm, bool* halted) {
         freeValue(&safeReturnValue);
     }
 
-    if (halted) *halted = false;
+    // Signal halt when we've popped the last call frame so the caller can
+    // terminate execution gracefully.
+    if (halted) {
+        *halted = (vm->frameCount == 0);
+    }
     return INTERPRET_OK;
 }
 


### PR DESCRIPTION
## Summary
- ensure VM halts cleanly when the final call frame returns, preventing stray execution after thread joins
- add a deterministic thread spawn/join debug test covering sequential child threads

## Testing
- `cmake --build build`
- `Tests/run_clike_tests.sh ThreadSpawnJoinDebug`
- `build/bin/clike Tests/clike/ThreadSpawnJoinCase.cl`


------
https://chatgpt.com/codex/tasks/task_e_68b257b3b098832ab728b79e13c58580