### PR TITLE
Fix SDL event polling for interactive Mandelbrot example

### DIFF
--- a/Examples/clike/sdl_mandelbrot_interactive
+++ b/Examples/clike/sdl_mandelbrot_interactive
@@ -80,6 +80,13 @@ int main() {
     quitMutex = mutex();
 
     while (!getQuit()) {
+        /*
+         * Pump SDL events before handling input so mouse and keyboard state
+         * are up to date.  Previously this was done at the end of the loop,
+         * which could miss short clicks that occurred between polls.
+         */
+        graphloop(16);
+
         if (redraw) {
             maxIm = minIm + (maxRe - minRe) * Height / Width;
             reFactor = (maxRe - minRe) / (Width - 1);
@@ -174,8 +181,6 @@ int main() {
             redraw = 1;
         }
         prevButtons = mouseButtons;
-
-        graphloop(16);
     }
 
     destroytexture(textureID);


### PR DESCRIPTION
## Summary
- Pump SDL events before reading input in the interactive Mandelbrot demo to capture mouse clicks reliably

## Testing
- `Tests/run_all_tests` (fails: pascal/clike/pscalvm binaries missing)


------
https://chatgpt.com/codex/tasks/task_e_68b38e1fd060832ab2aa5d7c89211dcd