### PR TITLE
Add mutex destroy builtin

### DIFF
--- a/Docs/clike_language_reference.md
+++ b/Docs/clike_language_reference.md
@@ -212,6 +212,7 @@ The language provides lightweight concurrency and mutex primitives through the f
 * `rcmutex` – creates a recursive mutex and pushes its identifier.
 * `lock` – pops a mutex identifier and blocks until it is acquired.
 * `unlock` – releases the mutex whose identifier is on top of the stack.
+* `destroy` – pops a mutex identifier and permanently frees the mutex.
 
 Example:
 

--- a/Docs/clike_overview.md
+++ b/Docs/clike_overview.md
@@ -37,7 +37,7 @@ to the VM:
   parameters allow pass‑by‑reference semantics.
 - **Structs and pointers** – `struct` aggregates fields. `new(&node)` allocates
   dynamic storage and `->` dereferences pointer fields.
-- **Threading and Synchronization** – `spawn` launches a parameterless function in a new thread and returns its id; `join` waits for a thread to complete; `mutex`/`rcmutex` create standard or recursive mutexes and return ids, and `lock`/`unlock` guard critical sections.
+- **Threading and Synchronization** – `spawn` launches a parameterless function in a new thread and returns its id; `join` waits for a thread to complete; `mutex`/`rcmutex` create standard or recursive mutexes and return ids, and `lock`/`unlock`/`destroy` manage critical sections and mutex lifetime.
 
 ## Example: Sorting a String
 

--- a/Docs/pascal_language_reference.md
+++ b/Docs/pascal_language_reference.md
@@ -229,6 +229,7 @@ The Pascal front end supports lightweight concurrency and mutex primitives using
 * `rcmutex` – creates a recursive mutex and returns its identifier.
 * `lock` – takes a mutex identifier and waits until the mutex is acquired.
 * `unlock` – releases a previously acquired mutex.
+* `destroy` – permanently frees a mutex so its identifier can no longer be used.
 
 Threads share global variables and are scheduled cooperatively; a `join` yields control until the target thread completes.
 

--- a/Docs/pascal_overview.md
+++ b/Docs/pascal_overview.md
@@ -21,7 +21,7 @@ Pscal implements a substantial subset of classic Pascal:
 * **Control flow** – `if`, `case`, `for`, `while`, `repeat…until`, and `break`.
 * **Subroutines** – functions and procedures with local variables and parameters.
 * **Units** – separate compilation modules that export types, variables and routines.
-* **Threading and Synchronization** – `spawn` starts a parameterless procedure in a new thread and returns its id; `join` waits for that thread to finish; `mutex` and `rcmutex` create standard or recursive mutexes and return ids, while `lock` and `unlock` manage them.
+* **Threading and Synchronization** – `spawn` starts a parameterless procedure in a new thread and returns its id; `join` waits for that thread to finish; `mutex` and `rcmutex` create standard or recursive mutexes and return ids, while `lock`, `unlock`, and `destroy` manage their lifecycle.
 
 Example program:
 

--- a/Docs/pscal_vm_builtins.md
+++ b/Docs/pscal_vm_builtins.md
@@ -107,6 +107,7 @@ VM. For instructions on adding your own routines, see
 | rcmutex | () | Integer | Create a recursive mutex and return its identifier. |
 | lock | (mid: Integer) | void | Acquire the mutex with the given identifier. |
 | unlock | (mid: Integer) | void | Release the specified mutex. |
+| destroy | (mid: Integer) | void | Destroy the specified mutex. |
 
 ## Math
 

--- a/Docs/pscal_vm_overview.md
+++ b/Docs/pscal_vm_overview.md
@@ -307,6 +307,9 @@ MyFunction(a, b);
 * **`OP_MUTEX_UNLOCK`**:
     * **Operands:** None (uses mutex id on stack).
     * **Action:** Pops a mutex identifier and releases the corresponding mutex.
+* **`OP_MUTEX_DESTROY`**:
+    * **Operands:** None (uses mutex id on stack).
+    * **Action:** Pops a mutex identifier and destroys the corresponding mutex.
 
 #### **I/O and Miscellaneous Opcodes**
 

--- a/Tests/Pascal/RecursiveMutexTest
+++ b/Tests/Pascal/RecursiveMutexTest
@@ -17,5 +17,6 @@ begin
   mid := rcmutex();
   tid := spawn Worker;
   join tid;
+  destroy(mid);
   writeln('done');
 end.

--- a/Tests/Pascal/ThreadMutexTest
+++ b/Tests/Pascal/ThreadMutexTest
@@ -38,5 +38,6 @@ begin
   t2 := spawn Worker2;
   join t1;
   join t2;
+  destroy(mid);
   writeln(counter);
 end.

--- a/Tests/clike/RecursiveMutex.cl
+++ b/Tests/clike/RecursiveMutex.cl
@@ -12,6 +12,7 @@ int main() {
     mid = rcmutex();
     int t = spawn worker();
     join t;
+    destroy(mid);
     printf("done\n");
     return 0;
 }

--- a/Tests/clike/ThreadMutex.cl
+++ b/Tests/clike/ThreadMutex.cl
@@ -30,6 +30,7 @@ int main() {
     int t2 = spawn worker2();
     join t1;
     join t2;
+    destroy(mid);
     printf("%d\n", counter);
     return 0;
 }

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -3297,6 +3297,7 @@ void registerAllBuiltins(void) {
     registerBuiltinFunction("rcmutex", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("lock", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("unlock", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("destroy", AST_PROCEDURE_DECL, NULL);
     /* Allow externally linked modules to add more builtins. */
     registerExtendedBuiltins();
     pthread_mutex_unlock(&builtin_registry_mutex);

--- a/src/clike/codegen.c
+++ b/src/clike/codegen.c
@@ -977,6 +977,16 @@ static void compileExpression(ASTNodeClike *node, BytecodeChunk *chunk, FuncCont
                 writeBytecodeChunk(chunk, OP_MUTEX_UNLOCK, node->token.line);
                 break;
             }
+            if (strcasecmp(name, "destroy") == 0) {
+                if (node->child_count != 1) {
+                    fprintf(stderr, "Compile error: destroy expects 1 argument.\n");
+                } else {
+                    compileExpression(node->children[0], chunk, ctx);
+                }
+                free(name);
+                writeBytecodeChunk(chunk, OP_MUTEX_DESTROY, node->token.line);
+                break;
+            }
             if (strcasecmp(name, "printf") == 0) {
                 int arg_index = 0;
                 int write_arg_count = 0;

--- a/src/clike/semantics.c
+++ b/src/clike/semantics.c
@@ -408,7 +408,7 @@ static VarType analyzeExpr(ASTNodeClike *node, ScopeStack *scopes) {
                 node->var_type = TYPE_INT32;
                 return TYPE_INT32;
             }
-            if (strcasecmp(name, "lock") == 0 || strcasecmp(name, "unlock") == 0) {
+            if (strcasecmp(name, "lock") == 0 || strcasecmp(name, "unlock") == 0 || strcasecmp(name, "destroy") == 0) {
                 if (node->child_count != 1) {
                     fprintf(stderr,
                             "Type error: %s expects 1 argument at line %d, column %d\n",

--- a/src/compiler/bytecode.c
+++ b/src/compiler/bytecode.c
@@ -721,6 +721,9 @@ int disassembleInstruction(BytecodeChunk* chunk, int offset, HashTable* procedur
         case OP_MUTEX_UNLOCK:
             printf("OP_MUTEX_UNLOCK\n");
             return offset + 1;
+        case OP_MUTEX_DESTROY:
+            printf("OP_MUTEX_DESTROY\n");
+            return offset + 1;
         // NOTE: There is no OP_BREAK in your bytecode.h enum, so it cannot be disassembled.
         // The AST_BREAK node is handled by the compiler generating jump instructions.
 

--- a/src/compiler/bytecode.h
+++ b/src/compiler/bytecode.h
@@ -106,7 +106,8 @@ typedef enum {
     OP_MUTEX_CREATE,       // Create a standard mutex. Pushes mutex id
     OP_RCMUTEX_CREATE,     // Create a recursive mutex. Pushes mutex id
     OP_MUTEX_LOCK,         // Lock mutex whose id is on top of stack
-    OP_MUTEX_UNLOCK        // Unlock mutex whose id is on top of stack
+    OP_MUTEX_UNLOCK,       // Unlock mutex whose id is on top of stack
+    OP_MUTEX_DESTROY       // Destroy mutex whose id is on top of stack
 
 } OpCode;
 

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -2045,6 +2045,15 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
                 writeBytecodeChunk(chunk, OP_MUTEX_UNLOCK, line);
                 break;
             }
+            if (strcasecmp(calleeName, "destroy") == 0) {
+                if (node->child_count != 1) {
+                    fprintf(stderr, "L%d: Compiler Error: destroy expects 1 argument.\n", line);
+                } else {
+                    compileRValue(node->children[0], chunk, getLine(node->children[0]));
+                }
+                writeBytecodeChunk(chunk, OP_MUTEX_DESTROY, line);
+                break;
+            }
             if (strcasecmp(calleeName, "mutex") == 0) {
                 if (node->child_count != 0) {
                     fprintf(stderr, "L%d: Compiler Error: mutex expects no arguments.\n", line);
@@ -2696,7 +2705,16 @@ static void compileRValue(AST* node, BytecodeChunk* chunk, int current_line_appr
                 writeBytecodeChunk(chunk, OP_MUTEX_UNLOCK, line);
                 break;
             }
-            
+            if (strcasecmp(functionName, "destroy") == 0) {
+                if (node->child_count != 1) {
+                    fprintf(stderr, "L%d: Compiler Error: destroy expects 1 argument.\n", line);
+                } else {
+                    compileRValue(node->children[0], chunk, getLine(node->children[0]));
+                }
+                writeBytecodeChunk(chunk, OP_MUTEX_DESTROY, line);
+                break;
+            }
+
             // --- NEW, MORE ROBUST LOOKUP LOGIC ---
             Symbol* func_symbol_lookup = NULL;
             char func_name_lower[MAX_SYMBOL_LENGTH];

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -21,7 +21,6 @@
 #include <unistd.h>
 #include <sys/ioctl.h>
 #include "backend_ast/builtin.h"
-#include "backend_ast/audio.h"
 
 #define MAX_WRITELN_ARGS_VM 32
 
@@ -153,6 +152,14 @@ static bool unlockMutex(VM* vm, int id) {
     VM* owner = vm->mutexOwner ? vm->mutexOwner : vm;
     if (id < 0 || id >= owner->mutexCount || !owner->mutexes[id].active) return false;
     return pthread_mutex_unlock(&owner->mutexes[id].handle) == 0;
+}
+
+static bool destroyMutex(VM* vm, int id) {
+    VM* owner = vm->mutexOwner ? vm->mutexOwner : vm;
+    if (id < 0 || id >= owner->mutexCount || !owner->mutexes[id].active) return false;
+    if (pthread_mutex_destroy(&owner->mutexes[id].handle) != 0) return false;
+    owner->mutexes[id].active = false;
+    return true;
 }
 
 // Internal function shared by stack dump helpers
@@ -3018,6 +3025,25 @@ comparison_error_label:
                 }
                 int mid = (int)midVal.i_val;
                 if (!unlockMutex(vm, mid)) {
+                    runtimeError(vm, "Invalid mutex id %d.", mid);
+                    Value popped_mid = pop(vm);
+                    freeValue(&popped_mid);
+                    return INTERPRET_RUNTIME_ERROR;
+                }
+                Value popped_mid = pop(vm);
+                freeValue(&popped_mid);
+                break;
+            }
+            case OP_MUTEX_DESTROY: {
+                Value midVal = peek(vm, 0);
+                if (!IS_INTLIKE(midVal)) {
+                    runtimeError(vm, "Mutex id must be integer.");
+                    Value popped_mid = pop(vm);
+                    freeValue(&popped_mid);
+                    return INTERPRET_RUNTIME_ERROR;
+                }
+                int mid = (int)midVal.i_val;
+                if (!destroyMutex(vm, mid)) {
                     runtimeError(vm, "Invalid mutex id %d.", mid);
                     Value popped_mid = pop(vm);
                     freeValue(&popped_mid);


### PR DESCRIPTION
## Summary
- allow Pascal and CLike programs to release mutexes via new `destroy` builtin
- document and test mutex destruction behavior
- remove duplicate audio header include in VM

## Testing
- `bash Tests/run_pascal_tests.sh`
- `bash Tests/run_clike_tests.sh`
- `bash Tests/run_tiny_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b5b706f040832a879daa53fe483d7b