### PR TITLE
Make dascal build optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@ add_compile_options(-Wall)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 add_compile_definitions(PROGRAM_VERSION="${PROGRAM_VERSION_STRING}")
 
+# Optionally build the debug "dascal" binary
+option(BUILD_DASCAL "Build the dascal debugging binary" OFF)
+
 # Optionally enable SDL-based features
 option(SDL "Enable SDL-based graphics and audio" OFF)
 if(SDL)
@@ -257,7 +260,9 @@ function(add_pscal_executable target_name)
 endfunction()
 
 add_pscal_executable(pascal)
-add_pscal_executable(dascal)
+if(BUILD_DASCAL)
+    add_pscal_executable(dascal)
+endif()
 # add_pscal_executable(hscal) // Lets not build this normally
 
 # Standalone VM binary
@@ -377,8 +382,12 @@ add_subdirectory(Examples)
 
 # ---- optional install ----
 include(GNUInstallDirs)
-install(TARGETS pascal dascal pscalvm
+install(TARGETS pascal pscalvm
         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+if(BUILD_DASCAL)
+    install(TARGETS dascal
+            RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+endif()
 
 add_test(NAME pascal_tests COMMAND bash ${CMAKE_SOURCE_DIR}/Tests/run_pascal_tests.sh)
 add_test(NAME clike_tests COMMAND bash ${CMAKE_SOURCE_DIR}/Tests/run_clike_tests.sh)

--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ cmake ..            # add -DSDL=ON to enable SDL support
 make
 ```
 
-Binaries are written to `build/bin` (e.g. `pascal` and `dascal`).
+Binaries are written to `build/bin` (e.g. `pascal`).
+To also build the debugging-oriented `dascal` binary, configure CMake with `-DBUILD_DASCAL=ON`.
 
-The `dascal` binary has very verbose debugging enabled
+The `dascal` binary has very verbose debugging enabled and is not built by default.
 
 To build without SDL explicitly:
 

--- a/install.sh
+++ b/install.sh
@@ -37,9 +37,9 @@ cp -r fonts/* /usr/local/pscal/fonts
 mkdir -p /usr/local/pscal/etc
 cp -r etc/* /usr/local/pscal/etc
 
-# Set group to executable
-chmod go+x /usr/local/bin/clike
-chmod go+x /usr/local/bin/clike-repl
-chmod go+x /usr/local/bin/dascal
-chmod go+x /usr/local/bin/pascal
-chmod go+x /usr/local/bin/pscalvm
+# Set group to executable for any installed binaries
+for bin in clike clike-repl dascal pascal pscalvm; do
+    if [ -f "/usr/local/bin/$bin" ]; then
+        chmod go+x "/usr/local/bin/$bin"
+    fi
+done


### PR DESCRIPTION
## Summary
- add `BUILD_DASCAL` CMake option and only build debug `dascal` when enabled
- skip installing `dascal` unless requested and handle missing binary in install script
- document how to enable `dascal`

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ls build/bin`
- `cd Tests && ./run_pascal_tests.sh`
- `cd Tests && ./run_clike_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b2954bd00c832aab01217adb8aa877