### PR TITLE
Fix WebSocketEcho example in CLike examples

### DIFF
--- a/Examples/clike/WebSocketEcho
+++ b/Examples/clike/WebSocketEcho
@@ -17,8 +17,8 @@ int main() {
   // send masked text frame "hi"
   socketsend(s, "\x81\x82\x12\x34\x56\x78\x7a\x5d");
   mstream msg = socketreceive(s, 1024);
-  unsigned char* buf = mstreambuffer(msg);
-  printf("echo: %c%c\n", buf[2], buf[3]);
+  str buf = mstreambuffer(msg);
+  printf("echo: %c%c\n", buf[3], buf[4]);
   mstreamfree(&msg);
   socketclose(s);
   return 0;


### PR DESCRIPTION
## Summary
- Support adjacent string literal concatenation in the CLike parser
- Restore multi-line WebSocket handshake in WebSocketEcho example without concatenation operators

## Testing
- `cmake -S . -B build`
- `cmake --build build --target clike`
- `build/bin/clike Examples/clike/WebSocketEcho`


------
https://chatgpt.com/codex/tasks/task_e_68b8cb63610c832abc0f5a3abaf53e7e