### PR TITLE
Protect mutex registry with central lock

### DIFF
--- a/src/vm/vm.h
+++ b/src/vm/vm.h
@@ -94,6 +94,7 @@ typedef struct VM_s {
     // Mutex support
     Mutex mutexes[VM_MAX_MUTEXES];
     int mutexCount;
+    pthread_mutex_t mutexRegistryLock; // Protects mutex registry updates
     struct VM_s* mutexOwner; // VM that owns the mutex registry
 
 } VM;


### PR DESCRIPTION
## Summary
- Guard VM mutex registry updates with a new `mutexRegistryLock`
- Initialize and destroy the registry lock during VM setup and teardown
- Synchronize mutex creation, destruction, and lookups using the registry lock

## Testing
- `./Tests/run_all_tests` *(fails: clike binary not found at /workspace/pscal/build/bin/clike)*
- `bash run_pascal_tests.sh` *(fails: pascal binary not found at /workspace/pscal/build/bin/pascal)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fb6c0ca8832a9d3bc5e8ccddffe7