### PR TITLE
Prevent overlapping firework sounds in SDL example

### DIFF
--- a/Examples/Pascal/SDLFireWorks
+++ b/Examples/Pascal/SDLFireWorks
@@ -37,7 +37,7 @@ begin
     Particles[j].g := Random(255);
     Particles[j].b := Random(255);
   end;
-  if boom <> -1 then
+  if (boom <> -1) and not IsSoundPlaying() then
     PlaySound(boom);   { play once when spawning }
 end;
 


### PR DESCRIPTION
## Summary
- Avoid starting a new explosion sound if one is already playing in the SDLFireWorks example.

## Testing
- `cmake --build build`
- `Tests/run_pascal_tests.sh` *(fails: stdout mismatch in HttpAsyncFileURL)*

------
https://chatgpt.com/codex/tasks/task_e_68b843658c88832ab27002668df7ae7f