### PR TITLE
Handle mixed boolean and integer operands in logical ops

### DIFF
--- a/Examples/clike/sdl_mandelbrot_interactive
+++ b/Examples/clike/sdl_mandelbrot_interactive
@@ -107,7 +107,16 @@ int main() {
                 int done, update;
                 lock(rowMutex);
                 done = rowDone[y];
-                update = done && (((y + 1) % ScreenUpdateInterval) == 0 || y == Height - 1);
+                /*
+                 * "done" is stored as an integer in rowDone[y].  The logical
+                 * operators in CLike require both operands to be of the same
+                 * type (either both integers or both booleans).  The expression
+                 * on the right-hand side produces a boolean result, so we
+                 * explicitly compare "done" against zero to convert it to a
+                 * boolean before using the && operator.  This avoids a runtime
+                 * type error when mixing INTEGER and BOOLEAN values.
+                 */
+                update = (done != 0) && (((y + 1) % ScreenUpdateInterval) == 0 || y == Height - 1);
                 if (update)
                     updatetexture(textureID, pixelData);
                 if (done)

--- a/src/clike/codegen.c
+++ b/src/clike/codegen.c
@@ -705,7 +705,17 @@ static void compileExpression(ASTNodeClike *node, BytecodeChunk *chunk, FuncCont
         }
         case TCAST_BINOP:
             compileExpression(node->left, chunk, ctx);
+            if (node->token.type == CLIKE_TOKEN_AND_AND ||
+                node->token.type == CLIKE_TOKEN_OR_OR) {
+                writeBytecodeChunk(chunk, OP_NOT, node->token.line);
+                writeBytecodeChunk(chunk, OP_NOT, node->token.line);
+            }
             compileExpression(node->right, chunk, ctx);
+            if (node->token.type == CLIKE_TOKEN_AND_AND ||
+                node->token.type == CLIKE_TOKEN_OR_OR) {
+                writeBytecodeChunk(chunk, OP_NOT, node->token.line);
+                writeBytecodeChunk(chunk, OP_NOT, node->token.line);
+            }
             switch (node->token.type) {
                 case CLIKE_TOKEN_PLUS: writeBytecodeChunk(chunk, OP_ADD, node->token.line); break;
                 case CLIKE_TOKEN_MINUS: writeBytecodeChunk(chunk, OP_SUBTRACT, node->token.line); break;


### PR DESCRIPTION
## Summary
- Ensure logical `&&` and `||` cast operands to boolean so integers and booleans can be mixed like in C

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68b38933d7c4832ab1e82c09378e2ed8