### PR TITLE
Add threaded input handling to Mandelbrot example

### DIFF
--- a/Examples/Pascal/SDLInteractiveMandelbrot_native
+++ b/Examples/Pascal/SDLInteractiveMandelbrot_native
@@ -39,6 +39,7 @@ VAR
   PixelData       : FlatPixelBuffer;
   QuitProgram     : Boolean;
   RedrawNeeded    : Boolean;
+  RenderInProgress : Boolean;
   MouseX, MouseY, MouseButtons : Integer;
   PrevMouseButtons : Integer; // Track previous mouse button state to detect fresh clicks
 
@@ -46,6 +47,7 @@ VAR
   CurrentViewWidthRe, CurrentViewHeightIm : Real;
   NewViewWidthRe, NewViewHeightIm     : Real;
   PercentDone : Integer;
+  MouseThreadID, KeyboardThreadID : Integer;
 
 // This procedure recalculates MaxIm and scaling factors based on CURRENT MinRe, MaxRe, MinIm
 PROCEDURE UpdateScalingAndDependentViewParams;
@@ -95,6 +97,7 @@ END;
 PROCEDURE FillPixelDataAndDisplayProgressively;
 VAR LocalPy, LocalPx, BufferBaseIdx : Integer;
 BEGIN
+  RenderInProgress := True;
   GotoXY(1, StatusLineY); ClrEol; Write('Calculating and rendering progressively...');
   FOR LocalPy := 0 TO ViewPixelHeight - 1 DO BEGIN
     FOR LocalPx := 0 TO ViewPixelWidth - 1 DO BEGIN
@@ -115,6 +118,48 @@ BEGIN
     BEGIN UpdateAndDisplayTextureInProgress; END;
   END; // Py
   GotoXY(1, StatusLineY); ClrEol; Write('Render complete. Click, R-Click, or Q.');
+  RedrawNeeded := False;
+  RenderInProgress := False;
+END;
+
+PROCEDURE KeyboardInputThread;
+BEGIN
+  WHILE NOT QuitProgram DO BEGIN
+    IF KeyPressed THEN BEGIN
+      IF UpCase(ReadKey) = 'Q' THEN QuitProgram := True;
+    END;
+    Delay(10);
+  END;
+END;
+
+PROCEDURE MouseInputThread;
+BEGIN
+  WHILE NOT QuitProgram DO BEGIN
+    GetMouseState(MouseX, MouseY, MouseButtons);
+    IF ((MouseButtons AND ButtonLeft) <> 0) AND ((PrevMouseButtons AND ButtonLeft) = 0) THEN BEGIN
+      IF NOT RedrawNeeded THEN BEGIN
+        WHILE RenderInProgress DO Delay(10);
+        NewCenterX := MinRe + (MouseX * ScaleRe); NewCenterY := MaxIm - (MouseY * ScaleIm);
+        CurrentViewWidthRe  := MaxRe - MinRe; CurrentViewHeightIm := MaxIm - MinIm;
+        NewViewWidthRe  := CurrentViewWidthRe / MandelZoomFactor; NewViewHeightIm := CurrentViewHeightIm / MandelZoomFactor;
+        MinRe := NewCenterX - (NewViewWidthRe / 2.0); MaxRe := NewCenterX + (NewViewWidthRe / 2.0);
+        MinIm := NewCenterY - (NewViewHeightIm / 2.0);
+        UpdateScalingAndDependentViewParams;
+        RedrawNeeded := True;
+        GotoXY(1,StatusLineY); ClrEol; Write('Zooming... Click @ (', MouseX, ',', MouseY, ')');
+      END;
+    END
+    ELSE IF ((MouseButtons AND ButtonRight) <> 0) AND ((PrevMouseButtons AND ButtonRight) = 0) THEN BEGIN
+      IF NOT RedrawNeeded THEN BEGIN
+        WHILE RenderInProgress DO Delay(10);
+        ResetViewToInitial;
+        RedrawNeeded := True;
+        GotoXY(1,StatusLineY); ClrEol; Write('Resetting view...');
+      END;
+    END;
+    PrevMouseButtons := MouseButtons;
+    Delay(10);
+  END;
 END;
 
 BEGIN // Main Program
@@ -134,41 +179,21 @@ BEGIN // Main Program
   RedrawNeeded := True;
   QuitProgram  := False;
   PrevMouseButtons := 0;
+  RenderInProgress := False;
+  MouseThreadID := spawn MouseInputThread;
+  KeyboardThreadID := spawn KeyboardInputThread;
 
   WHILE NOT QuitProgram DO BEGIN
     IF RedrawNeeded THEN BEGIN
       FillPixelDataAndDisplayProgressively;
-      RedrawNeeded := False;
     END ELSE BEGIN // If not redrawing, ensure screen is still updated and events processed
       ClearDevice; RenderCopy(MandelTextureID); UpdateScreen;
       GraphLoop(20);
     END;
-
-    IF KeyPressed THEN BEGIN IF UpCase(ReadKey) = 'Q' THEN QuitProgram := True; END;
-    GetMouseState(MouseX, MouseY, MouseButtons);
-
-    // Respond only to new button presses (transition from up to down)
-    IF ((MouseButtons AND ButtonLeft) <> 0) AND ((PrevMouseButtons AND ButtonLeft) = 0) THEN BEGIN
-      IF NOT RedrawNeeded THEN BEGIN
-        NewCenterX := MinRe + (MouseX * ScaleRe); NewCenterY := MaxIm - (MouseY * ScaleIm);
-        CurrentViewWidthRe  := MaxRe - MinRe; CurrentViewHeightIm := MaxIm - MinIm;
-        NewViewWidthRe  := CurrentViewWidthRe / MandelZoomFactor; NewViewHeightIm := CurrentViewHeightIm / MandelZoomFactor;
-        MinRe := NewCenterX - (NewViewWidthRe / 2.0); MaxRe := NewCenterX + (NewViewWidthRe / 2.0);
-        MinIm := NewCenterY - (NewViewHeightIm / 2.0);
-        UpdateScalingAndDependentViewParams; // <<<< CALL THE CORRECT PROCEDURE HERE
-        RedrawNeeded := True;
-        GotoXY(1,StatusLineY); ClrEol; Write('Zooming... Click @ (', MouseX, ',', MouseY, ')');
-      END;
-    END
-    ELSE IF ((MouseButtons AND ButtonRight) <> 0) AND ((PrevMouseButtons AND ButtonRight) = 0) THEN BEGIN
-      IF NOT RedrawNeeded THEN BEGIN
-        ResetViewToInitial; // <<<< CALL THE CORRECT PROCEDURE HERE
-        RedrawNeeded := True;
-        GotoXY(1,StatusLineY); ClrEol; Write('Resetting view...');
-      END;
-    END;
-    PrevMouseButtons := MouseButtons;
   END; // WHILE
+
+  join MouseThreadID;
+  join KeyboardThreadID;
 
   DestroyTexture(MandelTextureID); CloseGraph;
   GotoXY(1, StatusLineY + 2); ClrEol; NormVideo; ShowCursor; WriteLn; WriteLn('Program terminated.');


### PR DESCRIPTION
## Summary
- Serialize view updates with a `RenderInProgress` flag so mouse clicks wait for the current pass to finish
- Clear `RedrawNeeded` inside the render routine to prevent losing pending redraw requests

## Testing
- `cmake .. -DSDL=ON`
- `make -j2`
- `./bin/pascal ../Examples/Pascal/SDLInteractiveMandelbrot_native` *(fails: Pascal library directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b505310bac832ab8df75fd50250561