### PR TITLE
Fix HttpHeadersNet test string handling

### DIFF
--- a/Tests/clike/HttpHeadersNet.cl
+++ b/Tests/clike/HttpHeadersNet.cl
@@ -5,11 +5,11 @@ int main() {
   mstream out = mstreamcreate();
   int code = httprequest(s, "GET", "https://example.com", NULL, out);
   printf("%d\n", code);
-  string ctype = httpgetheader(s, "Content-Type");
+  str ctype = httpgetheader(s, "Content-Type");
   int n = length(ctype);
   if (n > 9) n = 9; // print only the media type prefix (e.g., text/html)
-  for (int i = 0; i < n; i = i + 1) putchar(ctype[i]);
-  putchar('\n');
+  for (int i = 0; i < n; i = i + 1) printf("%c", ctype[i]);
+  printf("\n");
   mstreamfree(&out);
   httpclose(s);
   return 0;


### PR DESCRIPTION
## Summary
- use `str` for string type and printf to output in HttpHeadersNet test

## Testing
- `build/bin/clike Tests/clike/HttpHeadersNet.cl` *(fails: curl failed: Failure when receiving data from the peer)*

------
https://chatgpt.com/codex/tasks/task_e_68b86790c858832a84820e96e52d4b4a