### PR TITLE
Add Accept-Encoding option for HTTP

### DIFF
--- a/Docs/pscal_vm_builtins.md
+++ b/Docs/pscal_vm_builtins.md
@@ -119,7 +119,7 @@ VM. For instructions on adding your own routines, see
 | HttpClose | (session: Integer) | void | Destroy a session and free resources. |
 | HttpSetHeader | (session: Integer, name: String, value: String) | void | Add a request header to the session. |
 | HttpClearHeaders | (session: Integer) | void | Clear all accumulated headers. |
-| HttpSetOption | (session: Integer, key: String, value: Int or String) | void | Set basic options: `timeout_ms` (Int), `follow_redirects` (Int 0/1), `user_agent` (String). |
+| HttpSetOption | (session: Integer, key: String, value: Int or String) | void | Set options such as `timeout_ms` (Int), `follow_redirects` (Int 0/1), `user_agent` (String), `accept_encoding` (String). |
 | HttpRequest | (session: Integer, method: String, url: String, body: String|MStream|nil, out: MStream) | Integer (status) | Perform a request; writes response body into `out`. Returns HTTP status or -1 on transport error. |
 
 Notes

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Built-in HTTP helpers are available to all front ends (Pascal and CLike). Highli
 - Headers: `HttpSetHeader/httpsetheader`, `HttpClearHeaders/httpclearheaders`, `HttpGetLastHeaders/httpgetlastheaders`, `HttpGetHeader/httpgetheader`.
 - Options via `HttpSetOption/httpsetoption` (key → value):
   - `timeout_ms`, `follow_redirects`, `user_agent`
+  - Compression: `accept_encoding` (e.g., `gzip` or empty string for all supported encodings)
   - TLS: `ca_path`, `client_cert`, `client_key`, hostname checks via `verify_peer`, `verify_host`
   - Proxy: `proxy`
   - HTTP/2: `http2`


### PR DESCRIPTION
## Summary
- allow configuring Accept-Encoding via `HttpSetOption`
- enable automatic decompression for sync and async HTTP requests
- document `accept_encoding` session option

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `make -C Tests test`


------
https://chatgpt.com/codex/tasks/task_e_68b88c7a5ab8832a9967387060b4477e