### PR TITLE
Fix Pascal MathLib test recursion causing stack overflow

### DIFF
--- a/Tests/Pascal/MathLibTest
+++ b/Tests/Pascal/MathLibTest
@@ -6,10 +6,6 @@ uses
 const
   TOL = 0.0001;
 
-var
-  r: real;
-  i: integer;
-
 procedure AssertEqualInt(expected, actual: integer; testName: string);
 begin
   write('START: ', testName, ': ');
@@ -45,7 +41,6 @@ begin
   AssertEqualReal(1.0, Min(2.0, 1.0), 'Min(2,1)');
   AssertEqualInt(3, Floor(3.7), 'Floor(3.7)');
   AssertEqualInt(4, Ceil(3.1), 'Ceil(3.1)');
-
 end;
 
 begin

--- a/src/Pascal/ast.c
+++ b/src/Pascal/ast.c
@@ -844,13 +844,24 @@ VarType getBuiltinReturnType(const char* name) {
     if (strcasecmp(name, "pollkey") == 0) return TYPE_INTEGER;
 
     /* Math routines returning REAL */
-    if (strcasecmp(name, "cos")  == 0 ||
-        strcasecmp(name, "sin")  == 0 ||
-        strcasecmp(name, "tan")  == 0 ||
-        strcasecmp(name, "sqrt") == 0 ||
-        strcasecmp(name, "ln")   == 0 ||
-        strcasecmp(name, "exp")  == 0 ||
-        strcasecmp(name, "real") == 0) {
+    if (strcasecmp(name, "cos")   == 0 ||
+        strcasecmp(name, "sin")   == 0 ||
+        strcasecmp(name, "tan")   == 0 ||
+        strcasecmp(name, "sqrt")  == 0 ||
+        strcasecmp(name, "ln")    == 0 ||
+        strcasecmp(name, "exp")   == 0 ||
+        strcasecmp(name, "real")  == 0 ||
+        strcasecmp(name, "arctan") == 0 ||
+        strcasecmp(name, "arcsin") == 0 ||
+        strcasecmp(name, "arccos") == 0 ||
+        strcasecmp(name, "cotan")  == 0 ||
+        strcasecmp(name, "power")  == 0 ||
+        strcasecmp(name, "log10")  == 0 ||
+        strcasecmp(name, "sinh")   == 0 ||
+        strcasecmp(name, "cosh")   == 0 ||
+        strcasecmp(name, "tanh")   == 0 ||
+        strcasecmp(name, "max")    == 0 ||
+        strcasecmp(name, "min")    == 0) {
         return TYPE_REAL;
     }
 
@@ -874,7 +885,9 @@ VarType getBuiltinReturnType(const char* name) {
         strcasecmp(name, "getmaxx")   == 0 ||
         strcasecmp(name, "getmaxy")   == 0 ||
         strcasecmp(name, "mutex")     == 0 ||
-        strcasecmp(name, "rcmutex")   == 0) {
+        strcasecmp(name, "rcmutex")   == 0 ||
+        strcasecmp(name, "floor")     == 0 ||
+        strcasecmp(name, "ceil")      == 0) {
         return TYPE_INTEGER;
     }
 


### PR DESCRIPTION
## Summary
- Ensure Pascal math builtins report correct return types
- Call VM math routines directly in MathLib test without temporary variables

## Testing
- `cmake .. && make -j$(nproc)`
- `TEST_HOME=$(mktemp -d); PASCAL_LIB_ROOT=$(mktemp -d); cp -R lib/. "$PASCAL_LIB_ROOT/"; cp lib/pascal/crtvt.pl "$PASCAL_LIB_ROOT/pascal/crt.pl"; PASCAL_LIB_DIR="$PASCAL_LIB_ROOT/pascal" PSCAL_LIB_DIR="$PASCAL_LIB_DIR" HOME="$TEST_HOME" build/bin/pascal Tests/Pascal/MathLibTest`


------
https://chatgpt.com/codex/tasks/task_e_68b87ff7070c832aab281b4a7a3dfe40