### PR TITLE
Fix HttpHeadersAuthDemo compile error

### DIFF
--- a/Examples/clike/HttpHeadersAuthDemo
+++ b/Examples/clike/HttpHeadersAuthDemo
@@ -12,12 +12,12 @@ int main() {
     printf("Server: %s\n", httpgetheader(s, "Server"));
 
     // Print a snippet of the body
-    string body = mstreambuffer(out);
-    int n = length(body);
+    str body = mstreambuffer(out);
+    int n = strlen(body);
     if (n > 80) n = 80;
     printf("Body (first %d): ", n);
-    for (int i = 0; i < n; i = i + 1) putchar(body[i]);
-    putchar('\n');
+    for (int i = 1; i <= n; i = i + 1) printf("%c", body[i]);
+    printf("\n");
 
     // Basic auth example (uncomment to try)
     // httpsetoption(s, "basic_auth", "user:passwd");


### PR DESCRIPTION
## Summary
- fix string type and body printing in HttpHeadersAuthDemo

## Testing
- `cmake --build build --target clike`
- `build/bin/clike Examples/clike/HttpHeadersAuthDemo` *(fails: httpRequest: curl failed: Failure when receiving data from the peer)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a81afab4832abf7ee157f03249b7