### PR TITLE
Fix GetMouseState usage and update Mandelbrot rendering loop

### DIFF
--- a/Examples/clike/sdl_mandelbrot_interactive
+++ b/Examples/clike/sdl_mandelbrot_interactive
@@ -149,8 +149,9 @@ void renderMandelbrot() {
             cleardevice();
             rendercopy(textureID);
             updatescreen();
+            graphloop(0);
         } else if (!done) {
-            delay(0);
+            graphloop(0);
         }
     }
 
@@ -183,11 +184,10 @@ int main() {
                 setQuit(1);
             }
         }
-        // GetMouseState uses VAR parameters, so we pass the variables directly
-        // instead of their addresses. Passing pointers here prevents the
-        // returned values from updating our variables, which made mouse clicks
-        // appear unresponsive.
-        getmousestate(mouseX, mouseY, buttons);
+        // GetMouseState uses VAR parameters and requires pointers to store
+        // the results. Pass the addresses of our variables so the function
+        // can update them correctly.
+        getmousestate(&mouseX, &mouseY, &buttons);
         if ((buttons & 1) && !(prev_buttons & 1)) {
             zoomAt(mouseX, mouseY, 0.5);
             renderMandelbrot();


### PR DESCRIPTION
## Summary
- pass variables by pointer to GetMouseState to satisfy VAR parameter requirements
- pump SDL events during Mandelbrot rendering so the window refreshes

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `Tests/run_clike_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b46c057bdc832aaf68ff781d0ac6f0