### PR TITLE
Fix HttpHeadersNet string indexing

### DIFF
--- a/Tests/clike/HttpHeadersNet.cl
+++ b/Tests/clike/HttpHeadersNet.cl
@@ -8,7 +8,7 @@ int main() {
   str ctype = httpgetheader(s, "Content-Type");
   int n = length(ctype);
   if (n > 9) n = 9; // print only the media type prefix (e.g., text/html)
-  for (int i = 0; i < n; i = i + 1) printf("%c", ctype[i]);
+  for (int i = 0; i < n; i = i + 1) printf("%c", ctype[i + 1]);
   printf("\n");
   mstreamfree(&out);
   httpclose(s);


### PR DESCRIPTION
## Summary
- handle Pascal-style length byte when reading HTTP Content-Type header in HttpHeadersNet test

## Testing
- `RUN_NET_TESTS=1 Tests/run_clike_tests.sh` *(fails: httpRequest curl failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b879f5f6cc832ab247f9b30965004c