### PR TITLE
Handle varying working directories in ApiSendReceiveTest

### DIFF
--- a/Tests/Pascal/ApiSendReceiveTest
+++ b/Tests/Pascal/ApiSendReceiveTest
@@ -7,7 +7,14 @@ var
   cwd: string;
 begin
   cwd := getenv('PWD');
-  url := 'file://' + cwd + '/Pascal/apiSendReceiveTest.data';
+  { Determine the correct path to the data file whether the test is
+    executed from the Tests directory or the Pascal subdirectory }
+  { The data file is named "ApiSendReceiveTest.data" (note the capital A).
+    Support running either from the Tests directory or its Pascal subdirectory. }
+  if fileexists(cwd + '/ApiSendReceiveTest.data') then
+    url := 'file://' + cwd + '/ApiSendReceiveTest.data'
+  else
+    url := 'file://' + cwd + '/Pascal/ApiSendReceiveTest.data';
   ms := apiSend(url, '');
   response := apiReceive(ms);
   if pos('Example Domain', response) = 0 then


### PR DESCRIPTION
## Summary
- Make ApiSendReceiveTest locate its data file regardless of whether it's run from `Tests` or `Tests/Pascal`
- Correct file name casing when constructing the `file://` URL

## Testing
- `../build/bin/pascal Pascal/ApiSendReceiveTest`
- `../../build/bin/pascal ApiSendReceiveTest`

------
https://chatgpt.com/codex/tasks/task_e_68b36c515b58832a863720d9f0360f29