### PR TITLE
refactor: conditionally lock builtins

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -2133,13 +2133,11 @@ Value vmBuiltinEof(VM* vm, int arg_count, Value* args) {
 
     if (arg_count == 0) {
         if (vm->vmGlobalSymbols) {
-            pthread_mutex_lock(&globals_mutex);
             Symbol* inputSym = hashTableLookup(vm->vmGlobalSymbols, "input");
             if (inputSym && inputSym->value &&
                 inputSym->value->type == TYPE_FILE) {
                 stream = inputSym->value->f_val;
             }
-            pthread_mutex_unlock(&globals_mutex);
         }
         if (!stream) {
             // No default input file has been opened; treat as EOF

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -694,6 +694,40 @@ static InterpretResult handleDefineGlobal(VM* vm, Value varNameVal) {
     return INTERPRET_OK;
 }
 
+// Determine if a core VM builtin requires access to global interpreter
+// structures protected by globals_mutex. Builtins that do not touch such
+// structures can execute without acquiring the global lock.
+static bool builtinUsesGlobalStructures(const char* name) {
+    if (!name) return false;
+
+    /*
+     * Builtins listed here read or modify interpreter globals declared in
+     * Pascal/globals.c (symbol tables, IO state, CRT state, etc.). They must
+     * execute while holding globals_mutex to avoid races with other
+     * interpreter threads touching the same shared state.
+     */
+    static const char* const needs_lock[] = {
+        "append",         "assign",        "biblinktext",   "biboldtext",
+        "biclrscr",       "bilowvideo",    "binormvideo",   "biunderlinetext",
+        "biwherex",       "biwherey",      "blinktext",     "boldtext",
+        "close",          "clreol",        "clrscr",        "cursoroff",
+        "cursoron",       "deline",        "dispose",       "eof",
+        "erase",          "gotoxy",        "hidecursor",    "highvideo",
+        "ioresult",       "insline",       "invertcolors",  "lowvideo",
+        "normvideo",      "normalcolors",  "paramcount",    "paramstr",
+        "quitrequested",  "read",          "readln",        "rename",
+        "reset",          "rewrite",       "screenrows",    "screencols",
+        "showcursor",     "textbackground", "textbackgrounde","textcolor",
+        "textcolore",     "underlinetext", "window",        "wherex",
+        "wherey",
+    };
+
+    for (size_t i = 0; i < sizeof(needs_lock)/sizeof(needs_lock[0]); i++) {
+        if (strcmp(name, needs_lock[i]) == 0) return true;
+    }
+    return false;
+}
+
 // --- Main Interpretation Loop ---
 InterpretResult interpretBytecode(VM* vm, BytecodeChunk* chunk, HashTable* globals, HashTable* const_globals, HashTable* procedures, uint16_t entry) {
     if (!vm || !chunk) return INTERPRET_RUNTIME_ERROR;
@@ -2545,9 +2579,10 @@ comparison_error_label:
                 VmBuiltinFn handler = getVmBuiltinHandler(builtin_name_lower); // Pass the lowercase name
 
                 if (handler) {
-                    pthread_mutex_lock(&globals_mutex);
+                    bool needs_lock = builtinUsesGlobalStructures(builtin_name_lower);
+                    if (needs_lock) pthread_mutex_lock(&globals_mutex);
                     Value result = handler(vm, arg_count, args);
-                    pthread_mutex_unlock(&globals_mutex);
+                    if (needs_lock) pthread_mutex_unlock(&globals_mutex);
 
                     // Pop arguments from the stack and free their contents
                     // This is crucial to prevent stack corruption.


### PR DESCRIPTION
## Summary
- Only acquire the global interpreter mutex for builtins that access shared state
- Remove redundant locking in `eof` builtin
- Lock `dispose` builtin when nullifying aliases
- Guard additional builtins that touch global interpreter variables

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b379f413c4832aaead91a576b32068