### PR TITLE
Add MandelbrotRow SDL Mandelbrot example

### DIFF
--- a/Examples/Pascal/SDLInteractiveMandelbrotRow_native
+++ b/Examples/Pascal/SDLInteractiveMandelbrotRow_native
@@ -1,0 +1,266 @@
+#!/usr/bin/env pascal
+PROGRAM SDLTextureMandelbrotZoomFixedRow;
+
+USES CRT;
+
+// Computes each row via MandelbrotRow extended builtin
+
+CONST
+  MandelWindowWidth   = 640;
+  MandelWindowHeight  = 480;
+  MandelWindowTitle   = 'Mandelbrot (Zoom Fixed - LMB:Zoom, RMB:Reset, Q:Quit)';
+  MandelMaxIterations = 50;
+  MandelZoomFactor    = 2.0;
+  MandelBytesPerPixel = 4;
+  MandelTextureUpdateIntervalRows = 1;
+  ThreadCount = 4;
+
+  InitialMinRe  = -2.0;
+  InitialMaxRe  =  1.0;
+  InitialMinIm  = -1.2;
+
+  ButtonLeft   = 1;
+  ButtonRight  = 4;
+
+  ControlsStartY = 4;
+  StatusLineY    = 10;
+
+TYPE
+  FlatPixelBuffer = ARRAY[0..(MandelWindowWidth * MandelWindowHeight * MandelBytesPerPixel) - 1] OF Byte;
+
+VAR
+  MinRe, MaxRe, MinIm, MaxIm : Real;
+  ViewPixelWidth, ViewPixelHeight : Integer;
+  ReRange, ImRange           : Real;
+  ScaleRe, ScaleIm           : Real;
+
+  MandelTextureID : Integer;
+  PixelData, DisplayPixelData : FlatPixelBuffer;
+  QuitProgram     : Boolean;
+  RedrawNeeded    : Boolean;
+  RenderInProgress : Boolean;
+  MouseX, MouseY, MouseButtons : Integer;
+  PrevMouseButtons : Integer; // Track previous mouse button state to detect fresh clicks
+
+  ThreadStart, ThreadEnd : ARRAY[0..ThreadCount - 1] OF Integer;
+  RowDone : ARRAY[0..MandelWindowHeight - 1] OF Integer;
+  RenderThreadIDs : ARRAY[0..ThreadCount - 1] OF Integer;
+  RowMutex : Integer;
+
+  NewCenterX, NewCenterY          : Real;
+  CurrentViewWidthRe, CurrentViewHeightIm : Real;
+  NewViewWidthRe, NewViewHeightIm     : Real;
+  PercentDone : Integer;
+  MouseThreadID, KeyboardThreadID : Integer;
+
+// This procedure recalculates MaxIm and scaling factors based on CURRENT MinRe, MaxRe, MinIm
+PROCEDURE UpdateScalingAndDependentViewParams;
+BEGIN
+  // GetMaxX/Y are based on InitGraph, which uses MandelWindowWidth/Height constants for texture too
+  ViewPixelWidth  := MandelWindowWidth;  // Assuming texture matches window size
+  ViewPixelHeight := MandelWindowHeight;
+
+  ReRange := MaxRe - MinRe;
+  IF ViewPixelWidth > 0 THEN
+    MaxIm := MinIm + (ReRange * ViewPixelHeight) / ViewPixelWidth
+  ELSE
+    MaxIm := MinIm;
+  ImRange := MaxIm - MinIm;
+
+  IF ViewPixelWidth > 1 THEN ScaleRe := ReRange / (ViewPixelWidth - 1)
+  ELSE IF ViewPixelWidth = 1 THEN ScaleRe := ReRange
+  ELSE ScaleRe := 0;
+
+  IF ViewPixelHeight > 1 THEN ScaleIm := ImRange / (ViewPixelHeight - 1)
+  ELSE IF ViewPixelHeight = 1 THEN ScaleIm := ImRange
+  ELSE ScaleIm := 0;
+
+  // Update console display
+  GotoXY(1, 2); ClrEol; Write('View: Re[', MinRe:0:4,'..',MaxRe:0:4,'], Im[',MinIm:0:4,'..',MaxIm:0:4,']');
+  GotoXY(1, ControlsStartY + 4); ClrEol;
+  Write('Max Iter: ', MandelMaxIterations, ', Zoom Factor: ', MandelZoomFactor:0:1, ', Texture ID: ', MandelTextureID); ClrEol;
+END;
+
+PROCEDURE ResetViewToInitial;
+BEGIN
+  MinRe := InitialMinRe;
+  MaxRe := InitialMaxRe;
+  MinIm := InitialMinIm;
+  UpdateScalingAndDependentViewParams; // Now calculate MaxIm and scales for these initial values
+END;
+
+PROCEDURE UpdateAndDisplayTextureInProgress;
+BEGIN
+  UpdateTexture(MandelTextureID, DisplayPixelData);
+  ClearDevice;
+  RenderCopy(MandelTextureID);
+  UpdateScreen;
+  GraphLoop(0);
+END;
+
+  // Compute rows using the MandelbrotRow extended builtin.
+  PROCEDURE ComputeRows(startY, endY: Integer);
+  VAR LocalPy, LocalPx, BufferBaseIdx, Iteration: Integer;
+      RowVals : ARRAY[0..MandelWindowWidth - 1] OF Integer;
+      c_im : Real;
+      R_calc, G_calc, B_calc: Byte;
+  BEGIN
+    FOR LocalPy := startY TO endY DO BEGIN
+      c_im := MaxIm - (LocalPy * ScaleIm);
+      MandelbrotRow(MinRe, ScaleRe, c_im, MandelMaxIterations, ViewPixelWidth - 1, RowVals);
+      FOR LocalPx := 0 TO ViewPixelWidth - 1 DO BEGIN
+        Iteration := RowVals[LocalPx];
+        IF Iteration = MandelMaxIterations THEN BEGIN
+          R_calc := 0; G_calc := 0; B_calc := 0;
+        END ELSE BEGIN
+          R_calc := ((Iteration * 12) MOD 256 + 256) MOD 256;
+          G_calc := ((Iteration * 8 + 80) MOD 256 + 256) MOD 256;
+          B_calc := ((Iteration * 5 + 160) MOD 256 + 256) MOD 256;
+        END;
+        BufferBaseIdx := (LocalPy * ViewPixelWidth + LocalPx) * MandelBytesPerPixel;
+        PixelData[BufferBaseIdx + 0] := R_calc;
+        PixelData[BufferBaseIdx + 1] := G_calc;
+        PixelData[BufferBaseIdx + 2] := B_calc;
+        PixelData[BufferBaseIdx + 3] := 255;
+      END; // Px
+      lock(RowMutex);
+      RowDone[LocalPy] := 1;
+      unlock(RowMutex);
+    END; // Py
+  END;
+
+PROCEDURE ComputeRowsThread0; BEGIN ComputeRows(ThreadStart[0], ThreadEnd[0]); END;
+PROCEDURE ComputeRowsThread1; BEGIN ComputeRows(ThreadStart[1], ThreadEnd[1]); END;
+PROCEDURE ComputeRowsThread2; BEGIN ComputeRows(ThreadStart[2], ThreadEnd[2]); END;
+PROCEDURE ComputeRowsThread3; BEGIN ComputeRows(ThreadStart[3], ThreadEnd[3]); END;
+
+PROCEDURE FillPixelDataAndDisplayProgressively;
+  VAR i, startY, endY, rowsPerThread, extra, y, doneFlag, bufferIdx, rowBytes, k : Integer;
+BEGIN
+  RenderInProgress := True;
+  GotoXY(1, StatusLineY); ClrEol; Write('Calculating and rendering progressively...');
+
+  RowMutex := mutex();
+  FOR i := 0 TO ViewPixelHeight - 1 DO RowDone[i] := 0;
+  rowBytes := ViewPixelWidth * MandelBytesPerPixel;
+  FOR k := 0 TO (ViewPixelWidth * ViewPixelHeight * MandelBytesPerPixel) - 1 DO
+    DisplayPixelData[k] := 0;
+
+  rowsPerThread := ViewPixelHeight DIV ThreadCount;
+  extra := ViewPixelHeight MOD ThreadCount;
+  startY := 0;
+  FOR i := 0 TO ThreadCount - 1 DO BEGIN
+    endY := startY + rowsPerThread - 1;
+    IF extra > 0 THEN BEGIN endY := endY + 1; extra := extra - 1; END;
+    ThreadStart[i] := startY;
+    ThreadEnd[i] := endY;
+    startY := endY + 1;
+  END;
+
+  RenderThreadIDs[0] := spawn ComputeRowsThread0;
+  RenderThreadIDs[1] := spawn ComputeRowsThread1;
+  RenderThreadIDs[2] := spawn ComputeRowsThread2;
+  RenderThreadIDs[3] := spawn ComputeRowsThread3;
+
+  y := 0;
+  WHILE y < ViewPixelHeight DO BEGIN
+    lock(RowMutex);
+    doneFlag := RowDone[y];
+    IF doneFlag <> 0 THEN BEGIN
+      bufferIdx := y * rowBytes;
+      FOR k := 0 TO rowBytes - 1 DO
+        DisplayPixelData[bufferIdx + k] := PixelData[bufferIdx + k];
+    END;
+    unlock(RowMutex);
+    IF doneFlag <> 0 THEN BEGIN
+      PercentDone := Trunc( (y + 1) * 100.0 / ViewPixelHeight );
+      GotoXY(1, StatusLineY); ClrEol; Write('Processing: Row ', y + 1, '/', ViewPixelHeight, '. ~', PercentDone, '%');
+      IF (((y + 1) MOD MandelTextureUpdateIntervalRows = 0) OR (y = ViewPixelHeight - 1)) THEN
+        UpdateAndDisplayTextureInProgress;
+      y := y + 1;
+    END ELSE BEGIN
+      GraphLoop(0);
+    END;
+  END;
+
+  FOR i := 0 TO ThreadCount - 1 DO join RenderThreadIDs[i];
+
+  GotoXY(1, StatusLineY); ClrEol; Write('Render complete. Click, R-Click, or Q.');
+  RedrawNeeded := False;
+  RenderInProgress := False;
+END;
+
+PROCEDURE KeyboardInputThread;
+BEGIN
+  WHILE NOT QuitProgram DO BEGIN
+    IF KeyPressed THEN BEGIN
+      IF UpCase(ReadKey) = 'Q' THEN QuitProgram := True;
+    END;
+  END;
+END;
+
+PROCEDURE MouseInputThread;
+BEGIN
+  WHILE NOT QuitProgram DO BEGIN
+    GetMouseState(MouseX, MouseY, MouseButtons);
+    IF ((MouseButtons AND ButtonLeft) <> 0) AND ((PrevMouseButtons AND ButtonLeft) = 0) THEN BEGIN
+      IF NOT RedrawNeeded THEN BEGIN
+        WHILE RenderInProgress DO Delay(0);
+        NewCenterX := MinRe + (MouseX * ScaleRe); NewCenterY := MaxIm - (MouseY * ScaleIm);
+        CurrentViewWidthRe  := MaxRe - MinRe; CurrentViewHeightIm := MaxIm - MinIm;
+        NewViewWidthRe  := CurrentViewWidthRe / MandelZoomFactor; NewViewHeightIm := CurrentViewHeightIm / MandelZoomFactor;
+        MinRe := NewCenterX - (NewViewWidthRe / 2.0); MaxRe := NewCenterX + (NewViewWidthRe / 2.0);
+        MinIm := NewCenterY - (NewViewHeightIm / 2.0);
+        UpdateScalingAndDependentViewParams;
+        RedrawNeeded := True;
+        GotoXY(1,StatusLineY); ClrEol; Write('Zooming... Click @ (', MouseX, ',', MouseY, ')');
+      END;
+    END
+    ELSE IF ((MouseButtons AND ButtonRight) <> 0) AND ((PrevMouseButtons AND ButtonRight) = 0) THEN BEGIN
+      IF NOT RedrawNeeded THEN BEGIN
+        WHILE RenderInProgress DO Delay(0);
+        ResetViewToInitial;
+        RedrawNeeded := True;
+        GotoXY(1,StatusLineY); ClrEol; Write('Resetting view...');
+      END;
+    END;
+    PrevMouseButtons := MouseButtons;
+  END;
+END;
+
+BEGIN // Main Program
+  HideCursor; ClrScr;
+  GotoXY(1, 1); Write('Pscal Texture Mandelbrot (Zoom Fixed)');
+  GotoXY(1, ControlsStartY);     Write('Controls:');
+  GotoXY(1, ControlsStartY + 1); Write('- LClick: Zoom In');
+  GotoXY(1, ControlsStartY + 2); Write('- RClick: Reset View');
+  GotoXY(1, ControlsStartY + 3); Write('- Q Key (in terminal): Quit');
+  GotoXY(1, ControlsStartY + 5); Write('----------------------------------------------------------');
+
+  InitGraph(MandelWindowWidth, MandelWindowHeight, MandelWindowTitle);
+  MouseThreadID := spawn MouseInputThread;
+  KeyboardThreadID := spawn KeyboardInputThread;
+  MandelTextureID := CreateTexture(MandelWindowWidth, MandelWindowHeight);
+  IF MandelTextureID < 0 THEN BEGIN GotoXY(1, StatusLineY); WriteLn('Error: No Texture! Halting.'); ReadKey; CloseGraph; NormVideo; ShowCursor; HALT; END;
+
+  ResetViewToInitial; // Sets MinRe,MaxRe,MinIm to defaults AND calculates scales/MaxIm
+  RedrawNeeded := True;
+  QuitProgram  := False;
+  PrevMouseButtons := 0;
+  RenderInProgress := False;
+
+  WHILE NOT QuitProgram DO BEGIN
+    IF RedrawNeeded THEN BEGIN
+      FillPixelDataAndDisplayProgressively;
+    END ELSE BEGIN // If not redrawing, ensure screen is still updated and events processed
+      ClearDevice; RenderCopy(MandelTextureID); UpdateScreen;
+      GraphLoop(20);
+    END;
+  END; // WHILE
+
+  join MouseThreadID;
+  join KeyboardThreadID;
+
+  DestroyTexture(MandelTextureID); CloseGraph;
+  GotoXY(1, StatusLineY + 2); ClrEol; NormVideo; ShowCursor; WriteLn; WriteLn('Program terminated.');
+END.


### PR DESCRIPTION
## Summary
- Restore original SDLInteractiveMandelbrot_native example
- Add SDLInteractiveMandelbrotRow_native leveraging MandelbrotRow extended builtin for row-wise fractal computation

## Testing
- `./Examples/Pascal/SDLInteractiveMandelbrotRow_native` *(fails: /usr/bin/env: 'pascal': No such file or directory)*
- `./Examples/Pascal/SDLInteractiveMandelbrot_native` *(fails: /usr/bin/env: 'pascal': No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b528d74160832ab35fcc9d99f9f4c0