### PR TITLE
refactor: conditionally lock builtins

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -2133,13 +2133,11 @@ Value vmBuiltinEof(VM* vm, int arg_count, Value* args) {
 
     if (arg_count == 0) {
         if (vm->vmGlobalSymbols) {
-            pthread_mutex_lock(&globals_mutex);
             Symbol* inputSym = hashTableLookup(vm->vmGlobalSymbols, "input");
             if (inputSym && inputSym->value &&
                 inputSym->value->type == TYPE_FILE) {
                 stream = inputSym->value->f_val;
             }
-            pthread_mutex_unlock(&globals_mutex);
         }
         if (!stream) {
             // No default input file has been opened; treat as EOF

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -699,7 +699,8 @@ static InterpretResult handleDefineGlobal(VM* vm, Value varNameVal) {
 // structures can execute without acquiring the global lock.
 static bool builtinUsesGlobalStructures(const char* name) {
     if (!name) return false;
-    return strcmp(name, "eof") == 0;
+    return strcmp(name, "eof") == 0 ||
+           strcmp(name, "dispose") == 0;
 }
 
 // --- Main Interpretation Loop ---


### PR DESCRIPTION
## Summary
- Only acquire the global interpreter mutex for builtins that access shared state
- Remove redundant locking in `eof` builtin

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: Interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b379f413c4832aaead91a576b32068