### PR TITLE
docs: add threading notes for extended built-ins

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -21,6 +21,6 @@ Start here to explore the available guides and references in this directory.
 ## Virtual machine
 - [pscal_vm_overview.md](pscal_vm_overview.md): stack-based VM architecture and opcode reference.
 - [pscal_vm_builtins.md](pscal_vm_builtins.md): catalog of built-in functions provided by the VM.
-- [extending_builtins.md](extending_builtins.md): how to add custom built-in routines.
+- [extended_builtins.md](extended_builtins.md): how to add custom built-in routines.
 - [standalone_vm_frontends.md](standalone_vm_frontends.md): writing external frontends that emit Pscal bytecode.
 

--- a/Docs/extended_builtins.md
+++ b/Docs/extended_builtins.md
@@ -29,6 +29,22 @@ the following CMake options (all default to `ON`):
 -DENABLE_EXT_BUILTIN_USER=ON/OFF
 ```
 
+## Threading considerations
+
+Extended built-ins execute inside the VM and may be called from multiple
+threads when the host application uses the interpreter concurrently.  To
+avoid race conditions or other undefined behavior:
+
+- Avoid mutable global or static state, or guard it with appropriate
+  synchronization primitives.
+- Prefer thread-safe library routines and be cautious when sharing
+  resources such as files or sockets.
+- Keep critical sections short and do not hold locks while calling back
+  into the VM.
+
+The VM itself does not provide locking for custom built-ins, so each
+extension is responsible for its own thread safety.
+
 ## Creating a new built-in
 
 1. Choose a category under `src/ext_builtins` or create a new one.  For

--- a/Docs/project_overview.md
+++ b/Docs/project_overview.md
@@ -12,7 +12,7 @@ Detailed descriptions of the Pascal and C-like front ends can be found in
 [`pscal_vm_overview.md`](pscal_vm_overview.md), and instructions for building
 custom front ends or extending VM builtins are in
 [`standalone_vm_frontends.md`](standalone_vm_frontends.md) and
-[`extending_builtins.md`](extending_builtins.md).
+[`extended_builtins.md`](extended_builtins.md).
 
 All frontends generate a compact bytecode stream that is executed by the VM. This virtual machine provides a rich set of built-in routines and offers optional integrations with **SDL2** for graphics and audio, and **libcurl** for networking. The system is designed to be easily extensible, allowing for the addition of new built-in functions.
 

--- a/Docs/pscal_vm_builtins.md
+++ b/Docs/pscal_vm_builtins.md
@@ -2,7 +2,7 @@
 
 This document lists the built-in procedures and functions provided by the Pscal
 VM. For instructions on adding your own routines, see
-[`extending_builtins.md`](extending_builtins.md).
+[`extended_builtins.md`](extended_builtins.md).
 
 ## General
 

--- a/Docs/standalone_vm_frontends.md
+++ b/Docs/standalone_vm_frontends.md
@@ -171,7 +171,7 @@ demonstrated in `src/clike/codegen.c`.
 Opcodes `OP_CALL_BUILTIN` and `OP_CALL_BUILTIN_PROC` invoke the VM's built-in
 functions and procedures. The VM exposes a large catalog of routines described in
 `Docs/pscal_vm_builtins.md`. To add your own, see
-[`extending_builtins.md`](extending_builtins.md).
+[`extended_builtins.md`](extended_builtins.md).
 
 To invoke a builtin from generated code:
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ sudo ./install.sh
 Additional VM builtin functions can be linked in by dropping C source files into
 `src/ext_builtins`.  Each file should implement a `registerExtendedBuiltins`
 function that registers its routines.  See
-[Docs/extending_builtins.md](Docs/extending_builtins.md) for details and an
+[Docs/extended_builtins.md](Docs/extended_builtins.md) for details and an
 example that exposes the host process ID in `src/ext_builtins/getpid.c`.
 
 ## License


### PR DESCRIPTION
## Summary
- document threading considerations for custom VM built-ins
- rename `extending_builtins.md` to `extended_builtins.md`
- update documentation links to new file name

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68b379d053a8832a9f92eaf8df18eeaa