### PR TITLE
Treat boolean as integer-like for CLike

### DIFF
--- a/Examples/clike/sdl_mandelbrot_interactive
+++ b/Examples/clike/sdl_mandelbrot_interactive
@@ -123,7 +123,7 @@ int main() {
                  * boolean before using the && operator.  This avoids a runtime
                  * type error when mixing INTEGER and BOOLEAN values.
                  */
-                update = (done != 0) && (((y + 1) % ScreenUpdateInterval) == 0 || y == Height - 1);
+                update = ((done != 0) && (((y + 1) % ScreenUpdateInterval) == 0 || y == Height - 1)) ? 1 : 0;
                 if (update)
                     updatetexture(textureID, pixelData);
                 if (done)

--- a/src/clike/parser.c
+++ b/src/clike/parser.c
@@ -190,6 +190,7 @@ static inline int isIntlikeTypeLocal(VarType t) {
         case TYPE_UINT32:
         case TYPE_INT64:
         case TYPE_UINT64:
+        case TYPE_BOOLEAN:
             return 1;
         default:
             return 0;

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -76,6 +76,7 @@ static inline bool isIntlikeType(VarType t) {
         case TYPE_INT64:
         case TYPE_UINT64:
             return true;
+        case TYPE_BOOLEAN:
         case TYPE_CHAR:
             return true;
         default:
@@ -96,8 +97,8 @@ static inline bool isRealType(VarType t) {
 
 static inline bool isOrdinalType(VarType t) {
     // Pascal ordinals: integer subranges, enumerations, char, boolean.
-    // Here we treat INTEGER/BYTE/WORD/CHAR/ENUM (BOOLEAN optional) as ordinal.
-    return isIntlikeType(t) || t == TYPE_CHAR || t == TYPE_ENUM /*|| t == TYPE_BOOLEAN*/;
+    // Treat INTEGER/BYTE/WORD/BOOLEAN/CHAR/ENUM as ordinal.
+    return isIntlikeType(t) || t == TYPE_CHAR || t == TYPE_ENUM;
 }
 
 static inline long long coerceToI64(const Value* v, VM* vm, const char* who) {


### PR DESCRIPTION
## Summary
- Recognize boolean values as integer-like so they can be implicitly converted in numeric contexts
- Extend CLike constant-expression evaluation to treat booleans as integer types

## Testing
- `cd Tests && ./run_all_tests`


------
https://chatgpt.com/codex/tasks/task_e_68b390d51058832abd0f6bb26a450a5e