### PR TITLE
Add bytecode dump options to Rea frontend

### DIFF
--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -3,6 +3,8 @@ project(pscal_examples NONE)
 
 # Path to the pascal interpreter built by main project
 set(PASCAL_BIN ${CMAKE_BINARY_DIR}/bin/pascal)
+# Path to the Rea front end built by main project
+set(REA_BIN ${CMAKE_BINARY_DIR}/bin/rea)
 
 # Basic example target
 add_custom_target(run_basic_examples
@@ -23,6 +25,13 @@ add_custom_target(run_threads_procptr_demo
 add_custom_target(run_http_fetch_demo
     COMMAND ${CMAKE_COMMAND} -E echo "Running HttpFetchDemo..."
     COMMAND ${PASCAL_BIN} ${CMAKE_CURRENT_SOURCE_DIR}/Pascal/HttpFetchDemo
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+# Rea example target
+add_custom_target(run_rea_examples
+    COMMAND ${CMAKE_COMMAND} -E echo "Running Rea examples..."
+    COMMAND ${REA_BIN} --dump-bytecode ${CMAKE_CURRENT_SOURCE_DIR}/rea/hello.rea
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 

--- a/Examples/rea/hello.rea
+++ b/Examples/rea/hello.rea
@@ -1,0 +1,1 @@
+class Main {}

--- a/Tests/rea/bytecode_dump.err
+++ b/Tests/rea/bytecode_dump.err
@@ -1,0 +1,7 @@
+--- Compiling Main Program AST to Bytecode ---
+== Disassembly: Tests/rea/bytecode_dump.rea ==
+Offset Line Opcode           Operand  Value / Target (Args)
+------ ---- ---------------- -------- --------------------------
+0000    0 OP_HALT
+== End Disassembly: Tests/rea/bytecode_dump.rea ==
+

--- a/Tests/rea/bytecode_dump.rea
+++ b/Tests/rea/bytecode_dump.rea
@@ -1,0 +1,1 @@
+class Test {}

--- a/Tests/rea/bytecode_exec.args
+++ b/Tests/rea/bytecode_exec.args
@@ -1,0 +1,1 @@
+--dump-bytecode

--- a/Tests/rea/bytecode_exec.err
+++ b/Tests/rea/bytecode_exec.err
@@ -1,0 +1,9 @@
+--- Compiling Main Program AST to Bytecode ---
+== Disassembly: Tests/rea/bytecode_exec.rea ==
+Offset Line Opcode           Operand  Value / Target (Args)
+------ ---- ---------------- -------- --------------------------
+0000    0 OP_HALT
+== End Disassembly: Tests/rea/bytecode_exec.rea ==
+
+
+--- executing Program with VM ---

--- a/Tests/rea/bytecode_exec.rea
+++ b/Tests/rea/bytecode_exec.rea
@@ -1,0 +1,1 @@
+class Run {}

--- a/Tests/run_all_tests
+++ b/Tests/run_all_tests
@@ -8,7 +8,12 @@ echo "Running CLike Tests"
 ./run_clike_tests.sh
 echo "CLike Tests End"
 echo "====================================="
-echo 
+echo
+echo "Running Rea Tests"
+./run_rea_tests.sh
+echo "Rea Tests End"
+echo "====================================="
+echo
 echo "Running Tiny Tests"
 ./run_tiny_tests.sh
 echo "Tiny Tests End"

--- a/Tests/run_rea_tests.sh
+++ b/Tests/run_rea_tests.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+REA_BIN="$ROOT_DIR/build/bin/rea"
+
+if [ ! -x "$REA_BIN" ]; then
+  echo "rea binary not found at $REA_BIN" >&2
+  exit 1
+fi
+
+cd "$ROOT_DIR"
+EXIT_CODE=0
+
+for src in "$SCRIPT_DIR"/rea/*.rea; do
+  test_name=$(basename "$src" .rea)
+  in_file="$SCRIPT_DIR/rea/$test_name.in"
+  out_file="$SCRIPT_DIR/rea/$test_name.out"
+  err_file="$SCRIPT_DIR/rea/$test_name.err"
+  src_rel=${src#$ROOT_DIR/}
+  args_file="$SCRIPT_DIR/rea/$test_name.args"
+  if [ -f "$args_file" ]; then
+    read -r args < "$args_file"
+  else
+    args="--dump-bytecode-only"
+  fi
+  actual_out=$(mktemp)
+  actual_err=$(mktemp)
+
+  echo "---- $test_name ----"
+  set +e
+  if [ -f "$in_file" ]; then
+    "$REA_BIN" $args "$src_rel" < "$in_file" > "$actual_out" 2> "$actual_err"
+  else
+    "$REA_BIN" $args "$src_rel" > "$actual_out" 2> "$actual_err"
+  fi
+  run_status=$?
+  set -e
+
+  perl -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]|\e\][^\a]*(?:\a|\e\\)//g' "$actual_out" > "$actual_out.clean"
+  mv "$actual_out.clean" "$actual_out"
+  perl -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]|\e\][^\a]*(?:\a|\e\\)//g' "$actual_err" > "$actual_err.clean"
+  mv "$actual_err.clean" "$actual_err"
+
+  if [ -f "$out_file" ]; then
+    if ! diff -u "$out_file" "$actual_out"; then
+      echo "Test failed (stdout mismatch): $test_name" >&2
+      EXIT_CODE=1
+    fi
+  elif [ -s "$actual_out" ]; then
+    echo "Test produced unexpected stdout: $test_name" >&2
+    cat "$actual_out"
+    EXIT_CODE=1
+  fi
+
+  if [ -f "$err_file" ]; then
+    if ! diff -u "$err_file" "$actual_err"; then
+      echo "Test failed (stderr mismatch): $test_name" >&2
+      EXIT_CODE=1
+    fi
+  elif [ -s "$actual_err" ]; then
+    echo "Unexpected stderr output in $test_name:" >&2
+    cat "$actual_err"
+    EXIT_CODE=1
+  fi
+
+  if [ $run_status -ne 0 ]; then
+    echo "Test exited with $run_status: $test_name" >&2
+    EXIT_CODE=1
+  fi
+
+  rm -f "$actual_out" "$actual_err"
+  echo
+  echo
+ done
+
+exit $EXIT_CODE

--- a/src/rea/README.md
+++ b/src/rea/README.md
@@ -5,6 +5,16 @@ language. At the moment the executable only loads a source file and executes
 an empty bytecode chunk, but the layout below sketches the path toward a full
 compiler.
 
+## Running
+
+The `rea` front end supports a few diagnostic options:
+
+```
+--dump-ast-json        Dump the parsed AST as JSON and exit.
+--dump-bytecode        Dump the compiled bytecode before execution.
+--dump-bytecode-only   Dump the compiled bytecode and exit without executing.
+```
+
 ## Roadmap
 
 - Build a lexer that produces tokens for the syntax described in


### PR DESCRIPTION
## Summary
- support `--dump-bytecode` and `--dump-bytecode-only` in Rea frontend
- add Rea example target and sample program
- introduce Rea regression tests and hook them into test runner

## Testing
- `Tests/run_rea_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b8e9c51d20832a87b5e8c31307a4e3