### PR TITLE
Ensure GetMouseState receives pointers

### DIFF
--- a/Docs/pscal_vm_builtins.md
+++ b/Docs/pscal_vm_builtins.md
@@ -201,7 +201,7 @@ These built-ins are available when Pscal is built with SDL support.
 | issoundplaying | (sound: Sound) | Boolean | Query if sound playing. |
 | inittextsystem | () | void | Initialize text subsystem. |
 | quittextsystem | () | void | Shut down text subsystem. |
-| getmousestate | () | (x: Integer, y: Integer, buttons: Integer) | Query mouse position and buttons. |
+| getmousestate | (var x: Integer, var y: Integer, var buttons: Integer) | void | Query mouse position and buttons. |
 | getticks | () | Integer | Milliseconds since start. |
 | pollkey | () | Integer | Poll for key press. |
 

--- a/Examples/clike/builtins.h
+++ b/Examples/clike/builtins.h
@@ -68,7 +68,7 @@ int freesound();
 int getenv();
 int getmaxx();
 int getmaxy();
-int getmousestate();
+void getmousestate(int* x, int* y, int* buttons);
 int getpixelcolor();
 int gettextsize();
 int getticks();

--- a/Examples/clike/sdl_mandelbrot_interactive
+++ b/Examples/clike/sdl_mandelbrot_interactive
@@ -23,7 +23,17 @@ int main() {
     int screenUpdateInterval = 16; // update screen every 16 rows
     int quit = 0;
     int redraw = 1;
-    int mouseX = 0, mouseY = 0, mouseButtons = 0, prevButtons = 0;
+
+    // Mouse state variables must be declared individually so that the
+    // address-of operator can correctly obtain a pointer to each one.  The
+    // previous single-line declaration confused the CLike compiler and the
+    // GetMouseState builtin received a non-pointer argument, triggering a
+    // runtime error.
+    int mouseX = 0;
+    int mouseY = 0;
+    int mouseButtons = 0;
+    int prevButtons = 0;
+
     int ButtonLeft = 1;
     int ButtonRight = 4;
 


### PR DESCRIPTION
## Summary
- declare mouse state variables separately so GetMouseState sees proper addresses
- document GetMouseState's VAR parameters
- note pointer-based prototype for getmousestate builtin

## Testing
- `cd Tests && ./run_all_tests`

------
https://chatgpt.com/codex/tasks/task_e_68b45e07951c832a9d2deb545c07c45d