### PR TITLE
Skip SocketSendReceiveTest on GitHub

### DIFF
--- a/Tests/run_pascal_tests.sh
+++ b/Tests/run_pascal_tests.sh
@@ -53,6 +53,13 @@ for src in "$SCRIPT_DIR"/Pascal/*; do
     continue
   fi
 
+  # Skip network-dependent test when running on GitHub Actions
+  if [ "$test_name" = "SocketSendReceiveTest" ] && [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+    echo "Skipping $test_name (networking disabled on GitHub Actions)"
+    echo
+    continue
+  fi
+
   in_file="$SCRIPT_DIR/Pascal/$test_name.in"
   out_file="$SCRIPT_DIR/Pascal/$test_name.out"
   err_file="$SCRIPT_DIR/Pascal/$test_name.err"


### PR DESCRIPTION
## Summary
- avoid CI hang by skipping SocketSendReceiveTest when GITHUB_ACTIONS is true

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `Tests/run_pascal_tests.sh`
- `GITHUB_ACTIONS=true Tests/run_pascal_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b8da43b914832a9d8d842d49f622dc