### PR TITLE
fix: responsive SDL Mandelbrot zoom

### DIFF
--- a/Examples/clike/sdl_mandelbrot_interactive
+++ b/Examples/clike/sdl_mandelbrot_interactive
@@ -11,6 +11,8 @@ const int BytesPerPixel = 4;
 const int ScreenUpdateInterval = 16;
 const double ZoomFactor = 2.0;
 const int ThreadCount = 4;
+const int ButtonLeft = 1;
+const int ButtonRight = 4;
 
 byte pixelData[Width * Height * BytesPerPixel];
 int rowDone[Height];
@@ -27,8 +29,10 @@ double imFactor;
 int textureID;
 int rowMutex;
 int quitMutex;
+int inputMutex;
 int quit = 0;
 int redraw = 1;
+int mouseX = 0, mouseY = 0, mouseButtons = 0, prevButtons = 0;
 
 int getQuit() { 
     int q; 
@@ -76,10 +80,23 @@ void computeRowsThread1() { computeRows(threadStart[1], threadEnd[1]); }
 void computeRowsThread2() { computeRows(threadStart[2], threadEnd[2]); }
 void computeRowsThread3() { computeRows(threadStart[3], threadEnd[3]); }
 
+void mouseThread() {
+    int x, y, b;
+    while (!getQuit()) {
+        graphloop(0);
+        getmousestate(&x, &y, &b);
+        lock(inputMutex);
+        prevButtons = mouseButtons;
+        mouseX = x;
+        mouseY = y;
+        mouseButtons = b;
+        unlock(inputMutex);
+    }
+}
+
 int main() {
-    int mouseX = 0, mouseY = 0, mouseButtons = 0, prevButtons = 0;
-    int ButtonLeft = 1, ButtonRight = 4;
     int tid[ThreadCount], i, y, rowsPerThread, extra, startY, endY;
+    int inputTid;
 
     printf("Calculating Mandelbrot set. The window will update as rows are drawn...\n");
     initgraph(Width, Height, "Mandelbrot in CLike (threaded)");
@@ -89,14 +106,11 @@ int main() {
 
     rowMutex = mutex();
     quitMutex = mutex();
+    inputMutex = mutex();
+    inputTid = spawn mouseThread();
 
     while (!getQuit()) {
-        /*
-         * Pump SDL events before handling input so mouse and keyboard state
-         * are up to date.  Previously this was done at the end of the loop,
-         * which could miss short clicks that occurred between polls.
-         */
-        graphloop(16);
+        graphloop(0);
 
         if (redraw) {
             maxIm = minIm + (maxRe - minRe) * Height / Width;
@@ -175,19 +189,23 @@ int main() {
             if (toupper(c) == 'Q') { setQuit(1); continue; }
         }
 
-        getmousestate(&mouseX, &mouseY, &mouseButtons);
-        if (((mouseButtons & ButtonLeft) != 0) && ((prevButtons & ButtonLeft) == 0)) {
-            double centerRe = minRe + mouseX * reFactor;
-            double centerIm = maxIm - mouseY * imFactor;
+        int mx, my, buttons, prev;
+        lock(inputMutex);
+        mx = mouseX; my = mouseY; buttons = mouseButtons; prev = prevButtons;
+        unlock(inputMutex);
+
+        if (((buttons & ButtonLeft) != 0) && ((prev & ButtonLeft) == 0)) {
+            double centerRe = minRe + mx * reFactor;
+            double centerIm = maxIm - my * imFactor;
             double newWidth = (maxRe - minRe) / ZoomFactor;
             double newHeight = (maxIm - minIm) / ZoomFactor;
             minRe = centerRe - newWidth / 2.0;
             maxRe = centerRe + newWidth / 2.0;
             minIm = centerIm - newHeight / 2.0;
             redraw = 1;
-        } else if (((mouseButtons & ButtonRight) != 0) && ((prevButtons & ButtonRight) == 0)) {
-            double centerRe = minRe + mouseX * reFactor;
-            double centerIm = maxIm - mouseY * imFactor;
+        } else if (((buttons & ButtonRight) != 0) && ((prev & ButtonRight) == 0)) {
+            double centerRe = minRe + mx * reFactor;
+            double centerIm = maxIm - my * imFactor;
             double newWidth = (maxRe - minRe) * ZoomFactor;
             double newHeight = (maxIm - minIm) * ZoomFactor;
             minRe = centerRe - newWidth / 2.0;
@@ -195,9 +213,8 @@ int main() {
             minIm = centerIm - newHeight / 2.0;
             redraw = 1;
         }
-        prevButtons = mouseButtons;
     }
-
+    join inputTid;
     destroytexture(textureID);
     closegraph();
     return 0;


### PR DESCRIPTION
## Summary
- track mouse state in a dedicated thread for fresh coordinates
- apply zoom based on thread-updated mouse position

## Testing
- `./Examples/clike/sdl_mandelbrot_interactive` *(fails: /usr/bin/env: ‘clike’: No such file or directory)*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68b61028ce24832ab2c65dd9aeb35bb2