### PR TITLE
Expand Rea scaffolding with lexer/parser stubs and spec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,6 +377,69 @@ if(SDL)
 
 endif()
 
+# Rea front-end executable (placeholder)
+set(REA_SOURCES
+    src/rea/main.c
+    src/rea/lexer.c
+    src/rea/parser.c
+    src/Pascal/globals.c
+    src/core/utils.c src/core/types.c src/core/list.c src/core/cache.c
+    src/compiler/bytecode.c
+    src/vm/vm.c
+    src/backend_ast/builtin.c src/backend_ast/builtin_network_api.c
+    src/symbol/symbol.c
+    src/rea/stubs.c
+)
+
+list(APPEND REA_SOURCES ${PSCAL_EXT_BUILTIN_SOURCES})
+
+if(SDL)
+    list(APPEND REA_SOURCES
+        src/backend_ast/sdl.c
+        src/backend_ast/audio.c
+    )
+endif()
+
+add_executable(rea ${REA_SOURCES})
+if(TARGET CURL::libcurl)
+    target_link_libraries(rea PRIVATE CURL::libcurl m Threads::Threads)
+else()
+    target_link_libraries(rea PRIVATE ${CURL_LIBRARIES} m Threads::Threads)
+endif()
+
+if(SDL)
+    target_include_directories(rea PRIVATE
+        ${SDL2_INCLUDE_DIRS}
+        ${PC_SDL2_IMAGE_INCLUDE_DIRS}
+        ${PC_SDL2_MIXER_INCLUDE_DIRS}
+        ${PC_SDL2_TTF_INCLUDE_DIRS}
+    )
+
+    target_link_directories(rea PRIVATE
+        ${PC_SDL2_IMAGE_LIBRARY_DIRS}
+        ${PC_SDL2_MIXER_LIBRARY_DIRS}
+        ${PC_SDL2_TTF_LIBRARY_DIRS}
+    )
+
+    set(REA_SDL_LIBS "")
+    if(TARGET SDL2::SDL2)
+        list(APPEND REA_SDL_LIBS SDL2::SDL2)
+    else()
+        list(APPEND REA_SDL_LIBS ${SDL2_LIBRARIES})
+    endif()
+    list(APPEND REA_SDL_LIBS
+        ${PC_SDL2_IMAGE_LIBRARIES}
+        ${PC_SDL2_MIXER_LIBRARIES}
+        ${PC_SDL2_TTF_LIBRARIES}
+        ${PC_SDL2_IMAGE_LDFLAGS_OTHER}
+        ${PC_SDL2_MIXER_LDFLAGS_OTHER}
+        ${PC_SDL2_TTF_LDFLAGS_OTHER}
+    )
+    list(REMOVE_DUPLICATES REA_SDL_LIBS)
+    target_link_libraries(rea PRIVATE ${REA_SDL_LIBS})
+    target_compile_definitions(rea PRIVATE SDL)
+endif()
+
 # ---- Examples ----
 add_subdirectory(Examples)
 

--- a/install.sh
+++ b/install.sh
@@ -29,6 +29,12 @@ cp -r lib/pascal/* /usr/local/pscal/pascal/lib/
 mkdir -p /usr/local/pscal/clike/lib
 cp -r lib/clike/* /usr/local/pscal/clike/lib/
 
+# Install Rea library if present
+mkdir -p /usr/local/pscal/rea/lib
+if [ -d "lib/rea" ]; then
+    cp -r lib/rea/* /usr/local/pscal/rea/lib/
+fi
+
 # Install fonts
 mkdir -p /usr/local/pscal/fonts
 cp -r fonts/* /usr/local/pscal/fonts
@@ -38,7 +44,7 @@ mkdir -p /usr/local/pscal/etc
 cp -r etc/* /usr/local/pscal/etc
 
 # Set group to executable for any installed binaries
-for bin in clike clike-repl dascal pascal pscalvm; do
+for bin in clike clike-repl dascal pascal pscalvm rea; do
     if [ -f "/usr/local/bin/$bin" ]; then
         chmod go+x "/usr/local/bin/$bin"
     fi

--- a/lib/rea/README.md
+++ b/lib/rea/README.md
@@ -1,0 +1,4 @@
+# Rea Standard Library
+
+This directory will hold standard modules for the Rea front end.
+Currently it is a placeholder.

--- a/src/rea/LANGUAGE_SPEC.md
+++ b/src/rea/LANGUAGE_SPEC.md
@@ -1,0 +1,147 @@
+### Rea: An Object-Oriented Language Specification
+
+This document outlines a plan for implementing **Rea**, a new,
+object-oriented front end for the PSCAL Virtual Machine (VM). The language is
+designed for readability and ease of use while leveraging the VM's stack-based
+architecture and existing capabilities. The design builds upon concepts found
+in the existing C-Like and Pascal front ends to introduce a class-based
+programming paradigm.
+
+***
+
+### 1. Language Semantics and Features
+
+The Rea language is a strongly typed, class-based, object-oriented language.
+
+#### 1.1. Lexical Structure
+
+* **Comments:** Supports single-line comments with `//` and multi-line comments
+  with `/* ... */`.
+* **Identifiers:** Identifiers for variables, classes, and methods are
+  case-sensitive. They must begin with a letter or an underscore and can be
+  followed by any number of letters, digits, or underscores.
+* **Keywords:**
+    * **Data Types:** `int`, `int64`, `int32`, `int16`, `int8`, `float`,
+      `float32`, `long double`, `char`, `byte`, `str`, `text`, `mstream`,
+      `void`, `bool`.
+    * **Class & Object:** `class`, `new`, `extends`, `this`, `super`.
+    * **Control Flow:** `if`, `else`, `while`, `for`, `do`, `switch`, `case`,
+      `default`, `break`, `continue`, `return`.
+    * **Other:** `const`, `#import`.
+* **Literals:** Integer, floating-point, character, and string literals will
+  follow the C-Like language specification.
+
+#### 1.2. Data Types
+
+Rea uses the VM's primitive types but standardizes on 64-bit integer and
+floating-point types as the default for new development.
+
+| Rea Keyword | VM Type | Description |
+| :--- | :--- | :--- |
+| `int` | `TYPE_INT64` | 64-bit signed integer. |
+| `int32` | `TYPE_INT32` | 32-bit signed integer. |
+| `int16` | `TYPE_INT16` | 16-bit signed integer. |
+| `int8` | `TYPE_INT8` | 8-bit signed integer. |
+| `float` | `TYPE_DOUBLE` | 64-bit floating-point number. |
+| `float32` | `TYPE_FLOAT` | 32-bit floating-point number. |
+| `long double` | `TYPE_LONG_DOUBLE` | Extended precision floating-point number. |
+| `str` | `TYPE_STRING` | Dynamic-length string. |
+| `bool` | `TYPE_BOOLEAN` | Boolean values (`true` and `false`). |
+| `void` | `TYPE_VOID` | Absence of value (for procedures). |
+
+#### 1.3. Object-Oriented Programming
+
+* **Class Definition:** The `class` keyword defines a new type that can contain
+  data fields and methods. Fields are declared like variables, and methods are
+  defined like functions. A class is a pointer type, so a variable of a class
+  type will hold a pointer to an object instance.
+* **Constructors:** A special method with the same name as the class will serve
+  as the constructor. It initializes the object's fields. A constructor will
+  not have a return type.
+* **Object Instantiation:** The `new` keyword will allocate memory for a new
+  object on the heap and call the class's constructor. This will translate to a
+  sequence of opcodes that handle memory allocation and initialization,
+  leveraging the existing VM memory management.
+* **Field and Method Access:** The dot `.` operator is used to access an
+  object's fields and methods.
+* **`this` and `super`:** The `this` keyword provides a reference to the
+  current object instance within a method. The `super` keyword provides a
+  reference to the parent class's constructor and methods, allowing for proper
+  initialization and method overriding.
+* **Inheritance:** The `extends` keyword will be used to create a subclass that
+  inherits fields and methods from a parent class.
+* **Polymorphism:** Method overriding will be supported. To implement this on
+  the PSCAL VM, the compiler will generate a virtual method table (V-table) for
+  each class. This table would be a constant array of function pointers. When a
+  method is called, the bytecode will look up the correct function pointer in
+  the V-table based on the object's dynamic type, enabling polymorphic
+  behavior.
+* **No Overloading:** As specified, method overloading will not be supported.
+  Each method within a class, and each top-level function, must have a unique
+  name.
+* **Built-in Routines:** Rea will have access to the VM's built-in functions
+  and procedures. This includes core built-ins like `writeln` and `printf`, as
+  well as extended built-ins for I/O, string manipulation, mathematics, and
+  threading.
+
+***
+
+### 2. Implementation Plan
+
+The implementation will focus on creating a compiler for Rea that translates
+source code into PSCAL VM bytecode. The process involves a front-end component
+(parser, semantic analyzer) and a back-end component (code generator).
+
+#### 2.1. Front End (Rea Compiler)
+
+* **Lexical Analysis:** A new lexer will be created to parse the Rea syntax,
+  including new keywords and literals, and produce a stream of tokens.
+* **Parsing:** A new parser will build an Abstract Syntax Tree (AST) for Rea
+  code. It must be able to handle class definitions, method declarations,
+  inheritance relationships, and method calls.
+* **Semantic Analysis:** This phase will perform type checking and resolve
+  symbols (variables, methods, class names). The compiler will need a symbol
+  table that can manage class-scoped symbols and handle inheritance, ensuring
+  that field and method lookups are correct.
+
+#### 2.2. Back End (Code Generation)
+
+This is where the translation to PSCAL VM opcodes occurs.
+
+* **Class Representation:** A class will be represented in the bytecode as a
+  type definition with a list of its fields and methods. An object instance
+  will be a structured block of memory similar to a Pascal `record` or C
+  `struct`.
+* **Object & Field Opcodes:**
+    * `new ClassName(...)` → A call to a runtime built-in function that
+      allocates a block of memory for the object and initializes it. This could
+      use the `OP_INIT_LOCAL_ARRAY` opcode with a new type for objects.
+    * `obj.field = value` → `OP_GET_GLOBAL_ADDRESS` (or
+      `OP_GET_LOCAL_ADDRESS`) to get a pointer to the object, followed by
+      `OP_GET_FIELD_ADDRESS` to get a pointer to the field. Finally,
+      `OP_SET_INDIRECT` to write the value to the field.
+* **Method Dispatch Opcodes:**
+    * `obj.method()` → The compiler will determine if `method` is a virtual
+      method (i.e., overridden). If it is, the compiler will emit opcodes to:
+        1. Push the object reference onto the stack.
+        2. Push arguments.
+        3. Look up the correct function pointer from the object's V-table based
+           on its type.
+        4. Call the function using a modified `OP_CALL`.
+    * **VM Extension:** The VM's `CallFrame` and `procedureTable` will be
+      extended to store and look up class and method information to support the
+      V-table mechanism.
+
+***
+
+### 3. Summary of Rea Implementation Details
+
+* **Compiler:** A new compiler will be developed to translate Rea source code
+  into PSCAL VM bytecode.
+* **Virtual Machine:** The existing PSCAL VM will be extended with minimal
+  changes, primarily in the symbol table and `CallFrame` to support
+  object-oriented constructs like V-tables for dynamic method dispatch.
+* **Opcodes:** The implementation will reuse many existing opcodes for
+  arithmetic and control flow. New bytecode opcodes may be introduced to
+  simplify object and method handling.
+

--- a/src/rea/README.md
+++ b/src/rea/README.md
@@ -1,0 +1,20 @@
+# Rea Front End
+
+This directory hosts the experimental front end for the Rea programming
+language. At the moment the executable only loads a source file and executes
+an empty bytecode chunk, but the layout below sketches the path toward a full
+compiler.
+
+## Roadmap
+
+- Build a lexer that produces tokens for the syntax described in
+  `LANGUAGE_SPEC.md`.
+- Implement a recursive-descent parser that constructs an AST.
+- Perform semantic analysis with a class-aware symbol table and type system.
+- Generate PSCAL VM bytecode, including support for object allocation, field
+  access and virtual method dispatch.
+- Wire the resulting compiler into the existing build and testing
+  infrastructure.
+
+See `LANGUAGE_SPEC.md` for the complete language specification.
+

--- a/src/rea/lexer.c
+++ b/src/rea/lexer.c
@@ -1,0 +1,17 @@
+#include "rea/lexer.h"
+
+void reaInitLexer(ReaLexer *lexer, const char *source) {
+    lexer->source = source;
+    lexer->pos = 0;
+    lexer->line = 1;
+}
+
+ReaToken reaNextToken(ReaLexer *lexer) {
+    ReaToken t;
+    t.type = REA_TOKEN_EOF;
+    t.start = lexer->source + lexer->pos;
+    t.length = 0;
+    t.line = lexer->line;
+    return t;
+}
+

--- a/src/rea/lexer.h
+++ b/src/rea/lexer.h
@@ -1,0 +1,28 @@
+#ifndef REA_LEXER_H
+#define REA_LEXER_H
+
+#include <stddef.h>
+
+typedef enum {
+    REA_TOKEN_EOF = 0,
+    REA_TOKEN_UNKNOWN
+} ReaTokenType;
+
+typedef struct {
+    ReaTokenType type;
+    const char *start;
+    size_t length;
+    int line;
+} ReaToken;
+
+typedef struct {
+    const char *source;
+    size_t pos;
+    int line;
+} ReaLexer;
+
+void reaInitLexer(ReaLexer *lexer, const char *source);
+ReaToken reaNextToken(ReaLexer *lexer);
+
+#endif
+

--- a/src/rea/main.c
+++ b/src/rea/main.c
@@ -1,0 +1,83 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "vm/vm.h"
+#include "core/cache.h"
+#include "core/utils.h"
+#include "symbol/symbol.h"
+#include "Pascal/globals.h"
+#include "backend_ast/builtin.h"
+#include "rea/parser.h"
+
+int gParamCount = 0;
+char **gParamValues = NULL;
+
+static void initSymbolSystem(void) {
+    globalSymbols = createHashTable();
+    constGlobalSymbols = createHashTable();
+    procedure_table = createHashTable();
+    current_procedure_table = procedure_table;
+}
+
+int main(int argc, char **argv) {
+    vmInitTerminalState();
+
+    if (argc < 2) {
+        fprintf(stderr, "Usage: rea <source.rea> [program_parameters...]\n");
+        return vmExitWithCleanup(EXIT_FAILURE);
+    }
+
+    const char *path = argv[1];
+    FILE *f = fopen(path, "rb");
+    if (!f) {
+        perror("open");
+        return vmExitWithCleanup(EXIT_FAILURE);
+    }
+    fseek(f, 0, SEEK_END);
+    long len = ftell(f);
+    rewind(f);
+    char *src = (char *)malloc(len + 1);
+    if (!src) {
+        fclose(f);
+        return vmExitWithCleanup(EXIT_FAILURE);
+    }
+    size_t bytes_read = fread(src, 1, len, f);
+    fclose(f);
+    if (bytes_read != (size_t)len) {
+        free(src);
+        fprintf(stderr, "Error reading source file '%s'\n", path);
+        return vmExitWithCleanup(EXIT_FAILURE);
+    }
+    src[len] = '\0';
+
+    AST *ast = parseRea(src);
+    if (ast) {
+        freeAST(ast);
+    }
+
+    // Placeholder: no compilation yet. Just run an empty chunk.
+    initSymbolSystem();
+    registerAllBuiltins();
+
+    BytecodeChunk chunk;
+    initBytecodeChunk(&chunk);
+    writeBytecodeChunk(&chunk, OP_HALT, 0);
+
+    if (argc > 2) {
+        gParamCount = argc - 2;
+        gParamValues = &argv[2];
+    }
+
+    VM vm;
+    initVM(&vm);
+    InterpretResult result = interpretBytecode(&vm, &chunk, globalSymbols, constGlobalSymbols, procedure_table, 0);
+    freeVM(&vm);
+    freeBytecodeChunk(&chunk);
+
+    if (globalSymbols) freeHashTable(globalSymbols);
+    if (constGlobalSymbols) freeHashTable(constGlobalSymbols);
+    if (procedure_table) freeHashTable(procedure_table);
+
+    free(src);
+    return vmExitWithCleanup(result == INTERPRET_OK ? EXIT_SUCCESS : EXIT_FAILURE);
+}
+

--- a/src/rea/parser.c
+++ b/src/rea/parser.c
@@ -1,0 +1,10 @@
+#include "rea/parser.h"
+
+AST *parseRea(const char *source) {
+    ReaLexer lexer;
+    reaInitLexer(&lexer, source);
+    ReaToken t = reaNextToken(&lexer);
+    (void)t;
+    return NULL;
+}
+

--- a/src/rea/parser.h
+++ b/src/rea/parser.h
@@ -1,0 +1,10 @@
+#ifndef REA_PARSER_H
+#define REA_PARSER_H
+
+#include "rea/lexer.h"
+#include "Pascal/ast.h"
+
+AST *parseRea(const char *source);
+
+#endif
+

--- a/src/rea/stubs.c
+++ b/src/rea/stubs.c
@@ -1,0 +1,63 @@
+#include "Pascal/ast.h"
+#include "symbol/symbol.h"
+#include "core/types.h"
+#include "core/utils.h"
+#include <stdlib.h>
+#include <string.h>
+
+AST* lookupType(const char* name) {
+    (void)name;
+    return NULL;
+}
+
+Value evaluateCompileTimeValue(AST* node) {
+    (void)node;
+    return makeNil();
+}
+
+void insertType(const char* name, AST* typeDef) {
+    (void)name;
+    (void)typeDef;
+}
+
+AST* newASTNode(ASTNodeType type, Token* token) {
+    AST* node = (AST*)calloc(1, sizeof(AST));
+    node->type = type;
+    if (token) {
+        node->token = (Token*)malloc(sizeof(Token));
+        node->token->type = token->type;
+        node->token->line = token->line;
+        node->token->column = token->column;
+        node->token->value = token->value ? strdup(token->value) : NULL;
+    }
+    return node;
+}
+
+void setTypeAST(AST* node, VarType type) {
+    if (node) node->var_type = type;
+}
+
+void setRight(AST* parent, AST* child) {
+    if (parent) {
+        parent->right = child;
+        if (child) child->parent = parent;
+    }
+}
+
+void addChild(AST* parent, AST* child) {
+    if (!parent || !child) return;
+    if (parent->child_capacity <= parent->child_count) {
+        int newcap = parent->child_capacity ? parent->child_capacity * 2 : 4;
+        parent->children = (AST**)realloc(parent->children, sizeof(AST*) * newcap);
+        parent->child_capacity = newcap;
+    }
+    parent->children[parent->child_count++] = child;
+    child->parent = parent;
+}
+
+void freeAST(AST* node) { (void)node; }
+
+void dumpAST(AST* node, int indent) { (void)node; (void)indent; }
+
+AST* copyAST(AST* node) { (void)node; return NULL; }
+


### PR DESCRIPTION
## Summary
- wire placeholder lexer and parser into the Rea front end and build system
- document the Rea language spec and provide a roadmap for completing the compiler

## Testing
- `cmake -S . -B build`
- `cmake --build build --target rea`
- `cmake --build build --target pascal clike`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b8c4edb088832aaf2e2159cb66a0f1