### PR TITLE
Rename clike front-end functions to CamelCase

### DIFF
--- a/src/clike/builtins.c
+++ b/src/clike/builtins.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include <strings.h>
 
-int clike_get_builtin_id(const char *name) {
+int clikeGetBuiltinID(const char *name) {
     // The VM exposes Pascal's `length` builtin for string length.  Map the
     // C-like `strlen` to that builtin so we don't need a backend change.
     if (strcasecmp(name, "strlen") == 0) {
@@ -26,7 +26,7 @@ int clike_get_builtin_id(const char *name) {
     return getBuiltinIDForCompiler(name);
 }
 
-void clike_register_builtins(void) {
+void clikeRegisterBuiltins(void) {
     registerAllBuiltins();
     registerBuiltinFunction("printf", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("scanf", AST_FUNCTION_DECL, NULL);

--- a/src/clike/builtins.h
+++ b/src/clike/builtins.h
@@ -1,7 +1,7 @@
 #ifndef CLIKE_BUILTINS_H
 #define CLIKE_BUILTINS_H
 
-int clike_get_builtin_id(const char *name);
-void clike_register_builtins(void);
+int clikeGetBuiltinID(const char *name);
+void clikeRegisterBuiltins(void);
 
 #endif

--- a/src/clike/codegen.c
+++ b/src/clike/codegen.c
@@ -103,8 +103,8 @@ static Token* makeIdentTokenLocal(const char* s) {
 
 // Create a core AST node representing a builtin type token
 static AST* makeBuiltinTypeASTFromToken(ClikeToken t) {
-    const char* name = clike_tokenTypeToTypeName(t.type);
-    VarType vt = clike_tokenTypeToVarType(t.type);
+    const char* name = clikeTokenTypeToTypeName(t.type);
+    VarType vt = clikeTokenTypeToVarType(t.type);
     if (!name) return NULL;
     Token* tok = makeIdentTokenLocal(name);
     AST* node = newASTNode(AST_VARIABLE, tok);
@@ -486,7 +486,7 @@ static void compileStatement(ASTNodeClike *node, BytecodeChunk *chunk, FuncConte
                     if (node->right && node->right->type == TCAST_IDENTIFIER) {
                         if (node->right->token.type == CLIKE_TOKEN_IDENTIFIER) {
                             char *tname = tokenToCString(node->right->token);
-                            base = clike_lookup_struct(tname);
+                            base = clikeLookupStruct(tname);
                             if (!base) base = lookupType(tname);
                             free(tname);
                         } else {
@@ -1259,7 +1259,7 @@ static void patchForwardCalls(BytecodeChunk *chunk) {
     }
 }
 
-void clike_compile(ASTNodeClike *program, BytecodeChunk *chunk) {
+void clikeCompile(ASTNodeClike *program, BytecodeChunk *chunk) {
     initBytecodeChunk(chunk);
     if (!program) return;
 
@@ -1392,6 +1392,6 @@ void clike_compile(ASTNodeClike *program, BytecodeChunk *chunk) {
     free(clike_imports);
     clike_imports = NULL;
     clike_import_count = 0;
-    clike_free_structs();
+    clikeFreeStructs();
 }
 

--- a/src/clike/codegen.h
+++ b/src/clike/codegen.h
@@ -4,6 +4,6 @@
 #include "clike/ast.h"
 #include "compiler/bytecode.h"
 
-void clike_compile(ASTNodeClike *program, BytecodeChunk *chunk);
+void clikeCompile(ASTNodeClike *program, BytecodeChunk *chunk);
 
 #endif

--- a/src/clike/lexer.c
+++ b/src/clike/lexer.c
@@ -11,7 +11,7 @@ static bool isDigit(char c) {
     return c >= '0' && c <= '9';
 }
 
-void clike_initLexer(ClikeLexer *lexer, const char *source) {
+void clikeInitLexer(ClikeLexer *lexer, const char *source) {
     lexer->src = source;
     lexer->pos = 0;
     lexer->line = 1;
@@ -134,7 +134,7 @@ static ClikeToken charToken(ClikeLexer *lexer, const char *start, int column) {
     return t;
 }
 
-ClikeToken clike_nextToken(ClikeLexer *lexer) {
+ClikeToken clikeNextToken(ClikeLexer *lexer) {
     while (1) {
         char c = peek(lexer);
         if (c == '\0') return makeToken(lexer, CLIKE_TOKEN_EOF, "", 0, lexer->column);

--- a/src/clike/lexer.h
+++ b/src/clike/lexer.h
@@ -103,8 +103,8 @@ typedef struct {
     int column;
 } ClikeLexer;
 
-void clike_initLexer(ClikeLexer *lexer, const char *source);
-ClikeToken clike_nextToken(ClikeLexer *lexer);
+void clikeInitLexer(ClikeLexer *lexer, const char *source);
+ClikeToken clikeNextToken(ClikeLexer *lexer);
 const char* clikeTokenTypeToString(ClikeTokenType type);
 
 #endif

--- a/src/clike/main.c
+++ b/src/clike/main.c
@@ -85,7 +85,7 @@ int main(int argc, char **argv) {
 #ifdef SDL
     defines[define_count++] = "SDL_ENABLED";
 #endif
-    char *pre_src = clike_preprocess(src, defines, define_count);
+    char *pre_src = clikePreprocess(src, defines, define_count);
 
     ParserClike parser; initParserClike(&parser, pre_src ? pre_src : src);
     ASTNodeClike *prog = parseProgramClike(&parser);
@@ -94,7 +94,7 @@ int main(int argc, char **argv) {
     if (!verifyASTClikeLinks(prog, NULL)) {
         fprintf(stderr, "AST verification failed after parsing.\n");
         freeASTClike(prog);
-        clike_free_structs();
+        clikeFreeStructs();
         free(src);
         return vmExitWithCleanup(EXIT_FAILURE);
     }
@@ -104,7 +104,7 @@ int main(int argc, char **argv) {
         dumpASTClikeJSON(prog, stdout);
         fprintf(stderr, "\n--- AST JSON Dump Complete (stderr print)---\n");
         freeASTClike(prog);
-        clike_free_structs();
+        clikeFreeStructs();
         free(src);
         return vmExitWithCleanup(EXIT_SUCCESS);
     }
@@ -115,13 +115,13 @@ int main(int argc, char **argv) {
     }
 
     initSymbolSystemClike();
-    clike_register_builtins();
+    clikeRegisterBuiltins();
     analyzeSemanticsClike(prog);
 
     if (!verifyASTClikeLinks(prog, NULL)) {
         fprintf(stderr, "AST verification failed after semantic analysis.\n");
         freeASTClike(prog);
-        clike_free_structs();
+        clikeFreeStructs();
         free(src);
         if (globalSymbols) freeHashTable(globalSymbols);
         if (constGlobalSymbols) freeHashTable(constGlobalSymbols);
@@ -135,7 +135,7 @@ int main(int argc, char **argv) {
     if (clike_error_count > 0) {
         fprintf(stderr, "Compilation halted with %d error(s).\n", clike_error_count);
         freeASTClike(prog);
-        clike_free_structs();
+        clikeFreeStructs();
         free(src);
         if (globalSymbols) freeHashTable(globalSymbols);
         if (constGlobalSymbols) freeHashTable(constGlobalSymbols);
@@ -147,7 +147,7 @@ int main(int argc, char **argv) {
     if (!verifyASTClikeLinks(prog, NULL)) {
         fprintf(stderr, "AST verification failed after optimization.\n");
         freeASTClike(prog);
-        clike_free_structs();
+        clikeFreeStructs();
         free(src);
         if (globalSymbols) freeHashTable(globalSymbols);
         if (constGlobalSymbols) freeHashTable(constGlobalSymbols);
@@ -155,7 +155,7 @@ int main(int argc, char **argv) {
         return vmExitWithCleanup(EXIT_FAILURE);
     }
 
-    BytecodeChunk chunk; clike_compile(prog, &chunk);
+    BytecodeChunk chunk; clikeCompile(prog, &chunk);
     if (dump_bytecode_flag) {
         fprintf(stderr, "--- Compiling Main Program AST to Bytecode ---\n");
         disassembleBytecodeChunk(&chunk, path ? path : "CompiledChunk", procedure_table);
@@ -167,7 +167,7 @@ int main(int argc, char **argv) {
     freeVM(&vm);
     freeBytecodeChunk(&chunk);
     freeASTClike(prog);
-    clike_free_structs();
+    clikeFreeStructs();
     free(src);
     if (pre_src) free(pre_src);
     if (globalSymbols) freeHashTable(globalSymbols);

--- a/src/clike/parser.c
+++ b/src/clike/parser.c
@@ -6,7 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-VarType clike_tokenTypeToVarType(ClikeTokenType t) {
+VarType clikeTokenTypeToVarType(ClikeTokenType t) {
     switch (t) {
         case CLIKE_TOKEN_INT:        return TYPE_INT32;
         case CLIKE_TOKEN_LONG:       return TYPE_INT64;
@@ -24,7 +24,7 @@ VarType clike_tokenTypeToVarType(ClikeTokenType t) {
     }
 }
 
-const char *clike_tokenTypeToTypeName(ClikeTokenType t) {
+const char *clikeTokenTypeToTypeName(ClikeTokenType t) {
     switch (t) {
         case CLIKE_TOKEN_INT:    return "int";
         case CLIKE_TOKEN_LONG:   return "long";
@@ -52,7 +52,7 @@ static VarType literalTokenToVarType(ClikeTokenType t) {
 
 static void advanceParser(ParserClike *p) {
     p->current = p->next;
-    p->next = clike_nextToken(&p->lexer);
+    p->next = clikeNextToken(&p->lexer);
 }
 
 static int matchToken(ParserClike *p, ClikeTokenType type) {
@@ -129,8 +129,8 @@ static ASTNodeClike* breakStatement(ParserClike *p);
 static ASTNodeClike* continueStatement(ParserClike *p);
 static ASTNodeClike* returnStatement(ParserClike *p);
 static ASTNodeClike* switchStatement(ParserClike *p);
-ASTNodeClike* clike_spawnStatement(ParserClike *p);
-ASTNodeClike* clike_joinStatement(ParserClike *p);
+ASTNodeClike* clikeSpawnStatement(ParserClike *p);
+ASTNodeClike* clikeJoinStatement(ParserClike *p);
 
 char **clike_imports = NULL;
 int clike_import_count = 0;
@@ -234,14 +234,14 @@ static long long evalConstExpr(ASTNodeClike* node, int *ok) {
     }
 }
 
-AST* clike_lookup_struct(const char *name) {
+AST* clikeLookupStruct(const char *name) {
     for (int i = 0; i < clike_struct_count; ++i) {
         if (strcmp(clike_structs[i].name, name) == 0) return clike_structs[i].ast;
     }
     return NULL;
 }
 
-void clike_register_struct(const char *name, AST *ast) {
+void clikeRegisterStruct(const char *name, AST *ast) {
     for (int i = 0; i < clike_struct_count; ++i) {
         if (strcmp(clike_structs[i].name, name) == 0) {
             clike_structs[i].ast = ast;
@@ -261,7 +261,7 @@ void clike_register_struct(const char *name, AST *ast) {
     clike_struct_count++;
 }
 
-void clike_free_structs(void) {
+void clikeFreeStructs(void) {
     for (int i = 0; i < clike_struct_count; ++i) free(clike_structs[i].name);
     free(clike_structs);
     clike_structs = NULL;
@@ -286,8 +286,8 @@ static char* clikeTokenToCString(ClikeToken t) {
 }
 
 static AST* makeBuiltinTypeAST(ClikeToken t) {
-    const char *name = clike_tokenTypeToTypeName(t.type);
-    VarType vt = clike_tokenTypeToVarType(t.type);
+    const char *name = clikeTokenTypeToTypeName(t.type);
+    VarType vt = clikeTokenTypeToVarType(t.type);
     if (!name) { name = "integer"; vt = TYPE_INT64; }
     Token *tok = makeIdentToken(name);
     AST *node = newASTNode(AST_VARIABLE, tok);
@@ -327,9 +327,9 @@ static void queueImportPath(ParserClike *p, ClikeToken tok) {
 }
 
 void initParserClike(ParserClike *parser, const char *source) {
-    clike_initLexer(&parser->lexer, source);
-    parser->current = clike_nextToken(&parser->lexer);
-    parser->next = clike_nextToken(&parser->lexer);
+    clikeInitLexer(&parser->lexer, source);
+    parser->current = clikeNextToken(&parser->lexer);
+    parser->next = clikeNextToken(&parser->lexer);
     parser->imports = NULL;
     parser->import_count = 0;
     parser->import_capacity = 0;
@@ -453,8 +453,8 @@ static ASTNodeClike* parseArrayDim(ParserClike *p) {
 
 static ASTNodeClike* varDeclarationNoSemi(ParserClike *p, ClikeToken type_token, ClikeToken ident, int isPointer) {
     ASTNodeClike *node = newASTNodeClike(TCAST_VAR_DECL, ident);
-    node->var_type = isPointer ? TYPE_POINTER : clike_tokenTypeToVarType(type_token.type);
-    node->element_type = isPointer ? clike_tokenTypeToVarType(type_token.type) : TYPE_UNKNOWN;
+    node->var_type = isPointer ? TYPE_POINTER : clikeTokenTypeToVarType(type_token.type);
+    node->element_type = isPointer ? clikeTokenTypeToVarType(type_token.type) : TYPE_UNKNOWN;
     setRightClike(node, newASTNodeClike(TCAST_IDENTIFIER, type_token));
     node->right->var_type = node->var_type;
     if (matchToken(p, CLIKE_TOKEN_LBRACKET)) {
@@ -551,8 +551,8 @@ static ASTNodeClike* structDeclaration(ParserClike *p, ClikeToken nameTok) {
             fieldDecl->right->var_type = fieldDecl->var_type;
         } else {
             fieldDecl = newASTNodeClike(TCAST_VAR_DECL, fieldName);
-            fieldDecl->var_type = isPtr ? TYPE_POINTER : clike_tokenTypeToVarType(typeTok.type);
-            fieldDecl->element_type = isPtr ? clike_tokenTypeToVarType(typeTok.type) : TYPE_UNKNOWN;
+            fieldDecl->var_type = isPtr ? TYPE_POINTER : clikeTokenTypeToVarType(typeTok.type);
+            fieldDecl->element_type = isPtr ? clikeTokenTypeToVarType(typeTok.type) : TYPE_UNKNOWN;
             setRightClike(fieldDecl, newASTNodeClike(TCAST_IDENTIFIER, typeTok));
             fieldDecl->right->var_type = fieldDecl->var_type;
         }
@@ -573,7 +573,7 @@ static ASTNodeClike* structDeclaration(ParserClike *p, ClikeToken nameTok) {
             if (strncmp(stype, nameTok.lexeme, nameTok.length) == 0 && strlen(stype) == (size_t)nameTok.length) {
                 base = recordAst;
             } else {
-                base = clike_lookup_struct(stype);
+                base = clikeLookupStruct(stype);
             }
             if (isPtr) {
                 AST *ptrAst = newASTNode(AST_POINTER_TYPE, NULL);
@@ -603,7 +603,7 @@ static ASTNodeClike* structDeclaration(ParserClike *p, ClikeToken nameTok) {
     expectToken(p, CLIKE_TOKEN_SEMICOLON, ";");
 
     char *name = clikeTokenToCString(nameTok);
-    clike_register_struct(name, recordAst);
+    clikeRegisterStruct(name, recordAst);
     free(name);
     return node;
 }
@@ -614,8 +614,8 @@ static ASTNodeClike* funDeclaration(ParserClike *p, ClikeToken type_token, Clike
     expectToken(p, CLIKE_TOKEN_RPAREN, ")");
     ASTNodeClike *body = compoundStmt(p);
     ASTNodeClike *node = newASTNodeClike(TCAST_FUN_DECL, ident);
-    node->var_type = isPointer ? TYPE_POINTER : clike_tokenTypeToVarType(type_token.type);
-    if (isPointer) node->element_type = clike_tokenTypeToVarType(type_token.type);
+    node->var_type = isPointer ? TYPE_POINTER : clikeTokenTypeToVarType(type_token.type);
+    if (isPointer) node->element_type = clikeTokenTypeToVarType(type_token.type);
     setLeftClike(node, paramsNode);
     setRightClike(node, body);
     return node;
@@ -658,8 +658,8 @@ static ASTNodeClike* param(ParserClike *p) {
         if (p->current.type == CLIKE_TOKEN_STAR) { advanceParser(p); isPtr = 1; }
         ClikeToken ident = p->current; expectToken(p, CLIKE_TOKEN_IDENTIFIER, "param name");
         ASTNodeClike *node = newASTNodeClike(TCAST_PARAM, ident);
-        node->var_type = isPtr ? TYPE_POINTER : clike_tokenTypeToVarType(type_tok.type);
-        node->element_type = isPtr ? clike_tokenTypeToVarType(type_tok.type) : TYPE_UNKNOWN;
+        node->var_type = isPtr ? TYPE_POINTER : clikeTokenTypeToVarType(type_tok.type);
+        node->element_type = isPtr ? clikeTokenTypeToVarType(type_tok.type) : TYPE_UNKNOWN;
         setLeftClike(node, newASTNodeClike(TCAST_IDENTIFIER, type_tok));
         node->left->var_type = node->var_type;
         node->is_const = isConst;
@@ -736,7 +736,7 @@ static ASTNodeClike* statement(ParserClike *p) {
         case CLIKE_TOKEN_BREAK: return breakStatement(p);
         case CLIKE_TOKEN_CONTINUE: return continueStatement(p);
         case CLIKE_TOKEN_RETURN: return returnStatement(p);
-        case CLIKE_TOKEN_JOIN: return clike_joinStatement(p);
+        case CLIKE_TOKEN_JOIN: return clikeJoinStatement(p);
         case CLIKE_TOKEN_LBRACE: return compoundStmt(p);
         default: return expressionStatement(p);
     }
@@ -920,7 +920,7 @@ static ASTNodeClike* returnStatement(ParserClike *p) {
     return node;
 }
 
-ASTNodeClike* clike_joinStatement(ParserClike *p) {
+ASTNodeClike* clikeJoinStatement(ParserClike *p) {
     ClikeToken tok = p->current;
     expectToken(p, CLIKE_TOKEN_JOIN, "join");
     ASTNodeClike *expr = expression(p);
@@ -930,7 +930,7 @@ ASTNodeClike* clike_joinStatement(ParserClike *p) {
     return node;
 }
 
-ASTNodeClike* clike_spawnStatement(ParserClike *p) {
+ASTNodeClike* clikeSpawnStatement(ParserClike *p) {
     ClikeToken tok = p->current;
     expectToken(p, CLIKE_TOKEN_SPAWN, "spawn");
     ClikeToken ident = p->current;
@@ -1177,7 +1177,7 @@ static ASTNodeClike* unary(ParserClike *p) {
                 ClikeToken type_tok = parseTypeToken(p);
                 expectToken(p, CLIKE_TOKEN_RPAREN, ")");
                 operand = newASTNodeClike(TCAST_IDENTIFIER, type_tok);
-                operand->var_type = clike_tokenTypeToVarType(type_tok.type);
+                operand->var_type = clikeTokenTypeToVarType(type_tok.type);
             } else {
                 operand = expression(p);
                 expectToken(p, CLIKE_TOKEN_RPAREN, ")");
@@ -1194,7 +1194,7 @@ static ASTNodeClike* unary(ParserClike *p) {
 
 static ASTNodeClike* factor(ParserClike *p) {
     if (p->current.type == CLIKE_TOKEN_SPAWN) {
-        return clike_spawnStatement(p);
+        return clikeSpawnStatement(p);
     }
     if (matchToken(p, CLIKE_TOKEN_LPAREN)) {
         if (isTypeToken(p->current.type)) {

--- a/src/clike/parser.h
+++ b/src/clike/parser.h
@@ -19,18 +19,18 @@ typedef struct {
 void initParserClike(ParserClike *parser, const char *source);
 void freeParserClike(ParserClike *parser);
 ASTNodeClike* parseProgramClike(ParserClike *parser);
-ASTNodeClike* clike_spawnStatement(ParserClike *p);
-ASTNodeClike* clike_joinStatement(ParserClike *p);
+ASTNodeClike* clikeSpawnStatement(ParserClike *p);
+ASTNodeClike* clikeJoinStatement(ParserClike *p);
 
 extern char **clike_imports;
 extern int clike_import_count;
 
 // Struct type registration and lookup
-AST* clike_lookup_struct(const char *name);
-void clike_register_struct(const char *name, AST *ast);
-void clike_free_structs(void);
+AST* clikeLookupStruct(const char *name);
+void clikeRegisterStruct(const char *name, AST *ast);
+void clikeFreeStructs(void);
 
-VarType clike_tokenTypeToVarType(ClikeTokenType t);
-const char* clike_tokenTypeToTypeName(ClikeTokenType t);
+VarType clikeTokenTypeToVarType(ClikeTokenType t);
+const char* clikeTokenTypeToTypeName(ClikeTokenType t);
 
 #endif

--- a/src/clike/preproc.c
+++ b/src/clike/preproc.c
@@ -11,7 +11,7 @@ static bool isDefined(const char *name, const char **defines, int count) {
     return false;
 }
 
-char* clike_preprocess(const char *source, const char **defines, int count) {
+char* clikePreprocess(const char *source, const char **defines, int count) {
     if (!source) return NULL;
     size_t len = strlen(source);
     char *out = (char*)malloc(len + 1);

--- a/src/clike/preproc.h
+++ b/src/clike/preproc.h
@@ -1,6 +1,6 @@
 #ifndef CLIKE_PREPROC_H
 #define CLIKE_PREPROC_H
 
-char* clike_preprocess(const char *source, const char **defines, int define_count);
+char* clikePreprocess(const char *source, const char **defines, int define_count);
 
 #endif // CLIKE_PREPROC_H

--- a/src/clike/repl.c
+++ b/src/clike/repl.c
@@ -58,7 +58,7 @@ int main(void) {
 #ifdef SDL
         defines[define_count++] = "SDL_ENABLED";
 #endif
-        char *pre_src = clike_preprocess(src, defines, define_count);
+        char *pre_src = clikePreprocess(src, defines, define_count);
 
         ParserClike parser; initParserClike(&parser, pre_src ? pre_src : src);
         ASTNodeClike *prog = parseProgramClike(&parser);
@@ -105,20 +105,20 @@ int main(void) {
         if (!verifyASTClikeLinks(prog, NULL)) {
             fprintf(stderr, "AST verification failed after parsing.\n");
             freeASTClike(prog);
-            clike_free_structs();
+            clikeFreeStructs();
             free(src);
             for (int i = 0; i < clike_import_count; ++i) free(clike_imports[i]);
             free(clike_imports); clike_imports = NULL; clike_import_count = 0;
             return vmExitWithCleanup(EXIT_FAILURE);
         }
         initSymbolSystemClike();
-        clike_register_builtins();
+        clikeRegisterBuiltins();
         analyzeSemanticsClike(prog);
 
         if (!verifyASTClikeLinks(prog, NULL)) {
             fprintf(stderr, "AST verification failed after semantic analysis.\n");
             freeASTClike(prog);
-            clike_free_structs();
+            clikeFreeStructs();
             free(src);
             if (globalSymbols) freeHashTable(globalSymbols);
             if (constGlobalSymbols) freeHashTable(constGlobalSymbols);
@@ -132,7 +132,7 @@ int main(void) {
         if (!verifyASTClikeLinks(prog, NULL)) {
             fprintf(stderr, "AST verification failed after optimization.\n");
             freeASTClike(prog);
-            clike_free_structs();
+            clikeFreeStructs();
             free(src);
             if (globalSymbols) freeHashTable(globalSymbols);
             if (constGlobalSymbols) freeHashTable(constGlobalSymbols);
@@ -142,14 +142,14 @@ int main(void) {
             return vmExitWithCleanup(EXIT_FAILURE);
         }
         if (clike_error_count == 0) {
-            BytecodeChunk chunk; clike_compile(prog, &chunk);
+            BytecodeChunk chunk; clikeCompile(prog, &chunk);
             VM vm; initVM(&vm);
             interpretBytecode(&vm, &chunk, globalSymbols, constGlobalSymbols, procedure_table, 0);
             freeVM(&vm);
             freeBytecodeChunk(&chunk);
         }
         freeASTClike(prog);
-        clike_free_structs();
+        clikeFreeStructs();
         if (pre_src) free(pre_src);
         free(src);
         if (globalSymbols) freeHashTable(globalSymbols);

--- a/src/clike/semantics.c
+++ b/src/clike/semantics.c
@@ -325,7 +325,7 @@ static VarType analyzeExpr(ASTNodeClike *node, ScopeStack *scopes) {
             size_t size = 0;
             if (node->left) {
                 ASTNodeClike *operand = node->left;
-                VarType tokenType = clike_tokenTypeToVarType(operand->token.type);
+                VarType tokenType = clikeTokenTypeToVarType(operand->token.type);
                 if (operand->type == TCAST_IDENTIFIER && tokenType != TYPE_UNKNOWN && operand->token.type != CLIKE_TOKEN_IDENTIFIER) {
                     size = varTypeSize(tokenType);
                 } else {
@@ -430,7 +430,7 @@ static VarType analyzeExpr(ASTNodeClike *node, ScopeStack *scopes) {
 
             VarType t = getFunctionType(name);
             if (t == TYPE_UNKNOWN) {
-                int bid = clike_get_builtin_id(name);
+                int bid = clikeGetBuiltinID(name);
                 if (bid != -1) {
                     t = builtinReturnType(name);
                 } else {

--- a/src/clike/stubs.c
+++ b/src/clike/stubs.c
@@ -9,7 +9,7 @@
 
 AST* lookupType(const char* name) {
     // First, see if this name refers to a previously-declared struct.
-    AST* type = clike_lookup_struct(name);
+    AST* type = clikeLookupStruct(name);
     if (type) return type;
 
     // Otherwise, create a simple AST node for one of the builtin types.


### PR DESCRIPTION
## Summary
- Align clike front-end with CamelCase naming convention

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `timeout 100 ./Tests/run_all_tests`

------
https://chatgpt.com/codex/tasks/task_e_68b33e583180832aa42d12b1b65e86b5