### PR TITLE
Fix integer division producing real results

### DIFF
--- a/src/clike/codegen.c
+++ b/src/clike/codegen.c
@@ -727,12 +727,11 @@ static void compileExpression(ASTNodeClike *node, BytecodeChunk *chunk, FuncCont
                         isIntlikeType(node->right->var_type)) {
                         /*
                          * In C, dividing two integers performs integer division
-                         * (truncating toward zero).  The VM has a dedicated
-                         * opcode for this behaviour (OP_INT_DIV), whereas
-                         * OP_DIVIDE always produces a real result.  Without this
-                         * check, expressions like `w / 4` would yield a real
-                         * value, which breaks APIs expecting integer arguments
-                         * (e.g. drawrect in the graphics tests).
+                         * (truncating toward zero).  Although the VM now
+                         * preserves integer types for OP_DIVIDE, emitting
+                         * OP_INT_DIV makes the intent explicit and maintains
+                         * compatibility with older bytecode that relied on the
+                         * dedicated opcode.
                          */
                         writeBytecodeChunk(chunk, OP_INT_DIV, node->token.line);
                     } else {

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1080,6 +1080,12 @@ InterpretResult interpretBytecode(VM* vm, BytecodeChunk* chunk, HashTable* globa
                         freeValue(&a_val_popped); freeValue(&b_val_popped); \
                         return INTERPRET_RUNTIME_ERROR; \
                     } \
+                    if (current_instruction_code == OP_DIVIDE && ia == LLONG_MIN && ib == -1) { \
+                        runtimeError(vm, "Runtime Error: Integer overflow."); \
+                        freeValue(&a_val_popped); \
+                        freeValue(&b_val_popped); \
+                        return INTERPRET_RUNTIME_ERROR; \
+                    } \
                     long long iresult = 0; \
                     bool overflow = false; \
                     switch (current_instruction_code) { \
@@ -1093,7 +1099,7 @@ InterpretResult interpretBytecode(VM* vm, BytecodeChunk* chunk, HashTable* globa
                             overflow = __builtin_mul_overflow(ia, ib, &iresult); \
                             break; \
                         case OP_DIVIDE: \
-                            result_val = makeReal((long double)ia / (long double)ib); \
+                            iresult = ia / ib; \
                             break; \
                         case OP_MOD: \
                             iresult = ib == 0 ? 0 : ia % ib; \
@@ -1103,9 +1109,7 @@ InterpretResult interpretBytecode(VM* vm, BytecodeChunk* chunk, HashTable* globa
                             freeValue(&a_val_popped); freeValue(&b_val_popped); \
                             return INTERPRET_RUNTIME_ERROR; \
                     } \
-                    if (current_instruction_code == OP_DIVIDE) { \
-                        /* result_val already set for division */ \
-                    } else if (overflow) { \
+                    if (overflow) { \
                         runtimeError(vm, "Runtime Error: Integer overflow."); \
                         freeValue(&a_val_popped); \
                         freeValue(&b_val_popped); \


### PR DESCRIPTION
## Summary
- Keep integer operands as integers during division in the VM
- Clarify C-like code generation comment about integer division
- Detect INT_MIN / -1 overflow in integer division to prevent SIGFPE

## Testing
- `cmake ..`
- `make -j8`
- `Tests/run_all_tests` *(fails: ExitFunctionReturnTest stdout mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b48f3fbcf4832a9dbb2454db93b255