### PR TITLE
Use portable localtime for DOS date/time builtins

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -2587,7 +2587,14 @@ Value vmBuiltinDosGetdate(VM* vm, int arg_count, Value* args) {
     }
     time_t t = time(NULL);
     struct tm tm_info;
-    localtime_r(&t, &tm_info);
+#if defined(_WIN32) && !defined(__CYGWIN__)
+    localtime_s(&tm_info, &t);
+#else
+    if (!localtime_r(&t, &tm_info)) {
+        struct tm *tmp = localtime(&t);
+        if (tmp) tm_info = *tmp; else memset(&tm_info, 0, sizeof(tm_info));
+    }
+#endif
     Value* year = (Value*)args[0].ptr_val;
     Value* month = (Value*)args[1].ptr_val;
     Value* day = (Value*)args[2].ptr_val;
@@ -2607,7 +2614,14 @@ Value vmBuiltinDosGettime(VM* vm, int arg_count, Value* args) {
     struct timeval tv;
     gettimeofday(&tv, NULL);
     struct tm tm_info;
-    localtime_r(&tv.tv_sec, &tm_info);
+#if defined(_WIN32) && !defined(__CYGWIN__)
+    localtime_s(&tm_info, &tv.tv_sec);
+#else
+    if (!localtime_r(&tv.tv_sec, &tm_info)) {
+        struct tm *tmp = localtime(&tv.tv_sec);
+        if (tmp) tm_info = *tmp; else memset(&tm_info, 0, sizeof(tm_info));
+    }
+#endif
     Value* hour = (Value*)args[0].ptr_val;
     Value* min = (Value*)args[1].ptr_val;
     Value* sec = (Value*)args[2].ptr_val;


### PR DESCRIPTION
## Summary
- Restore MiscDemo to rely on the standard Dos unit for date/time routines
- Make `dos_getdate`/`dos_gettime` use `localtime_s` on Windows and fall back to `localtime` when `localtime_r` is unavailable

## Testing
- `./Tests/run_pascal_tests.sh`
- `PASCAL_LIB_DIR=../lib/pascal ./bin/pascal /tmp/test_date.pas`


------
https://chatgpt.com/codex/tasks/task_e_68b4f661a0ac832a93f91c36d45e0a12