### PR TITLE
Add mutex coordination to threaded Mandelbrot example

### DIFF
--- a/Examples/clike/sdl_mandelbrot_threaded
+++ b/Examples/clike/sdl_mandelbrot_threaded
@@ -25,11 +25,28 @@ int threadEnd[4];
 volatile int rowDone[768];
 volatile int quit = 0;
 
+int rowMutex;
+int quitMutex;
+
+int getQuit() {
+    int q;
+    lock(quitMutex);
+    q = quit;
+    unlock(quitMutex);
+    return q;
+}
+
+void setQuit(int v) {
+    lock(quitMutex);
+    quit = v;
+    unlock(quitMutex);
+}
+
 void computeRows(int startY, int endY) {
     int row[1024], x, y, n, R, G, B, bufferBaseIdx;
     float c_im;
 
-    for (y = startY; y <= endY && !quit; y++) {
+    for (y = startY; y <= endY && !getQuit(); y++) {
         c_im = MaxIm - y * ImFactor;
         mandelbrotrow(MinRe, ReFactor, c_im, MaxIterations, MaxX, &row);
         for (x = 0; x <= MaxX; x++) {
@@ -46,7 +63,9 @@ void computeRows(int startY, int endY) {
             pixelData[bufferBaseIdx + 2] = B;
             pixelData[bufferBaseIdx + 3] = 255;
         }
+        lock(rowMutex);
         rowDone[y] = 1;
+        unlock(rowMutex);
     }
 }
 
@@ -58,11 +77,11 @@ void computeRowsThread3() { computeRows(threadStart[3], threadEnd[3]); }
 
 void waitForQuit() {
     char c;
-    while (!quit) {
+    while (!getQuit()) {
         if (keypressed()) {
             c = readkey();
             if (upcase(c) == 'Q') {
-                quit = 1;
+                setQuit(1);
             }
         }
         delay(10);
@@ -97,6 +116,9 @@ int main() {
         startY = endY + 1;
     }
 
+    rowMutex = mutex();
+    quitMutex = mutex();
+
     tid[0] = spawn computeRowsThread0();
     tid[1] = spawn computeRowsThread1();
     tid[2] = spawn computeRowsThread2();
@@ -104,8 +126,12 @@ int main() {
     tid[4] = spawn waitForQuit();
 
     y = 0;
-    while (y <= MaxY && !quit) {
-        if (rowDone[y]) {
+    while (y <= MaxY && !getQuit()) {
+        int done;
+        lock(rowMutex);
+        done = rowDone[y];
+        unlock(rowMutex);
+        if (done) {
             if (((y + 1) % ScreenUpdateInterval) == 0 || y == MaxY) {
                 updatetexture(textureID, pixelData);
                 cleardevice();
@@ -123,7 +149,7 @@ int main() {
         join tid[i];
 
     printf("Mandelbrot rendered. Press Q in the console to quit.\n");
-    while (!quit)
+    while (!getQuit())
         graphloop(16);
 
     join tid[4];


### PR DESCRIPTION
## Summary
- protect `quit` flag with a dedicated mutex and accessor helpers
- guard `rowDone` updates and reads with a mutex to prevent races
- create mutexes before spawning threads to ensure safe synchronization

## Testing
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68b27ca06c00832aa01fa9321806a8e1