### PR TITLE
Recycle mutex slots and fix thread call frames

### DIFF
--- a/Examples/Pascal/SDLInteractiveMandelbrotRow
+++ b/Examples/Pascal/SDLInteractiveMandelbrotRow
@@ -95,7 +95,6 @@ BEGIN
   ClearDevice;
   RenderCopy(MandelTextureID);
   UpdateScreen;
-  GraphLoop(0);
 END;
 
   // Compute rows using the MandelbrotRow extended builtin.
@@ -176,7 +175,10 @@ BEGIN
       PercentDone := Trunc( (y + 1) * 100.0 / ViewPixelHeight );
       GotoXY(1, StatusLineY); ClrEol; Write('Processing: Row ', y + 1, '/', ViewPixelHeight, '. ~', PercentDone, '%');
       IF (((y + 1) MOD MandelTextureUpdateIntervalRows = 0) OR (y = ViewPixelHeight - 1)) THEN
+      BEGIN
         UpdateAndDisplayTextureInProgress;
+        GraphLoop(0);
+      END;
       y := y + 1;
     END ELSE BEGIN
       GraphLoop(0);
@@ -185,7 +187,11 @@ BEGIN
 
   FOR i := 0 TO ThreadCount - 1 DO join RenderThreadIDs[i];
 
-  GotoXY(1, StatusLineY); ClrEol; Write('Render complete. Click, R-Click, or Q.');
+  // Ensure the final image is copied to the texture and presented.
+  UpdateAndDisplayTextureInProgress;
+  GraphLoop(0);
+
+  GotoXY(1, StatusLineY); ClrEol; WriteLn('Render complete. Click, R-Click, or Q.');
   RedrawNeeded := False;
   RenderInProgress := False;
 END;

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -3297,6 +3297,7 @@ void registerAllBuiltins(void) {
     registerBuiltinFunction("rcmutex", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("lock", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("unlock", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("destroyMutex", AST_PROCEDURE_DECL, NULL);
     /* Allow externally linked modules to add more builtins. */
     registerExtendedBuiltins();
     pthread_mutex_unlock(&builtin_registry_mutex);

--- a/src/clike/codegen.c
+++ b/src/clike/codegen.c
@@ -977,6 +977,16 @@ static void compileExpression(ASTNodeClike *node, BytecodeChunk *chunk, FuncCont
                 writeBytecodeChunk(chunk, OP_MUTEX_UNLOCK, node->token.line);
                 break;
             }
+            if (strcasecmp(name, "destroymutex") == 0) {
+                if (node->child_count != 1) {
+                    fprintf(stderr, "Compile error: destroyMutex expects 1 argument.\n");
+                } else {
+                    compileExpression(node->children[0], chunk, ctx);
+                }
+                free(name);
+                writeBytecodeChunk(chunk, OP_MUTEX_DESTROY, node->token.line);
+                break;
+            }
             if (strcasecmp(name, "printf") == 0) {
                 int arg_index = 0;
                 int write_arg_count = 0;

--- a/src/clike/semantics.c
+++ b/src/clike/semantics.c
@@ -427,6 +427,25 @@ static VarType analyzeExpr(ASTNodeClike *node, ScopeStack *scopes) {
                 node->var_type = TYPE_VOID;
                 return TYPE_VOID;
             }
+            if (strcasecmp(name, "destroymutex") == 0) {
+                if (node->child_count != 1) {
+                    fprintf(stderr,
+                            "Type error: %s expects 1 argument at line %d, column %d\n",
+                            name, node->token.line, node->token.column);
+                    clike_error_count++;
+                } else {
+                    VarType at = analyzeExpr(node->children[0], scopes);
+                    if (!isIntlikeType(at)) {
+                        fprintf(stderr,
+                                "Type error: %s argument must be integer at line %d, column %d\n",
+                                name, node->token.line, node->token.column);
+                        clike_error_count++;
+                    }
+                }
+                free(name);
+                node->var_type = TYPE_VOID;
+                return TYPE_VOID;
+            }
 
             VarType t = getFunctionType(name);
             if (t == TYPE_UNKNOWN) {

--- a/src/compiler/bytecode.c
+++ b/src/compiler/bytecode.c
@@ -721,6 +721,9 @@ int disassembleInstruction(BytecodeChunk* chunk, int offset, HashTable* procedur
         case OP_MUTEX_UNLOCK:
             printf("OP_MUTEX_UNLOCK\n");
             return offset + 1;
+        case OP_MUTEX_DESTROY:
+            printf("OP_MUTEX_DESTROY\n");
+            return offset + 1;
         // NOTE: There is no OP_BREAK in your bytecode.h enum, so it cannot be disassembled.
         // The AST_BREAK node is handled by the compiler generating jump instructions.
 

--- a/src/compiler/bytecode.h
+++ b/src/compiler/bytecode.h
@@ -106,7 +106,8 @@ typedef enum {
     OP_MUTEX_CREATE,       // Create a standard mutex. Pushes mutex id
     OP_RCMUTEX_CREATE,     // Create a recursive mutex. Pushes mutex id
     OP_MUTEX_LOCK,         // Lock mutex whose id is on top of stack
-    OP_MUTEX_UNLOCK        // Unlock mutex whose id is on top of stack
+    OP_MUTEX_UNLOCK,       // Unlock mutex whose id is on top of stack
+    OP_MUTEX_DESTROY       // Destroy mutex whose id is on top of stack
 
 } OpCode;
 

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -2045,6 +2045,15 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
                 writeBytecodeChunk(chunk, OP_MUTEX_UNLOCK, line);
                 break;
             }
+            if (strcasecmp(calleeName, "destroymutex") == 0) {
+                if (node->child_count != 1) {
+                    fprintf(stderr, "L%d: Compiler Error: destroyMutex expects 1 argument.\n", line);
+                } else {
+                    compileRValue(node->children[0], chunk, getLine(node->children[0]));
+                }
+                writeBytecodeChunk(chunk, OP_MUTEX_DESTROY, line);
+                break;
+            }
             if (strcasecmp(calleeName, "mutex") == 0) {
                 if (node->child_count != 0) {
                     fprintf(stderr, "L%d: Compiler Error: mutex expects no arguments.\n", line);
@@ -2694,6 +2703,15 @@ static void compileRValue(AST* node, BytecodeChunk* chunk, int current_line_appr
                     compileRValue(node->children[0], chunk, getLine(node->children[0]));
                 }
                 writeBytecodeChunk(chunk, OP_MUTEX_UNLOCK, line);
+                break;
+            }
+            if (strcasecmp(functionName, "destroymutex") == 0) {
+                if (node->child_count != 1) {
+                    fprintf(stderr, "L%d: Compiler Error: destroyMutex expects 1 argument.\n", line);
+                } else {
+                    compileRValue(node->children[0], chunk, getLine(node->children[0]));
+                }
+                writeBytecodeChunk(chunk, OP_MUTEX_DESTROY, line);
                 break;
             }
             


### PR DESCRIPTION
## Summary
- recycle destroyed mutex slots so IDs can be reused
- initialize call frames for spawned threads and add mutex destroy opcode
- wire `destroyMutex` builtin through compiler and runtime

## Testing
- `build/bin/pascal Examples/Pascal/CheckExtBuiltin`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68b52c02d800832aa8c2070d1a6c2035