### PR TITLE
Fix mouse input handling in SDL Mandelbrot interactive example

### DIFF
--- a/Examples/clike/sdl_mandelbrot_interactive
+++ b/Examples/clike/sdl_mandelbrot_interactive
@@ -183,7 +183,11 @@ int main() {
                 setQuit(1);
             }
         }
-        getmousestate(&mouseX, &mouseY, &buttons);
+        // GetMouseState uses VAR parameters, so we pass the variables directly
+        // instead of their addresses. Passing pointers here prevents the
+        // returned values from updating our variables, which made mouse clicks
+        // appear unresponsive.
+        getmousestate(mouseX, mouseY, buttons);
         if ((buttons & 1) && !(prev_buttons & 1)) {
             zoomAt(mouseX, mouseY, 0.5);
             renderMandelbrot();


### PR DESCRIPTION
## Summary
- Correct GetMouseState usage in SDL Mandelbrot interactive demo so clicks update view

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd Tests && ./run_all_tests`


------
https://chatgpt.com/codex/tasks/task_e_68b3b3a0e73c832ab17c894b7f14a0bf