### PR TITLE
Handle lowercase quit key in SDL examples

### DIFF
--- a/Docs/clike_overview.md
+++ b/Docs/clike_overview.md
@@ -18,7 +18,8 @@ Pscal virtual machine.
 - **Concatenation with `+`** – The `+` operator joins strings, e.g.
   `buffer = mstreambuffer(ms) + "\n";`.
 - **Standard string helpers** – Built-ins such as `strlen`, `copy` and
-  `upcase` operate on `str` values.
+  `upcase` (also available as `topper`) aid string handling; `upcase`
+  converts a single character to uppercase.
 - **Dynamic allocation** – Use `new(&node);` to allocate structures;
   fields are accessed with the usual `->` syntax.
 

--- a/Docs/pscal_vm_builtins.md
+++ b/Docs/pscal_vm_builtins.md
@@ -26,7 +26,7 @@ VM. For instructions on adding your own routines, see
 | low | (a: Array or String) | Integer | Lowest index. |
 | high | (a: Array or String) | Integer | Highest index. |
 | succ | (x: Ordinal) | Ordinal | Successor of value. |
-| upcase | (ch: Char) | Char | Convert character to uppercase. |
+| upcase | (ch: Char or String) | Char | Convert character or first character of string to uppercase. Alias: `topper`. |
 | pos | (sub: String or Char, s: String) | Integer | Position of substring. |
 | copy | (s: String or Char, index: Integer, count: Integer) | String | Copy substring. |
 | paramcount | () | Integer | Number of command line parameters. |
@@ -233,7 +233,7 @@ end.
 ```c
 int main() {
   printf("Random: %d\n", random(100));
-  printf("Uppercase: %c\n", upcase('a'));
+  printf("Uppercase: %c %c\n", upcase('a'), topper('b'));
   return 0;
 }
 ```

--- a/Examples/clike/builtins.h
+++ b/Examples/clike/builtins.h
@@ -152,6 +152,7 @@ int textcolore();
 int trunc();
 int underlinetext();
 int upcase();
+int topper();
 int updatescreen();
 int updatetexture();
 int val();

--- a/Examples/clike/sdl_mandelbrot
+++ b/Examples/clike/sdl_mandelbrot
@@ -118,7 +118,7 @@ int main() {
         if (keypressed()) {
             char c;
             c = readkey();
-            if (upcase(c) == 'Q') {
+            if (topper(c) == 'Q') {
                 quit = 1;
             }
         }

--- a/Examples/clike/sdl_mandelbrot_interactive
+++ b/Examples/clike/sdl_mandelbrot_interactive
@@ -82,7 +82,7 @@ int main() {
 
         if (keypressed()) {
             char c = readkey();
-            if (upcase(c) == 'Q') {
+            if (topper(c) == 'Q') {
                 quit = 1;
             }
         }

--- a/Examples/clike/sdl_mandelbrot_threaded
+++ b/Examples/clike/sdl_mandelbrot_threaded
@@ -83,7 +83,7 @@ void waitForQuit() {
     while (!getQuit()) {
         if (keypressed()) {
             c = readkey();
-            if (upcase(c) == 'Q') {
+            if (topper(c) == 'Q') {
                 setQuit(1);
             }
         }

--- a/Examples/clike/sdl_multibouncingballs
+++ b/Examples/clike/sdl_multibouncingballs
@@ -79,7 +79,7 @@ int main() {
         if (keypressed()) {
             char c;
             c = readkey();
-            if (upcase(c) == 'Q') {
+            if (topper(c) == 'Q') {
                 quit = 1;
             }
         }

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -397,6 +397,14 @@ Value vmBuiltinUpcase(VM* vm, int arg_count, Value* args) {
         c = arg.c_val;
     } else if (IS_INTLIKE(arg)) {
         c = (int)AS_INTEGER(arg);
+    } else if (arg.type == TYPE_STRING) {
+        const char* s = AS_STRING(arg);
+        if (s && s[0] != '\0') {
+            c = (unsigned char)s[0];
+        } else {
+            runtimeError(vm, "Upcase expects a non-empty string or char argument.");
+            return makeChar('\0');
+        }
     } else {
         runtimeError(vm, "Upcase expects 1 char argument.");
         return makeChar('\0');

--- a/src/clike/builtins.c
+++ b/src/clike/builtins.c
@@ -20,6 +20,9 @@ int clike_get_builtin_id(const char *name) {
     if (strcasecmp(name, "remove") == 0) {
         name = "erase";
     }
+    if (strcasecmp(name, "topper") == 0) {
+        name = "upcase";
+    }
     return getBuiltinIDForCompiler(name);
 }
 
@@ -30,6 +33,7 @@ void clike_register_builtins(void) {
     registerBuiltinFunction("itoa", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("exit", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("remove", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("topper", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("mstreamcreate", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("mstreamloadfromfile", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("mstreamsavetofile", AST_FUNCTION_DECL, NULL);

--- a/src/clike/semantics.c
+++ b/src/clike/semantics.c
@@ -56,7 +56,8 @@ static VarType builtinReturnType(const char* name) {
     }
 
     if (strcasecmp(name, "readkey") == 0 ||
-        strcasecmp(name, "upcase")  == 0) {
+        strcasecmp(name, "upcase")  == 0 ||
+        strcasecmp(name, "topper")  == 0) {
         return TYPE_CHAR;
     }
 


### PR DESCRIPTION
## Summary
- Allow `upcase` builtin (aka `topper`) to uppercase chars or one-character strings
- Restore SDL demos to quit via `topper`, keeping case-insensitive behavior
- Document alias and expanded input handling for `upcase`

## Testing
- `./Tests/run_clike_tests.sh` *(clike binary not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2dec93010832a8ec00b2f04fd9786