### PR TITLE
Fix Mandelbrot interactive threading and zoom

### DIFF
--- a/Examples/clike/sdl_mandelbrot_interactive
+++ b/Examples/clike/sdl_mandelbrot_interactive
@@ -9,7 +9,7 @@ const int Height = 900;
 const int MaxIterations = 200;
 const int BytesPerPixel = 4;
 const int ScreenUpdateInterval = 16;
-const double ZoomFactor = 4.0;
+const double ZoomFactor = 2.0;
 const int ThreadCount = 4;
 
 byte pixelData[Width * Height * BytesPerPixel];
@@ -49,7 +49,7 @@ void computeRows(int startY, int endY) {
     double c_im;
     for (y = startY; y <= endY && !getQuit(); y++) {
         c_im = maxIm - y * imFactor;
-        mandelbrotrow(minRe, reFactor, c_im, MaxIterations, Width - 1, &row);
+        mandelbrotrow(minRe, reFactor, c_im, MaxIterations, Width - 1, row);
         idx = y * Width * BytesPerPixel;
         lock(rowMutex);
         for (x = 0; x < Width; x++) {
@@ -79,7 +79,7 @@ void computeRowsThread3() { computeRows(threadStart[3], threadEnd[3]); }
 int main() {
     int mouseX = 0, mouseY = 0, mouseButtons = 0, prevButtons = 0;
     int ButtonLeft = 1, ButtonRight = 4;
-    int tid[ThreadCount], i, y, rowsPerThread, extra, startY, endY;
+    int tid[ThreadCount], i, y, rowsPerThread, startY, endY;
 
     printf("Calculating Mandelbrot set. The window will update as rows are drawn...\n");
     initgraph(Width, Height, "Mandelbrot in CLike (threaded)");
@@ -104,15 +104,23 @@ int main() {
             imFactor = (maxIm - minIm) / (Height - 1);
             for (i = 0; i < Height; i++) rowDone[i] = 0;
 
-            rowsPerThread = Height / ThreadCount;
-            extra = Height % ThreadCount;
-            startY = 0;
+            /*
+             * Divide the work as evenly as possible between threads.  Any
+             * threads that would start past the last row simply end before
+             * they begin so they exit immediately.
+             */
+            rowsPerThread = (Height + ThreadCount - 1) / ThreadCount; /* ceil */
             for (i = 0; i < ThreadCount; i++) {
+                startY = i * rowsPerThread;
                 endY = startY + rowsPerThread - 1;
-                if (extra > 0) { endY++; extra--; }
+                if (startY >= Height) {
+                    startY = Height;        /* thread does nothing */
+                    endY = Height - 1;
+                }
+                if (endY >= Height)
+                    endY = Height - 1;
                 threadStart[i] = startY;
                 threadEnd[i] = endY;
-                startY = endY + 1;
             }
 
             tid[0] = spawn computeRowsThread0();
@@ -135,13 +143,14 @@ int main() {
                  * type error when mixing INTEGER and BOOLEAN values.
                  */
                 update = ((done != 0) && (((y + 1) % ScreenUpdateInterval) == 0 || y == Height - 1)) ? 1 : 0;
-                if (update)
-                    updatetexture(textureID, pixelData);
                 if (done)
                     y++;
                 unlock(rowMutex);
 
                 if (update) {
+                    lock(rowMutex);
+                    updatetexture(textureID, pixelData);
+                    unlock(rowMutex);
                     cleardevice();
                     rendercopy(textureID);
                     updatescreen();


### PR DESCRIPTION
## Summary
- Correct Mandelbrot row call and reduce zoom factor for finer control
- Evenly distribute rows among threads to avoid extra rendering work
- Avoid blocking worker threads during screen updates

## Testing
- `cd Tests && ./run_all_tests >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68b4db543698832abfc8fcd7684038f9