### PR TITLE
Handle both uppercase and lowercase Q to exit SDLFireWorks demo

### DIFF
--- a/Examples/Pascal/SDLFireWorks
+++ b/Examples/Pascal/SDLFireWorks
@@ -51,7 +51,7 @@ begin
 
   SpawnFirework(400, 300);  { initial burst }
 
-  while PollKey() <> Ord('q') do
+  while not (PollKey() in [Ord('q'), Ord('Q')]) do
   begin
     ClearDevice();
 
@@ -71,7 +71,7 @@ begin
         FillCircle(Round(Particles[i].x), Round(Particles[i].y), 2);
       end;
 
-    OutTextXY(10, 10, 'Click to launch fireworks – Q quits');
+    OutTextXY(10, 10, 'Click to launch fireworks – Q or q quits');
     UpdateScreen();
     GraphLoop(16);  { ~60 fps }
   end;


### PR DESCRIPTION
## Summary
- Allow SDLFireWorks example to quit on either lowercase or uppercase Q
- Update on-screen instructions to mention both cases

## Testing
- `fpc /tmp/SDLFireWorks.pas` *(fails: Identifier not found "IsSoundPlaying", etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b86028a77c832a9045e35e3de3df23