### PR TITLE
Fix HttpHeadersNet test string handling

### DIFF
--- a/Tests/clike/HttpHeadersNet.cl
+++ b/Tests/clike/HttpHeadersNet.cl
@@ -5,11 +5,11 @@ int main() {
   mstream out = mstreamcreate();
   int code = httprequest(s, "GET", "https://example.com", NULL, out);
   printf("%d\n", code);
-  string ctype = httpgetheader(s, "Content-Type");
+  str ctype = httpgetheader(s, "Content-Type");
   int n = length(ctype);
   if (n > 9) n = 9; // print only the media type prefix (e.g., text/html)
-  for (int i = 0; i < n; i = i + 1) putchar(ctype[i]);
-  putchar('\n');
+  for (int i = 0; i < n; i = i + 1) printf("%c", ctype[i]);
+  printf("\n");
   mstreamfree(&out);
   httpclose(s);
   return 0;

--- a/src/backend_ast/builtin_network_api.c
+++ b/src/backend_ast/builtin_network_api.c
@@ -1626,7 +1626,7 @@ Value vmBuiltinHttpGetHeader(VM* vm, int arg_count, Value* args) {
     size_t name_len = strlen(name);
     if (name_len == 0) return makeString("");
 
-    // Identify last header block (after final blank line)
+    // Identify start of the last header block (data before the final blank line)
     const char* all = s->last_headers;
     const char* block = all;
     const char* p = all;
@@ -1638,8 +1638,8 @@ Value vmBuiltinHttpGetHeader(VM* vm, int arg_count, Value* args) {
         else if (crlfcrlf) sep = crlfcrlf;
         else if (lflf) sep = lflf;
         else break;
-        block = sep + ((sep == crlfcrlf) ? 4 : 2);
-        p = block;
+        block = p;
+        p = sep + ((sep == crlfcrlf) ? 4 : 2);
     }
 
     // Scan lines in the last block for header name


### PR DESCRIPTION
## Summary
- use `str` for string type and printf to output in HttpHeadersNet test
- correctly locate last HTTP header block when fetching file:// URLs

## Testing
- `build/bin/pascal Tests/Pascal/HttpHeadersFileURL` *(fails: Runtime Error: Undefined global variable 'httpgetheader')*
- `build/bin/clike Tests/clike/HttpHeadersNet.cl` *(fails: httpRequest: curl failed: Failure when receiving data from the peer)*

------
https://chatgpt.com/codex/tasks/task_e_68b86790c858832a84820e96e52d4b4a