### PR TITLE
Fix GetMouseState crash on macOS

### DIFF
--- a/src/backend_ast/sdl.c
+++ b/src/backend_ast/sdl.c
@@ -384,11 +384,33 @@ Value vmBuiltinGetmousestate(VM* vm, int arg_count, Value* args) {
         return makeVoid();
     }
 
-    // Ensure SDL's event state is up to date before querying the mouse
-    SDL_PumpEvents();
-
     int mse_x, mse_y;
-    Uint32 sdl_buttons = SDL_GetMouseState(&mse_x, &mse_y);
+    Uint32 sdl_buttons;
+
+#ifdef __APPLE__
+    // On macOS SDL_PumpEvents must run on the main thread.  Calling it from
+    // the VM worker thread causes a crash.  SDL_GetGlobalMouseState queries the
+    // OS directly and avoids the need to pump events here.
+    int global_x, global_y;
+    sdl_buttons = SDL_GetGlobalMouseState(&global_x, &global_y);
+
+    int win_x = 0, win_y = 0;
+    SDL_GetWindowPosition(gSdlWindow, &win_x, &win_y);
+#if SDL_VERSION_ATLEAST(2,0,5)
+    int border_top = 0, border_left = 0, border_bottom = 0, border_right = 0;
+    if (SDL_GetWindowBordersSize(gSdlWindow, &border_top, &border_left,
+                                 &border_bottom, &border_right) == 0) {
+        win_x += border_left;
+        win_y += border_top;
+    }
+#endif
+    mse_x = global_x - win_x;
+    mse_y = global_y - win_y;
+#else
+    // Keep existing behaviour on other platforms by updating SDL's state first.
+    SDL_PumpEvents();
+    sdl_buttons = SDL_GetMouseState(&mse_x, &mse_y);
+#endif
     
     int pscal_buttons = 0;
     if (sdl_buttons & SDL_BUTTON_LMASK) pscal_buttons |= 1;


### PR DESCRIPTION
## Summary
- Prevent GetMouseState from calling SDL_PumpEvents on macOS, which crashed when run outside the main thread
- Convert global mouse coordinates to client-area space by subtracting window borders on macOS

## Testing
- `cmake -DSDL=ON ..`
- `make -j4`
- `./run_all_tests` *(fails: SDLFeaturesTest due to missing font and invalid XDG_RUNTIME_DIR)*

------
https://chatgpt.com/codex/tasks/task_e_68b6493fc95c832a928899dcd880763e