### PR TITLE
Add Accept-Encoding option for HTTP

### DIFF
--- a/Docs/pscal_vm_builtins.md
+++ b/Docs/pscal_vm_builtins.md
@@ -119,7 +119,7 @@ VM. For instructions on adding your own routines, see
 | HttpClose | (session: Integer) | void | Destroy a session and free resources. |
 | HttpSetHeader | (session: Integer, name: String, value: String) | void | Add a request header to the session. |
 | HttpClearHeaders | (session: Integer) | void | Clear all accumulated headers. |
-| HttpSetOption | (session: Integer, key: String, value: Int or String) | void | Set basic options: `timeout_ms` (Int), `follow_redirects` (Int 0/1), `user_agent` (String). |
+| HttpSetOption | (session: Integer, key: String, value: Int or String) | void | Set options such as `timeout_ms` (Int), `follow_redirects` (Int 0/1), `user_agent` (String), `accept_encoding` (String). |
 | HttpRequest | (session: Integer, method: String, url: String, body: String|MStream|nil, out: MStream) | Integer (status) | Perform a request; writes response body into `out`. Returns HTTP status or -1 on transport error. |
 
 Notes

--- a/Examples/clike/HttpAsyncDemo
+++ b/Examples/clike/HttpAsyncDemo
@@ -1,18 +1,11 @@
 #!/usr/bin/env clike
 
 int main() {
-  // Prepare source file for file:// demo
-  FILE *f = fopen("async_src_cl.txt", "w");
-  if (f) { fprintf(f, "HelloAsyncCL\n"); fclose(f); }
-  char* cwd = getenv("PWD");
-  string url = "file://"; url = url + cwd; url = url + "/async_src_cl.txt";
-
   int s = httpsession();
-  int id = httprequestasync(s, "GET", url, NULL);
+  int id = httprequestasync(s, "GET", "data:text/plain,HelloAsyncCL", NULL);
   while (httpisdone(id) == 0) { delay(10); }
   mstream out = mstreamcreate();
-  int code = httpawait(id, out);
-  printf("Status: %d\n", code);
+  httpawait(id, out);
   printf("Body: %s\n", mstreambuffer(out));
   mstreamfree(&out);
   httpclose(s);

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Built-in HTTP helpers are available to all front ends (Pascal and CLike). Highli
 - Headers: `HttpSetHeader/httpsetheader`, `HttpClearHeaders/httpclearheaders`, `HttpGetLastHeaders/httpgetlastheaders`, `HttpGetHeader/httpgetheader`.
 - Options via `HttpSetOption/httpsetoption` (key → value):
   - `timeout_ms`, `follow_redirects`, `user_agent`
+  - Compression: `accept_encoding` (e.g., `gzip` or empty string for all supported encodings)
   - TLS: `ca_path`, `client_cert`, `client_key`, hostname checks via `verify_peer`, `verify_host`
   - Proxy: `proxy`
   - HTTP/2: `http2`

--- a/src/backend_ast/builtin_network_api.c
+++ b/src/backend_ast/builtin_network_api.c
@@ -124,6 +124,7 @@ typedef struct HttpSession_s {
     char* ciphers;        // CURLOPT_SSL_CIPHER_LIST
     char* pinned_pubkey;  // CURLOPT_PINNEDPUBLICKEY
     char* out_file;       // optional sink for HttpRequest
+    char* accept_encoding; // CURLOPT_ACCEPT_ENCODING
     // Auth and last-results
     char* basic_auth;     // user:pass for basic auth
     char* last_headers;   // raw response headers from last request
@@ -176,6 +177,7 @@ static void httpFreeSession(int id) {
     if (s->curl) { curl_easy_cleanup(s->curl); s->curl = NULL; }
     if (s->user_agent) { free(s->user_agent); s->user_agent = NULL; }
     if (s->out_file) { free(s->out_file); s->out_file = NULL; }
+    if (s->accept_encoding) { free(s->accept_encoding); s->accept_encoding = NULL; }
     if (s->basic_auth) { free(s->basic_auth); s->basic_auth = NULL; }
     if (s->ca_path) { free(s->ca_path); s->ca_path = NULL; }
     if (s->client_cert) { free(s->client_cert); s->client_cert = NULL; }
@@ -318,6 +320,18 @@ Value vmBuiltinHttpSetOption(VM* vm, int arg_count, Value* args) {
     } else if (strcasecmp(key, "out_file") == 0 && args[2].type == TYPE_STRING) {
         if (s->out_file) free(s->out_file);
         s->out_file = strdup(args[2].s_val ? args[2].s_val : "");
+    } else if (strcasecmp(key, "accept_encoding") == 0) {
+        if (s->accept_encoding) {
+            /* Clear the libcurl handle to avoid dangling pointers before freeing */
+            curl_easy_setopt(s->curl, CURLOPT_ACCEPT_ENCODING, NULL);
+            free(s->accept_encoding);
+            s->accept_encoding = NULL;
+        }
+        if (args[2].type == TYPE_STRING) {
+            s->accept_encoding = strdup(args[2].s_val ? args[2].s_val : "");
+        } else if (!IS_INTLIKE(args[2])) {
+            runtimeError(vm, "httpSetOption: accept_encoding expects string or int.");
+        }
     } else {
         runtimeError(vm, "httpSetOption: unsupported option or value type for '%s'.", key);
     }
@@ -469,6 +483,7 @@ Value vmBuiltinHttpRequest(VM* vm, int arg_count, Value* args) {
     if (s->user_agent) curl_easy_setopt(s->curl, CURLOPT_USERAGENT, s->user_agent);
     if (s->headers) curl_easy_setopt(s->curl, CURLOPT_HTTPHEADER, s->headers);
     if (s->resolve) curl_easy_setopt(s->curl, CURLOPT_RESOLVE, s->resolve);
+    if (s->accept_encoding) curl_easy_setopt(s->curl, CURLOPT_ACCEPT_ENCODING, s->accept_encoding);
     if (s->basic_auth && s->basic_auth[0]) {
         curl_easy_setopt(s->curl, CURLOPT_HTTPAUTH, (long)CURLAUTH_BASIC);
         curl_easy_setopt(s->curl, CURLOPT_USERPWD, s->basic_auth);
@@ -710,6 +725,7 @@ Value vmBuiltinHttpRequestToFile(VM* vm, int arg_count, Value* args) {
     if (s->user_agent) curl_easy_setopt(s->curl, CURLOPT_USERAGENT, s->user_agent);
     if (s->headers) curl_easy_setopt(s->curl, CURLOPT_HTTPHEADER, s->headers);
     if (s->resolve) curl_easy_setopt(s->curl, CURLOPT_RESOLVE, s->resolve);
+    if (s->accept_encoding) curl_easy_setopt(s->curl, CURLOPT_ACCEPT_ENCODING, s->accept_encoding);
     if (s->basic_auth && s->basic_auth[0]) {
         curl_easy_setopt(s->curl, CURLOPT_HTTPAUTH, (long)CURLAUTH_BASIC);
         curl_easy_setopt(s->curl, CURLOPT_USERPWD, s->basic_auth);
@@ -972,6 +988,7 @@ typedef struct HttpAsyncJob_s {
     char* out_file;
     char* user_agent;
     char* basic_auth;
+    char* accept_encoding;
     char* ca_path; char* client_cert; char* client_key; char* proxy;
     char* proxy_userpwd; long proxy_type;
     long alpn; long tls_min; long tls_max; char* ciphers; char* pinned_pubkey;
@@ -1125,6 +1142,7 @@ static void* httpAsyncThread(void* arg) {
     if (job->user_agent && job->user_agent[0]) curl_easy_setopt(eh, CURLOPT_USERAGENT, job->user_agent);
     if (job->headers_slist) curl_easy_setopt(eh, CURLOPT_HTTPHEADER, job->headers_slist);
     if (job->resolve_slist) curl_easy_setopt(eh, CURLOPT_RESOLVE, job->resolve_slist);
+    if (job->accept_encoding) curl_easy_setopt(eh, CURLOPT_ACCEPT_ENCODING, job->accept_encoding);
     if (job->basic_auth && job->basic_auth[0]) {
         curl_easy_setopt(eh, CURLOPT_HTTPAUTH, (long)CURLAUTH_BASIC);
         curl_easy_setopt(eh, CURLOPT_USERPWD, job->basic_auth);
@@ -1293,6 +1311,7 @@ Value vmBuiltinHttpRequestAsync(VM* vm, int arg_count, Value* args) {
         job->verify_peer = s->verify_peer; job->verify_host = s->verify_host; job->force_http2 = s->force_http2;
         job->user_agent = s->user_agent ? strdup(s->user_agent) : NULL;
         job->basic_auth = s->basic_auth ? strdup(s->basic_auth) : NULL;
+        job->accept_encoding = s->accept_encoding ? strdup(s->accept_encoding) : NULL;
         job->ca_path = s->ca_path ? strdup(s->ca_path) : NULL;
         job->client_cert = s->client_cert ? strdup(s->client_cert) : NULL;
         job->client_key = s->client_key ? strdup(s->client_key) : NULL;
@@ -1328,6 +1347,7 @@ Value vmBuiltinHttpRequestAsync(VM* vm, int arg_count, Value* args) {
         if (job->body) free(job->body);
         if (job->user_agent) free(job->user_agent);
         if (job->basic_auth) free(job->basic_auth);
+        if (job->accept_encoding) free(job->accept_encoding);
         if (job->ca_path) free(job->ca_path);
         if (job->client_cert) free(job->client_cert);
         if (job->client_key) free(job->client_key);
@@ -1384,6 +1404,7 @@ Value vmBuiltinHttpRequestAsyncToFile(VM* vm, int arg_count, Value* args) {
         job->verify_peer = s->verify_peer; job->verify_host = s->verify_host; job->force_http2 = s->force_http2;
         job->user_agent = s->user_agent ? strdup(s->user_agent) : NULL;
         job->basic_auth = s->basic_auth ? strdup(s->basic_auth) : NULL;
+        job->accept_encoding = s->accept_encoding ? strdup(s->accept_encoding) : NULL;
         job->ca_path = s->ca_path ? strdup(s->ca_path) : NULL;
         job->client_cert = s->client_cert ? strdup(s->client_cert) : NULL;
         job->client_key = s->client_key ? strdup(s->client_key) : NULL;
@@ -1457,6 +1478,7 @@ Value vmBuiltinHttpAwait(VM* vm, int arg_count, Value* args) {
     if (job->error) free(job->error);
     if (job->user_agent) free(job->user_agent);
     if (job->basic_auth) free(job->basic_auth);
+    if (job->accept_encoding) free(job->accept_encoding);
     if (job->ca_path) free(job->ca_path);
     if (job->client_cert) free(job->client_cert);
     if (job->client_key) free(job->client_key);
@@ -1515,6 +1537,7 @@ Value vmBuiltinHttpTryAwait(VM* vm, int arg_count, Value* args) {
     if (job->error) free(job->error);
     if (job->user_agent) free(job->user_agent);
     if (job->basic_auth) free(job->basic_auth);
+    if (job->accept_encoding) free(job->accept_encoding);
     if (job->ca_path) free(job->ca_path);
     if (job->client_cert) free(job->client_cert);
     if (job->client_key) free(job->client_key);


### PR DESCRIPTION
## Summary
- allow configuring Accept-Encoding via `HttpSetOption`
- enable automatic decompression for sync and async HTTP requests
- document `accept_encoding` session option
- clear libcurl `CURLOPT_ACCEPT_ENCODING` when disabling or passing non-string values
- fix `HttpAsyncDemo` C-like example to use a data URL instead of file I/O

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `make -C Tests test`
- `build/bin/clike Examples/clike/HttpAsyncDemo`


------
https://chatgpt.com/codex/tasks/task_e_68b88c7a5ab8832a9967387060b4477e