### PR TITLE
Align interactive Mandelbrot demo with threaded main

### DIFF
--- a/Examples/clike/sdl_mandelbrot_interactive
+++ b/Examples/clike/sdl_mandelbrot_interactive
@@ -1,47 +1,62 @@
 #!/usr/bin/env clike
 /*
- * SDL Mandelbrot renderer using the MandelbrotRow builtin with threading.
- * Left click to zoom in, right click to zoom out, Q to quit.
+ * Threaded SDL Mandelbrot set renderer using mandelbrotrow.
+ * The window updates as rows are drawn. Press Q in the console to quit.
  */
 
-const int Width = 1200;
-const int Height = 900;
+const int WindowWidth = 1200;
+const int WindowHeight = 900;
 const int MaxIterations = 200;
-const int BytesPerPixel = 4;
+const double MinRe = -2.0;
+const double MaxRe = 1.0;
 const int ScreenUpdateInterval = 16;
-const double ZoomFactor = 4.0;
-const int ThreadCount = 4;
+const int MandelBytesPerPixel = 4;
 
-byte pixelData[Width * Height * BytesPerPixel];
-int rowDone[Height];
-int threadStart[ThreadCount];
-int threadEnd[ThreadCount];
-
-double minRe = -2.0;
-double maxRe = 1.0;
-double minIm = -1.2;
-double maxIm;
-double reFactor;
-double imFactor;
-
+byte pixelData[WindowWidth * WindowHeight * MandelBytesPerPixel];
 int textureID;
+
+double ImRange;
+double MinIm;
+double MaxIm;
+double ReFactor;
+double ImFactor;
+int MaxX;
+int MaxY;
+
+int threadCount = 4;
+int threadStart[4];
+int threadEnd[4];
+
+int rowDone[WindowHeight];
+int quit = 0;
+
 int rowMutex;
 int quitMutex;
-int quit = 0;
-int redraw = 1;
 
-int getQuit() { int q; lock(quitMutex); q = quit; unlock(quitMutex); return q; }
-void setQuit(int v) { lock(quitMutex); quit = v; unlock(quitMutex); }
+int getQuit() {
+    int q;
+    lock(quitMutex);
+    q = quit;
+    unlock(quitMutex);
+    return q;
+}
+
+void setQuit(int v) {
+    lock(quitMutex);
+    quit = v;
+    unlock(quitMutex);
+}
 
 void computeRows(int startY, int endY) {
-    int row[Width], x, y, n, R, G, B, idx;
+    int row[WindowWidth];
+    int x, y, n, R, G, B, bufferBaseIdx;
     double c_im;
+
     for (y = startY; y <= endY && !getQuit(); y++) {
-        c_im = maxIm - y * imFactor;
-        mandelbrotrow(minRe, reFactor, c_im, MaxIterations, Width - 1, &row);
-        idx = y * Width * BytesPerPixel;
+        c_im = MaxIm - y * ImFactor;
+        mandelbrotrow(MinRe, ReFactor, c_im, MaxIterations, MaxX, &row);
         lock(rowMutex);
-        for (x = 0; x < Width; x++) {
+        for (x = 0; x <= MaxX; x++) {
             n = row[x];
             if (n == MaxIterations) { R = G = B = 0; }
             else {
@@ -49,11 +64,11 @@ void computeRows(int startY, int endY) {
                 G = (n * 7 + 85) % 256;
                 B = (n * 11 + 170) % 256;
             }
-            pixelData[idx + 0] = R;
-            pixelData[idx + 1] = G;
-            pixelData[idx + 2] = B;
-            pixelData[idx + 3] = 255;
-            idx += BytesPerPixel;
+            bufferBaseIdx = (y * (MaxX + 1) + x) * MandelBytesPerPixel;
+            pixelData[bufferBaseIdx + 0] = R;
+            pixelData[bufferBaseIdx + 1] = G;
+            pixelData[bufferBaseIdx + 2] = B;
+            pixelData[bufferBaseIdx + 3] = 255;
         }
         rowDone[y] = 1;
         unlock(rowMutex);
@@ -65,119 +80,89 @@ void computeRowsThread1() { computeRows(threadStart[1], threadEnd[1]); }
 void computeRowsThread2() { computeRows(threadStart[2], threadEnd[2]); }
 void computeRowsThread3() { computeRows(threadStart[3], threadEnd[3]); }
 
-int main() {
-    int mouseX = 0, mouseY = 0, mouseButtons = 0, prevButtons = 0;
-    int ButtonLeft = 1, ButtonRight = 4;
-    int tid[ThreadCount], i, y, rowsPerThread, extra, startY, endY;
+void waitForQuit() {
+    char c;
+    while (!getQuit()) {
+        if (keypressed()) {
+            c = readkey();
+            if (toupper(c) == 'Q') {
+                setQuit(1);
+            }
+        }
+        delay(16);
+    }
+}
 
-    printf("Calculating Mandelbrot set. The window will update as rows are drawn...\n");
-    initgraph(Width, Height, "Mandelbrot in CLike (threaded)");
-    textureID = createtexture(Width, Height);
+int main() {
+    int i, startY, endY, rowsPerThread, extra, tid[5], y, done, needRedraw;
+
+    printf("Calculating Mandelbrot set with threads. The window will update as rows are drawn...\n");
+    initgraph(WindowWidth, WindowHeight, "Threaded Mandelbrot (mandelbrotrow)");
+    textureID = createtexture(WindowWidth, WindowHeight);
     if (textureID < 0) { printf("Error: unable to create texture.\n"); halt(); }
     cleardevice(); updatescreen();
+    MaxX = getmaxx(); MaxY = getmaxy();
+
+    ImRange = (MaxRe - MinRe) * MaxY / MaxX;
+    MinIm = -ImRange / 2.0; MaxIm = MinIm + ImRange;
+    ReFactor = (MaxRe - MinRe) / (MaxX - 1);
+    ImFactor = (MaxIm - MinIm) / (MaxY - 1);
+
+    for (i = 0; i <= MaxY; i++) rowDone[i] = 0;
+
+    rowsPerThread = (MaxY + 1) / threadCount;
+    extra = (MaxY + 1) % threadCount;
+    startY = 0;
+    for (i = 0; i < threadCount; i++) {
+        endY = startY + rowsPerThread - 1;
+        if (extra > 0) { endY++; extra--; }
+        threadStart[i] = startY;
+        threadEnd[i]   = endY;
+        startY = endY + 1;
+    }
 
     rowMutex = mutex();
     quitMutex = mutex();
 
-    while (!getQuit()) {
-        /*
-         * Pump SDL events before handling input so mouse and keyboard state
-         * are up to date.  Previously this was done at the end of the loop,
-         * which could miss short clicks that occurred between polls.
-         */
-        graphloop(16);
+    tid[0] = spawn computeRowsThread0();
+    tid[1] = spawn computeRowsThread1();
+    tid[2] = spawn computeRowsThread2();
+    tid[3] = spawn computeRowsThread3();
+    tid[4] = spawn waitForQuit();
 
-        if (redraw) {
-            maxIm = minIm + (maxRe - minRe) * Height / Width;
-            reFactor = (maxRe - minRe) / (Width - 1);
-            imFactor = (maxIm - minIm) / (Height - 1);
-            for (i = 0; i < Height; i++) rowDone[i] = 0;
-
-            rowsPerThread = Height / ThreadCount;
-            extra = Height % ThreadCount;
-            startY = 0;
-            for (i = 0; i < ThreadCount; i++) {
-                endY = startY + rowsPerThread - 1;
-                if (extra > 0) { endY++; extra--; }
-                threadStart[i] = startY;
-                threadEnd[i] = endY;
-                startY = endY + 1;
+    y = 0;
+    while (y <= MaxY && !getQuit()) {
+        lock(rowMutex);
+        done = rowDone[y];
+        needRedraw = 0;
+        if (done) {
+            if (((y + 1) % ScreenUpdateInterval) == 0 || y == MaxY) {
+                updatetexture(textureID, pixelData);
+                needRedraw = 1;
             }
-
-            tid[0] = spawn computeRowsThread0();
-            tid[1] = spawn computeRowsThread1();
-            tid[2] = spawn computeRowsThread2();
-            tid[3] = spawn computeRowsThread3();
-
-            y = 0;
-            while (y < Height && !getQuit()) {
-                int done, update;
-                lock(rowMutex);
-                done = rowDone[y];
-                /*
-                 * "done" is stored as an integer in rowDone[y].  The logical
-                 * operators in CLike require both operands to be of the same
-                 * type (either both integers or both booleans).  The expression
-                 * on the right-hand side produces a boolean result, so we
-                 * explicitly compare "done" against zero to convert it to a
-                 * boolean before using the && operator.  This avoids a runtime
-                 * type error when mixing INTEGER and BOOLEAN values.
-                 */
-                update = ((done != 0) && (((y + 1) % ScreenUpdateInterval) == 0 || y == Height - 1)) ? 1 : 0;
-                if (update)
-                    updatetexture(textureID, pixelData);
-                if (done)
-                    y++;
-                unlock(rowMutex);
-
-                if (update) {
-                    cleardevice();
-                    rendercopy(textureID);
-                    updatescreen();
-                }
-                if (keypressed()) {
-                    int c = readkey();
-                    if (toupper(c) == 'Q') setQuit(1);
-                }
-                if (!done || update)
-                    graphloop(0);
-            }
-
-            for (i = 0; i < ThreadCount; i++)
-                join tid[i];
-
-            redraw = 0;
+            y++;
         }
-
-        if (keypressed()) {
-            int c = readkey();
-            if (toupper(c) == 'Q') { setQuit(1); continue; }
+        unlock(rowMutex);
+        if (needRedraw) {
+            cleardevice();
+            rendercopy(textureID);
+            updatescreen();
+            graphloop(0);
+        } else if (!done) {
+            graphloop(0);
         }
-
-        getmousestate(&mouseX, &mouseY, &mouseButtons);
-        if (((mouseButtons & ButtonLeft) != 0) && ((prevButtons & ButtonLeft) == 0)) {
-            double centerRe = minRe + mouseX * reFactor;
-            double centerIm = maxIm - mouseY * imFactor;
-            double newWidth = (maxRe - minRe) / ZoomFactor;
-            double newHeight = (maxIm - minIm) / ZoomFactor;
-            minRe = centerRe - newWidth / 2.0;
-            maxRe = centerRe + newWidth / 2.0;
-            minIm = centerIm - newHeight / 2.0;
-            redraw = 1;
-        } else if (((mouseButtons & ButtonRight) != 0) && ((prevButtons & ButtonRight) == 0)) {
-            double centerRe = minRe + mouseX * reFactor;
-            double centerIm = maxIm - mouseY * imFactor;
-            double newWidth = (maxRe - minRe) * ZoomFactor;
-            double newHeight = (maxIm - minIm) * ZoomFactor;
-            minRe = centerRe - newWidth / 2.0;
-            maxRe = centerRe + newWidth / 2.0;
-            minIm = centerIm - newHeight / 2.0;
-            redraw = 1;
-        }
-        prevButtons = mouseButtons;
     }
 
-    destroytexture(textureID);
-    closegraph();
+    for (i = 0; i < threadCount; i++)
+        join tid[i];
+
+    printf("Mandelbrot rendered. Press Q in the console to quit.\n");
+    while (!getQuit())
+        graphloop(16);
+
+    join tid[4];
+    destroytexture(textureID); closegraph();
     return 0;
+
 }
+


### PR DESCRIPTION
## Summary
- Replace interactive Mandelbrot sample with a thread-driven version using `mandelbrotrow`
- Add `waitForQuit` helper and rename globals to `WindowWidth`/`WindowHeight`
- Update main loop to spawn threads, update the SDL texture as rows complete, and guard texture uploads with `rowMutex`
- Protect `rowDone` checks and pixel buffer writes under `rowMutex` to prevent data races

## Testing
- `cmake -S . -B build`
- `cmake --build build --target clike`
- `./Tests/run_clike_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b3a5573970832aa86b9e555356877a