### PR TITLE
Fix thread slot reuse to prevent VM thread limit exhaustion

### DIFF
--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -54,8 +54,16 @@ static void* threadStart(void* arg) {
 }
 
 static int createThread(VM* vm, uint16_t entry) {
-    if (vm->threadCount >= VM_MAX_THREADS) return -1;
-    Thread* t = &vm->threads[vm->threadCount];
+    int id = -1;
+    for (int i = 1; i < VM_MAX_THREADS; i++) {
+        if (!vm->threads[i].active && vm->threads[i].vm == NULL) {
+            id = i;
+            break;
+        }
+    }
+    if (id == -1) return -1;
+
+    Thread* t = &vm->threads[id];
     t->vm = malloc(sizeof(VM));
     if (!t->vm) return -1;
     initVM(t->vm);
@@ -83,8 +91,10 @@ static int createThread(VM* vm, uint16_t entry) {
         t->active = false;
         return -1;
     }
-    int id = vm->threadCount;
-    vm->threadCount++;
+
+    if (id >= vm->threadCount) {
+        vm->threadCount = id + 1;
+    }
     return id;
 }
 
@@ -102,6 +112,11 @@ static void joinThread(VM* vm, int id) {
         freeVM(t->vm);
         free(t->vm);
         t->vm = NULL;
+    }
+    while (vm->threadCount > 1 &&
+           !vm->threads[vm->threadCount - 1].active &&
+           vm->threads[vm->threadCount - 1].vm == NULL) {
+        vm->threadCount--;
     }
 }
 


### PR DESCRIPTION
## Summary
- Reuse VM thread slots only after joinThread cleanup
- Avoid shrinking threadCount for unjoined threads

## Testing
- `cd build && cmake .. && make -j$(nproc)`
- `cd Tests && ./run_all_tests`


------
https://chatgpt.com/codex/tasks/task_e_68b4c06aac04832abb33f332585a5de4