### PR TITLE
Use persistent worker threads for progressive Mandelbrot rendering

### DIFF
--- a/Examples/Pascal/SDLInteractiveMandelbrotRow
+++ b/Examples/Pascal/SDLInteractiveMandelbrotRow
@@ -45,6 +45,8 @@ VAR
   ThreadStart, ThreadEnd : ARRAY[0..ThreadCount - 1] OF Integer;
   RowDone : ARRAY[0..MandelWindowHeight - 1] OF Integer;
   RenderThreadIDs : ARRAY[0..ThreadCount - 1] OF Integer;
+  WorkReady : ARRAY[0..ThreadCount - 1] OF Integer;
+  WorkerShutdown : Boolean;
   RowMutex : Integer;
 
   NewCenterX, NewCenterY          : Real;
@@ -52,6 +54,7 @@ VAR
   NewViewWidthRe, NewViewHeightIm     : Real;
   PercentDone : Integer;
   MouseThreadID, KeyboardThreadID : Integer;
+  i : Integer;
 
 // This procedure recalculates MaxIm and scaling factors based on CURRENT MinRe, MaxRe, MinIm
 PROCEDURE UpdateScalingAndDependentViewParams;
@@ -130,10 +133,21 @@ END;
     END; // Py
   END;
 
-PROCEDURE ComputeRowsThread0; BEGIN ComputeRows(ThreadStart[0], ThreadEnd[0]); END;
-PROCEDURE ComputeRowsThread1; BEGIN ComputeRows(ThreadStart[1], ThreadEnd[1]); END;
-PROCEDURE ComputeRowsThread2; BEGIN ComputeRows(ThreadStart[2], ThreadEnd[2]); END;
-PROCEDURE ComputeRowsThread3; BEGIN ComputeRows(ThreadStart[3], ThreadEnd[3]); END;
+PROCEDURE WorkerLoop(id: Integer);
+BEGIN
+  WHILE NOT WorkerShutdown DO BEGIN
+    IF WorkReady[id] = 1 THEN BEGIN
+      ComputeRows(ThreadStart[id], ThreadEnd[id]);
+      WorkReady[id] := 0;
+    END ELSE
+      Delay(0);
+  END;
+END;
+
+PROCEDURE WorkerThread0; BEGIN WorkerLoop(0); END;
+PROCEDURE WorkerThread1; BEGIN WorkerLoop(1); END;
+PROCEDURE WorkerThread2; BEGIN WorkerLoop(2); END;
+PROCEDURE WorkerThread3; BEGIN WorkerLoop(3); END;
 
 PROCEDURE FillPixelDataAndDisplayProgressively;
   VAR i, startY, endY, rowsPerThread, extra, y, doneFlag : Integer;
@@ -153,12 +167,8 @@ BEGIN
     ThreadStart[i] := startY;
     ThreadEnd[i] := endY;
     startY := endY + 1;
+    WorkReady[i] := 1;
   END;
-
-  RenderThreadIDs[0] := spawn ComputeRowsThread0;
-  RenderThreadIDs[1] := spawn ComputeRowsThread1;
-  RenderThreadIDs[2] := spawn ComputeRowsThread2;
-  RenderThreadIDs[3] := spawn ComputeRowsThread3;
 
   y := 0;
   WHILE y < ViewPixelHeight DO BEGIN
@@ -179,7 +189,8 @@ BEGIN
     END;
   END;
 
-  FOR i := 0 TO ThreadCount - 1 DO join RenderThreadIDs[i];
+  FOR i := 0 TO ThreadCount - 1 DO
+    WHILE WorkReady[i] <> 0 DO Delay(0);
 
   // Ensure the final image is copied to the texture and presented.
   UpdateAndDisplayTextureInProgress;
@@ -245,6 +256,13 @@ BEGIN // Main Program
   MandelTextureID := CreateTexture(MandelWindowWidth, MandelWindowHeight);
   IF MandelTextureID < 0 THEN BEGIN GotoXY(1, StatusLineY); WriteLn('Error: No Texture! Halting.'); ReadKey; CloseGraph; NormVideo; ShowCursor; HALT; END;
 
+  WorkerShutdown := False;
+  FOR i := 0 TO ThreadCount - 1 DO WorkReady[i] := 0;
+  RenderThreadIDs[0] := spawn WorkerThread0;
+  RenderThreadIDs[1] := spawn WorkerThread1;
+  RenderThreadIDs[2] := spawn WorkerThread2;
+  RenderThreadIDs[3] := spawn WorkerThread3;
+
   ResetViewToInitial; // Sets MinRe,MaxRe,MinIm to defaults AND calculates scales/MaxIm
   RedrawNeeded := True;
   QuitProgram  := False;
@@ -260,6 +278,8 @@ BEGIN // Main Program
     END;
   END; // WHILE
 
+  WorkerShutdown := True;
+  FOR i := 0 TO ThreadCount - 1 DO join RenderThreadIDs[i];
   join MouseThreadID;
   join KeyboardThreadID;
 

--- a/Examples/Pascal/SDLInteractiveMandelbrot_native
+++ b/Examples/Pascal/SDLInteractiveMandelbrot_native
@@ -43,6 +43,8 @@ VAR
   ThreadStart, ThreadEnd : ARRAY[0..ThreadCount - 1] OF Integer;
   RowDone : ARRAY[0..MandelWindowHeight - 1] OF Integer;
   RenderThreadIDs : ARRAY[0..ThreadCount - 1] OF Integer;
+  WorkReady : ARRAY[0..ThreadCount - 1] OF Integer;
+  WorkerShutdown : Boolean;
   RowMutex : Integer;
 
   NewCenterX, NewCenterY          : Real;
@@ -50,6 +52,7 @@ VAR
   NewViewWidthRe, NewViewHeightIm     : Real;
   PercentDone : Integer;
   MouseThreadID, KeyboardThreadID : Integer;
+  i : Integer;
 
 // This procedure recalculates MaxIm and scaling factors based on CURRENT MinRe, MaxRe, MinIm
 PROCEDURE UpdateScalingAndDependentViewParams;
@@ -130,10 +133,21 @@ BEGIN
   END; // Py
 END;
 
-PROCEDURE ComputeRowsThread0; BEGIN ComputeRows(ThreadStart[0], ThreadEnd[0]); END;
-PROCEDURE ComputeRowsThread1; BEGIN ComputeRows(ThreadStart[1], ThreadEnd[1]); END;
-PROCEDURE ComputeRowsThread2; BEGIN ComputeRows(ThreadStart[2], ThreadEnd[2]); END;
-PROCEDURE ComputeRowsThread3; BEGIN ComputeRows(ThreadStart[3], ThreadEnd[3]); END;
+PROCEDURE WorkerLoop(id: Integer);
+BEGIN
+  WHILE NOT WorkerShutdown DO BEGIN
+    IF WorkReady[id] = 1 THEN BEGIN
+      ComputeRows(ThreadStart[id], ThreadEnd[id]);
+      WorkReady[id] := 0;
+    END ELSE
+      Delay(0);
+  END;
+END;
+
+PROCEDURE WorkerThread0; BEGIN WorkerLoop(0); END;
+PROCEDURE WorkerThread1; BEGIN WorkerLoop(1); END;
+PROCEDURE WorkerThread2; BEGIN WorkerLoop(2); END;
+PROCEDURE WorkerThread3; BEGIN WorkerLoop(3); END;
 
 PROCEDURE FillPixelDataAndDisplayProgressively;
   VAR i, startY, endY, rowsPerThread, extra, y, bufferIdx, rowBytes, k, displayedRows : Integer;
@@ -160,12 +174,8 @@ BEGIN
     ThreadStart[i] := startY;
     ThreadEnd[i] := endY;
     startY := endY + 1;
+    WorkReady[i] := 1;
   END;
-
-  RenderThreadIDs[0] := spawn ComputeRowsThread0;
-  RenderThreadIDs[1] := spawn ComputeRowsThread1;
-  RenderThreadIDs[2] := spawn ComputeRowsThread2;
-  RenderThreadIDs[3] := spawn ComputeRowsThread3;
 
   displayedRows := 0;
   WHILE displayedRows < ViewPixelHeight DO BEGIN
@@ -192,7 +202,8 @@ BEGIN
     END;
   END;
 
-  FOR i := 0 TO ThreadCount - 1 DO join RenderThreadIDs[i];
+  FOR i := 0 TO ThreadCount - 1 DO
+    WHILE WorkReady[i] <> 0 DO Delay(0);
 
   // Make sure the final frame is copied to the SDL texture and shown.
   // Without this call, the window may stay black once rendering finishes
@@ -256,16 +267,23 @@ BEGIN // Main Program
   MouseThreadID := spawn MouseInputThread;
   KeyboardThreadID := spawn KeyboardInputThread;
   MandelTextureID := CreateTexture(MandelWindowWidth, MandelWindowHeight);
-  IF MandelTextureID < 0 THEN 
-  BEGIN 
-    GotoXY(1, StatusLineY); 
-    WriteLn('Error: No Texture! Halting.'); 
-    ReadKey; 
-    CloseGraph; 
-    NormVideo; 
-    ShowCursor; 
-    HALT; 
+  IF MandelTextureID < 0 THEN
+  BEGIN
+    GotoXY(1, StatusLineY);
+    WriteLn('Error: No Texture! Halting.');
+    ReadKey;
+    CloseGraph;
+    NormVideo;
+    ShowCursor;
+    HALT;
   END;
+
+  WorkerShutdown := False;
+  FOR i := 0 TO ThreadCount - 1 DO WorkReady[i] := 0;
+  RenderThreadIDs[0] := spawn WorkerThread0;
+  RenderThreadIDs[1] := spawn WorkerThread1;
+  RenderThreadIDs[2] := spawn WorkerThread2;
+  RenderThreadIDs[3] := spawn WorkerThread3;
 
   ResetViewToInitial; // Sets MinRe,MaxRe,MinIm to defaults AND calculates scales/MaxIm
   RedrawNeeded := True;
@@ -282,14 +300,16 @@ BEGIN // Main Program
     END;
   END; // WHILE
 
+  WorkerShutdown := True;
+  FOR i := 0 TO ThreadCount - 1 DO join RenderThreadIDs[i];
   join MouseThreadID;
   join KeyboardThreadID;
 
   DestroyTexture(MandelTextureID); CloseGraph;
-  GotoXY(1, StatusLineY + 8); 
-  ClrEol; 
-  NormVideo; 
-  ShowCursor; 
-  WriteLn; 
+  GotoXY(1, StatusLineY + 8);
+  ClrEol;
+  NormVideo;
+  ShowCursor;
+  WriteLn;
   WriteLn('Program terminated.');
 END.


### PR DESCRIPTION
## Summary
- maintain a pool of Mandelbrot rendering threads launched at startup
- dispatch row range work via shared flags instead of spawning threads for each render
- cleanly shutdown and join worker threads before program exit

## Testing
- `./run_all_tests 2>&1 | tail -n 20` *(fails: permission denied and missing binaries)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f2d345a8832a8e10d45a690a14e3