### PR TITLE
Fix CLike SDL mouse state retrieval

### DIFF
--- a/Examples/clike/README.md
+++ b/Examples/clike/README.md
@@ -26,6 +26,7 @@ build/bin/clike Examples/Clike/<program>
    library search path.
 - `sdl_multibouncingballs` – SDL multi bouncing balls demo ported from Pascal.
 - `sdl_mandelbrot_interactive` – SDL Mandelbrot renderer using the MandelbrotRow builtin; left click to zoom in, right click to zoom out.
+- `sdl_getmousestate` – SDL demo printing mouse coordinates and button states.
 - `show_pid` – Uses an extended builtin function to show the process ID
 - `sort_string` – Shows how to copy and sort a string via a `str*` parameter
 - `vm_version_demo` – Prints VM and bytecode versions and exits on mismatch

--- a/Examples/clike/sdl_getmousestate
+++ b/Examples/clike/sdl_getmousestate
@@ -1,0 +1,38 @@
+#!/usr/bin/env clike
+/*
+ * SDL demo showcasing the getmousestate builtin.
+ * Displays mouse coordinates and button state while the window is open.
+ * Press Q to quit.
+ */
+
+int main() {
+#ifdef SDL_ENABLED
+    int x, y, buttons;
+    int prevX = -1;
+    int prevY = -1;
+    int prevButtons = 0;
+
+    printf("Move the mouse inside the window. Press Q to quit.\n");
+    initgraph(640, 480, "getmousestate demo");
+
+    while (1) {
+        graphloop(1);
+        getmousestate(&x, &y, &buttons);
+        if (x != prevX || y != prevY || buttons != prevButtons) {
+            printf("Mouse: x=%d y=%d buttons=%d\n", x, y, buttons);
+            prevX = x;
+            prevY = y;
+            prevButtons = buttons;
+        }
+        if (keypressed()) {
+            char c = readkey();
+            if (toupper(c) == 'Q')
+                break;
+        }
+    }
+    closegraph();
+#else
+    printf("SDL support not enabled.\n");
+#endif
+    return 0;
+}

--- a/src/backend_ast/sdl.c
+++ b/src/backend_ast/sdl.c
@@ -379,6 +379,14 @@ Value vmBuiltinGetmousestate(VM* vm, int arg_count, Value* args) {
     }
     // --- END SAFETY CHECKS ---
 
+    if (!gSdlInitialized || !gSdlWindow || !gSdlRenderer) {
+        runtimeError(vm, "Graphics system not initialized for GetMouseState.");
+        return makeVoid();
+    }
+
+    // Ensure SDL's event state is up to date before querying the mouse
+    SDL_PumpEvents();
+
     int mse_x, mse_y;
     Uint32 sdl_buttons = SDL_GetMouseState(&mse_x, &mse_y);
     


### PR DESCRIPTION
## Summary
- ensure the `getmousestate` builtin pumps SDL events and validates initialization
- run the demo's event loop with a small delay so mouse activity registers

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `Tests/run_clike_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b6358e49d4832a91261d059af9a9fa