### PR TITLE
Add threaded Sierpinski triangle Pascal example

### DIFF
--- a/Examples/Pascal/SierpinskiTriangleThreads
+++ b/Examples/Pascal/SierpinskiTriangleThreads
@@ -1,0 +1,103 @@
+#!/usr/bin/env pascal
+program SierpinskiTriangleThreads;
+
+uses CRT;
+
+const
+  MaxLevel = 13;  // Adjust for more/less detail
+  CharToDraw = '+';
+
+type
+  Triangle = array[0..5] of integer;
+
+var
+  Params: array[0..2] of Triangle;
+  ThreadIDs: array[0..2] of integer;
+  ThreadLevel: integer;
+
+procedure DrawPoint(x, y: integer);
+begin
+  GotoXY(x, y);
+  Write(CharToDraw);
+end;
+
+procedure DrawSierpinski(x1, y1, x2, y2, x3, y3: integer; level: integer);
+var
+  mx1, my1, mx2, my2, mx3, my3: integer;
+begin
+  if level = 0 then
+  begin
+    DrawPoint(x1, y1);
+    DrawPoint(x2, y2);
+    DrawPoint(x3, y3);
+  end
+  else
+  begin
+    mx1 := (x1 + x2) div 2; my1 := (y1 + y2) div 2;
+    mx2 := (x2 + x3) div 2; my2 := (y2 + y3) div 2;
+    mx3 := (x3 + x1) div 2; my3 := (y3 + y1) div 2;
+    DrawSierpinski(x1, y1, mx1, my1, mx3, my3, level - 1);
+    DrawSierpinski(mx1, my1, x2, y2, mx2, my2, level - 1);
+    DrawSierpinski(mx3, my3, mx2, my2, x3, y3, level - 1);
+  end;
+end;
+
+procedure Thread0;
+begin
+  DrawSierpinski(Params[0][0], Params[0][1], Params[0][2], Params[0][3], Params[0][4], Params[0][5], ThreadLevel);
+end;
+
+procedure Thread1;
+begin
+  DrawSierpinski(Params[1][0], Params[1][1], Params[1][2], Params[1][3], Params[1][4], Params[1][5], ThreadLevel);
+end;
+
+procedure Thread2;
+begin
+  DrawSierpinski(Params[2][0], Params[2][1], Params[2][2], Params[2][3], Params[2][4], Params[2][5], ThreadLevel);
+end;
+
+var
+  maxX, maxY: integer;
+  x1, y1, x2, y2, x3, y3: integer;
+  mx1, my1, mx2, my2, mx3, my3: integer;
+  ch: char;
+
+begin
+  ClrScr;
+  HideCursor;
+
+  maxY := ScreenRows;
+  maxX := ScreenCols;
+
+  writeln('Drawing Sierpinski Triangle with threads (Level ', MaxLevel, ')...');
+  Delay(1000);
+
+  x1 := maxX div 2; y1 := 2;
+  x2 := 2; y2 := maxY - 1;
+  x3 := maxX - 1; y3 := maxY - 1;
+
+  mx1 := (x1 + x2) div 2; my1 := (y1 + y2) div 2;
+  mx2 := (x2 + x3) div 2; my2 := (y2 + y3) div 2;
+  mx3 := (x3 + x1) div 2; my3 := (y3 + y1) div 2;
+
+  ThreadLevel := MaxLevel - 1;
+
+  Params[0][0] := x1; Params[0][1] := y1; Params[0][2] := mx1; Params[0][3] := my1; Params[0][4] := mx3; Params[0][5] := my3;
+  Params[1][0] := mx1; Params[1][1] := my1; Params[1][2] := x2; Params[1][3] := y2; Params[1][4] := mx2; Params[1][5] := my2;
+  Params[2][0] := mx3; Params[2][1] := my3; Params[2][2] := mx2; Params[2][3] := my2; Params[2][4] := x3; Params[2][5] := y3;
+
+  ThreadIDs[0] := spawn Thread0;
+  ThreadIDs[1] := spawn Thread1;
+  ThreadIDs[2] := spawn Thread2;
+
+  join ThreadIDs[0];
+  join ThreadIDs[1];
+  join ThreadIDs[2];
+
+  GotoXY(1, maxY);
+  ShowCursor;
+  Write('Done. Press any key to exit.');
+  ch := ReadKey;
+  ClrScr;
+end.


### PR DESCRIPTION
## Summary
- Add `SierpinskiTriangleThreads` Pascal example showing how to use `spawn` and `join`
- Demonstrates drawing a Sierpinski triangle across three worker threads

## Testing
- `bash run_pascal_tests.sh`
- `bash run_clike_tests.sh`
- `bash run_tiny_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b5fd7375ec832ab213f87d5e21f545