### PR TITLE
Pipe 'Q' into SDLFeaturesTest for automated exit

### DIFF
--- a/Tests/run_pascal_tests.sh
+++ b/Tests/run_pascal_tests.sh
@@ -55,7 +55,9 @@ for src in "$SCRIPT_DIR"/Pascal/*; do
   echo "---- $test_name ----"
 
   set +e
-  if [ -f "$in_file" ]; then
+  if [ "$test_name" = "SDLFeaturesTest" ]; then
+    (cd "$SCRIPT_DIR" && printf 'Q\n' | "$PASCAL_BIN" "Pascal/$test_name" > "$actual_out" 2> "$actual_err")
+  elif [ -f "$in_file" ]; then
     (cd "$SCRIPT_DIR" && "$PASCAL_BIN" "Pascal/$test_name" < "$in_file" > "$actual_out" 2> "$actual_err")
   else
     (cd "$SCRIPT_DIR" && "$PASCAL_BIN" "Pascal/$test_name" > "$actual_out" 2> "$actual_err")


### PR DESCRIPTION
## Summary
- Ensure SDLFeaturesTest exits automatically during Pascal tests by piping a `Q` into its stdin

## Testing
- `bash Tests/run_pascal_tests.sh` *(fails: pascal binary not found at /workspace/pscal/build/bin/pascal)*

------
https://chatgpt.com/codex/tasks/task_e_68b652762a70832a86fc7bd2dea02a48