### PR TITLE
Enable default HTTP response decompression

### DIFF
--- a/src/backend_ast/builtin_network_api.c
+++ b/src/backend_ast/builtin_network_api.c
@@ -193,6 +193,7 @@ typedef struct HttpSession_s {
     char* pinned_pubkey;  // CURLOPT_PINNEDPUBLICKEY
     char* out_file;       // optional sink for HttpRequest
     char* accept_encoding; // CURLOPT_ACCEPT_ENCODING
+    long  accept_encoding_disabled; // explicitly cleared by user
     char* cookie_file;    // CURLOPT_COOKIEFILE
     char* cookie_jar;     // CURLOPT_COOKIEJAR
     long max_retries;     // number of retries
@@ -257,6 +258,7 @@ static void httpFreeSession(int id) {
     if (s->user_agent) { free(s->user_agent); s->user_agent = NULL; }
     if (s->out_file) { free(s->out_file); s->out_file = NULL; }
     if (s->accept_encoding) { free(s->accept_encoding); s->accept_encoding = NULL; }
+    s->accept_encoding_disabled = 0;
     if (s->cookie_file) { free(s->cookie_file); s->cookie_file = NULL; }
     if (s->cookie_jar) { free(s->cookie_jar); s->cookie_jar = NULL; }
     if (s->basic_auth) { free(s->basic_auth); s->basic_auth = NULL; }
@@ -411,7 +413,10 @@ Value vmBuiltinHttpSetOption(VM* vm, int arg_count, Value* args) {
         }
         if (args[2].type == TYPE_STRING) {
             s->accept_encoding = strdup(args[2].s_val ? args[2].s_val : "");
-        } else if (!IS_INTLIKE(args[2])) {
+            s->accept_encoding_disabled = 0;
+        } else if (IS_INTLIKE(args[2])) {
+            s->accept_encoding_disabled = 1;
+        } else {
             runtimeError(vm, "httpSetOption: accept_encoding expects string or int.");
         }
     } else if (strcasecmp(key, "cookie_file") == 0 && args[2].type == TYPE_STRING) {
@@ -582,7 +587,10 @@ Value vmBuiltinHttpRequest(VM* vm, int arg_count, Value* args) {
     if (s->user_agent) curl_easy_setopt(s->curl, CURLOPT_USERAGENT, s->user_agent);
     if (s->headers) curl_easy_setopt(s->curl, CURLOPT_HTTPHEADER, s->headers);
     if (s->resolve) curl_easy_setopt(s->curl, CURLOPT_RESOLVE, s->resolve);
-    if (s->accept_encoding) curl_easy_setopt(s->curl, CURLOPT_ACCEPT_ENCODING, s->accept_encoding);
+    if (!s->accept_encoding_disabled) {
+        curl_easy_setopt(s->curl, CURLOPT_ACCEPT_ENCODING,
+                         s->accept_encoding ? s->accept_encoding : "");
+    }
     if (s->cookie_file) curl_easy_setopt(s->curl, CURLOPT_COOKIEFILE, s->cookie_file);
     if (s->cookie_jar) curl_easy_setopt(s->curl, CURLOPT_COOKIEJAR, s->cookie_jar);
     if (s->max_recv_speed > 0) curl_easy_setopt(s->curl, CURLOPT_MAX_RECV_SPEED_LARGE, s->max_recv_speed);
@@ -893,7 +901,10 @@ Value vmBuiltinHttpRequestToFile(VM* vm, int arg_count, Value* args) {
     if (s->user_agent) curl_easy_setopt(s->curl, CURLOPT_USERAGENT, s->user_agent);
     if (s->headers) curl_easy_setopt(s->curl, CURLOPT_HTTPHEADER, s->headers);
     if (s->resolve) curl_easy_setopt(s->curl, CURLOPT_RESOLVE, s->resolve);
-    if (s->accept_encoding) curl_easy_setopt(s->curl, CURLOPT_ACCEPT_ENCODING, s->accept_encoding);
+    if (!s->accept_encoding_disabled) {
+        curl_easy_setopt(s->curl, CURLOPT_ACCEPT_ENCODING,
+                         s->accept_encoding ? s->accept_encoding : "");
+    }
     if (s->cookie_file) curl_easy_setopt(s->curl, CURLOPT_COOKIEFILE, s->cookie_file);
     if (s->cookie_jar) curl_easy_setopt(s->curl, CURLOPT_COOKIEJAR, s->cookie_jar);
     if (s->max_recv_speed > 0) curl_easy_setopt(s->curl, CURLOPT_MAX_RECV_SPEED_LARGE, s->max_recv_speed);
@@ -1518,6 +1529,7 @@ typedef struct HttpAsyncJob_s {
     char* user_agent;
     char* basic_auth;
     char* accept_encoding;
+    long  accept_encoding_disabled;
     char* cookie_file;
     char* cookie_jar;
     long max_retries;
@@ -1678,7 +1690,10 @@ static void* httpAsyncThread(void* arg) {
     if (job->user_agent && job->user_agent[0]) curl_easy_setopt(eh, CURLOPT_USERAGENT, job->user_agent);
     if (job->headers_slist) curl_easy_setopt(eh, CURLOPT_HTTPHEADER, job->headers_slist);
     if (job->resolve_slist) curl_easy_setopt(eh, CURLOPT_RESOLVE, job->resolve_slist);
-    if (job->accept_encoding) curl_easy_setopt(eh, CURLOPT_ACCEPT_ENCODING, job->accept_encoding);
+    if (!job->accept_encoding_disabled) {
+        curl_easy_setopt(eh, CURLOPT_ACCEPT_ENCODING,
+                         job->accept_encoding ? job->accept_encoding : "");
+    }
     if (job->cookie_file) curl_easy_setopt(eh, CURLOPT_COOKIEFILE, job->cookie_file);
     if (job->cookie_jar) curl_easy_setopt(eh, CURLOPT_COOKIEJAR, job->cookie_jar);
     if (job->max_recv_speed > 0) curl_easy_setopt(eh, CURLOPT_MAX_RECV_SPEED_LARGE, job->max_recv_speed);
@@ -1911,6 +1926,7 @@ Value vmBuiltinHttpRequestAsync(VM* vm, int arg_count, Value* args) {
         job->user_agent = s->user_agent ? strdup(s->user_agent) : NULL;
         job->basic_auth = s->basic_auth ? strdup(s->basic_auth) : NULL;
         job->accept_encoding = s->accept_encoding ? strdup(s->accept_encoding) : NULL;
+        job->accept_encoding_disabled = s->accept_encoding_disabled;
         job->cookie_file = s->cookie_file ? strdup(s->cookie_file) : NULL;
         job->cookie_jar = s->cookie_jar ? strdup(s->cookie_jar) : NULL;
         job->max_retries = s->max_retries;
@@ -2014,6 +2030,7 @@ Value vmBuiltinHttpRequestAsyncToFile(VM* vm, int arg_count, Value* args) {
         job->user_agent = s->user_agent ? strdup(s->user_agent) : NULL;
         job->basic_auth = s->basic_auth ? strdup(s->basic_auth) : NULL;
         job->accept_encoding = s->accept_encoding ? strdup(s->accept_encoding) : NULL;
+        job->accept_encoding_disabled = s->accept_encoding_disabled;
         job->cookie_file = s->cookie_file ? strdup(s->cookie_file) : NULL;
         job->cookie_jar = s->cookie_jar ? strdup(s->cookie_jar) : NULL;
         job->max_retries = s->max_retries;


### PR DESCRIPTION
## Summary
- Ensure HTTP requests automatically decompress responses unless `accept_encoding` is explicitly cleared
- Respect `accept_encoding` disabling across sync and async HTTP helpers
- Propagate the disabled state when queuing async jobs

## Testing
- `cmake -S . -B build`
- `cmake --build build -j4`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b8d315f5b8832aa0735336886ad357