### PR TITLE
Fix interactive Mandelbrot example exit handling

### DIFF
--- a/Examples/clike/sdl_mandelbrot_interactive
+++ b/Examples/clike/sdl_mandelbrot_interactive
@@ -136,7 +136,7 @@ int main() {
                     updatescreen();
                 }
                 if (keypressed()) {
-                    char c = readkey();
+                    int c = readkey();
                     if (toupper(c) == 'Q') setQuit(1);
                 }
                 if (!done || update)
@@ -146,17 +146,11 @@ int main() {
             for (i = 0; i < ThreadCount; i++)
                 join tid[i];
 
-            if (!getQuit()) {
-                updatetexture(textureID, pixelData);
-                cleardevice();
-                rendercopy(textureID);
-                updatescreen();
-                redraw = 0;
-            }
+            redraw = 0;
         }
 
         if (keypressed()) {
-            char c = readkey();
+            int c = readkey();
             if (toupper(c) == 'Q') { setQuit(1); continue; }
         }
 


### PR DESCRIPTION
## Summary
- fix crash when quitting Mandelbrot demo by reading key as int before using `toupper`
- remove redundant final texture update to avoid extra render delay

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd Tests && make test` *(fails: Pascal library directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b39f9ebbc0832aa6ff61a818ac3f97