### PR TITLE
Fix integer division producing real results

### DIFF
--- a/src/clike/codegen.c
+++ b/src/clike/codegen.c
@@ -727,12 +727,11 @@ static void compileExpression(ASTNodeClike *node, BytecodeChunk *chunk, FuncCont
                         isIntlikeType(node->right->var_type)) {
                         /*
                          * In C, dividing two integers performs integer division
-                         * (truncating toward zero).  The VM has a dedicated
-                         * opcode for this behaviour (OP_INT_DIV), whereas
-                         * OP_DIVIDE always produces a real result.  Without this
-                         * check, expressions like `w / 4` would yield a real
-                         * value, which breaks APIs expecting integer arguments
-                         * (e.g. drawrect in the graphics tests).
+                         * (truncating toward zero).  Although the VM now
+                         * preserves integer types for OP_DIVIDE, emitting
+                         * OP_INT_DIV makes the intent explicit and maintains
+                         * compatibility with older bytecode that relied on the
+                         * dedicated opcode.
                          */
                         writeBytecodeChunk(chunk, OP_INT_DIV, node->token.line);
                     } else {

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1093,7 +1093,7 @@ InterpretResult interpretBytecode(VM* vm, BytecodeChunk* chunk, HashTable* globa
                             overflow = __builtin_mul_overflow(ia, ib, &iresult); \
                             break; \
                         case OP_DIVIDE: \
-                            result_val = makeReal((long double)ia / (long double)ib); \
+                            iresult = ia / ib; \
                             break; \
                         case OP_MOD: \
                             iresult = ib == 0 ? 0 : ia % ib; \
@@ -1103,9 +1103,7 @@ InterpretResult interpretBytecode(VM* vm, BytecodeChunk* chunk, HashTable* globa
                             freeValue(&a_val_popped); freeValue(&b_val_popped); \
                             return INTERPRET_RUNTIME_ERROR; \
                     } \
-                    if (current_instruction_code == OP_DIVIDE) { \
-                        /* result_val already set for division */ \
-                    } else if (overflow) { \
+                    if (overflow) { \
                         runtimeError(vm, "Runtime Error: Integer overflow."); \
                         freeValue(&a_val_popped); \
                         freeValue(&b_val_popped); \


### PR DESCRIPTION
## Summary
- Keep integer operands as integers during division in the VM
- Clarify C-like code generation comment about integer division

## Testing
- `cmake ..`
- `make`
- `./run_all_tests` *(fails: MathLibTest stdout mismatch, SuccEnumTest stdout mismatch, Cache reuse test failure)*

------
https://chatgpt.com/codex/tasks/task_e_68b48f3fbcf4832a9dbb2454db93b255