### PR TITLE
Support arithmetic expressions in Rea prototype

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,6 +383,7 @@ set(REA_SOURCES
     src/rea/lexer.c
     src/rea/parser.c
     src/rea/ast.c
+    src/rea/compiler.c
     src/ast/ast.c
     src/Pascal/globals.c
     src/core/utils.c src/core/types.c src/core/list.c src/core/cache.c

--- a/src/rea/README.md
+++ b/src/rea/README.md
@@ -1,9 +1,11 @@
 # Rea Front End
 
 This directory hosts the experimental front end for the Rea programming
-language. At the moment the executable only loads a source file and executes
-an empty bytecode chunk, but the layout below sketches the path toward a full
-compiler.
+language. The current prototype recognises arithmetic expressions composed of
+integer and floating-point numeric literals, parentheses and the `+`, `-`, `*`
+and `/` operators. Each top-level expression is compiled to bytecode that
+prints its result via the existing PSCAL VM. The layout below sketches the path
+toward a full compiler.
 
 ## Running
 

--- a/src/rea/ast.c
+++ b/src/rea/ast.c
@@ -32,9 +32,7 @@ void reaFreeAST(ReaAST *node) {
         reaFreeAST(node->children[i]);
     }
     free(node->children);
-    if (node->type == REA_AST_TOKEN) {
-        reaFreeToken(&node->token);
-    }
+    reaFreeToken(&node->token);
     free(node);
 }
 
@@ -113,7 +111,8 @@ const char *reaTokenTypeToString(ReaTokenType type) {
 const char *reaASTNodeTypeToString(ReaASTNodeType type) {
     switch (type) {
         case REA_AST_PROGRAM: return "PROGRAM";
-        case REA_AST_TOKEN: return "TOKEN";
+        case REA_AST_NUMBER: return "NUMBER";
+        case REA_AST_BINARY: return "BINARY";
     }
     return "UNKNOWN";
 }
@@ -151,7 +150,7 @@ static void dumpJSON(ReaAST *node, FILE *out, int indent) {
     indent++;
     printIndent(out, indent);
     fprintf(out, "\"node_type\": \"%s\"", reaASTNodeTypeToString(node->type));
-    if (node->type == REA_AST_TOKEN) {
+    if (node->token.start) {
         fputs(",\n", out);
         printIndent(out, indent);
         fprintf(out, "\"token_type\": \"%s\",\n", reaTokenTypeToString(node->token.type));

--- a/src/rea/ast.h
+++ b/src/rea/ast.h
@@ -6,12 +6,13 @@
 
 typedef enum {
     REA_AST_PROGRAM,
-    REA_AST_TOKEN
+    REA_AST_NUMBER,
+    REA_AST_BINARY
 } ReaASTNodeType;
 
 typedef struct ReaAST {
     ReaASTNodeType type;
-    ReaToken token;            // Valid if type == REA_AST_TOKEN
+    ReaToken token;            // Used by literal and operator nodes
     struct ReaAST **children;
     int child_count;
     int child_capacity;

--- a/src/rea/compiler.c
+++ b/src/rea/compiler.c
@@ -1,0 +1,86 @@
+#include "rea/compiler.h"
+#include "core/utils.h"
+#include "core/types.h"
+#include <string.h>
+
+// Helper to create the minimal block/declaration structure expected by
+// the existing compiler.  The block contains an empty declaration list
+// and a single statement compound passed in as `statements`.
+static AST *makeProgramWithStatements(AST *statements) {
+    AST *program = newASTNode(AST_PROGRAM, NULL);
+
+    AST *block = newASTNode(AST_BLOCK, NULL);
+    block->is_global_scope = true;
+
+    AST *decls = newASTNode(AST_COMPOUND, NULL);
+    addChild(block, decls);
+    addChild(block, statements);
+
+    setRight(program, block);
+    return program;
+}
+
+static AST *convertExpr(ReaAST *node) {
+    if (!node) return NULL;
+    switch (node->type) {
+        case REA_AST_NUMBER: {
+            const char *lex = node->token.start ? node->token.start : "";
+            TokenType ttype = TOKEN_INTEGER_CONST;
+            VarType vtype = TYPE_INTEGER;
+
+            if (strpbrk(lex, ".eE")) {
+                ttype = TOKEN_REAL_CONST;
+                vtype = TYPE_REAL;
+            }
+
+            Token *num_tok = newToken(ttype,
+                                     lex,
+                                     node->token.line,
+                                     0);
+            AST *num = newASTNode(AST_NUMBER, num_tok);
+            setTypeAST(num, vtype);
+            return num;
+        }
+        case REA_AST_BINARY: {
+            AST *left = convertExpr(node->children[0]);
+            AST *right = convertExpr(node->children[1]);
+            TokenType optype = TOKEN_UNKNOWN;
+            switch (node->token.type) {
+                case REA_TOKEN_PLUS: optype = TOKEN_PLUS; break;
+                case REA_TOKEN_MINUS: optype = TOKEN_MINUS; break;
+                case REA_TOKEN_STAR: optype = TOKEN_MUL; break;
+                case REA_TOKEN_SLASH: optype = TOKEN_SLASH; break;
+                default: break;
+            }
+            Token *op_tok = newToken(optype,
+                                     node->token.start ? node->token.start : "",
+                                     node->token.line,
+                                     0);
+            AST *bin = newASTNode(AST_BINARY_OP, op_tok);
+            setLeft(bin, left);
+            setRight(bin, right);
+            return bin;
+        }
+        default:
+            return NULL;
+    }
+}
+
+AST *reaConvertToAST(ReaAST *root) {
+    if (!root || root->child_count == 0) return NULL;
+
+    AST *stmts = newASTNode(AST_COMPOUND, NULL);
+    for (int i = 0; i < root->child_count; ++i) {
+        AST *expr = convertExpr(root->children[i]);
+        if (!expr) continue;
+        AST *writeln = newASTNode(AST_WRITELN, NULL);
+        addChild(writeln, expr);
+        addChild(stmts, writeln);
+    }
+    if (stmts->child_count == 0) {
+        freeAST(stmts);
+        return NULL;
+    }
+    return makeProgramWithStatements(stmts);
+}
+

--- a/src/rea/compiler.h
+++ b/src/rea/compiler.h
@@ -1,0 +1,17 @@
+#ifndef REA_COMPILER_H
+#define REA_COMPILER_H
+
+#include "rea/ast.h"
+#include "ast/ast.h"
+
+// Convert a Rea AST into the core AST used by the existing
+// PSCAL backend.  The current implementation recognises a very
+// small subset of the language – a single number literal – and
+// wraps it in a "writeln" call so it can be executed by the VM.
+//
+// On success an AST_PROGRAM node is returned.  NULL indicates the
+// Rea tree could not be translated.
+AST *reaConvertToAST(ReaAST *root);
+
+#endif // REA_COMPILER_H
+

--- a/src/rea/parser.c
+++ b/src/rea/parser.c
@@ -2,30 +2,102 @@
 #include <stdlib.h>
 #include <string.h>
 
-ReaAST *parseRea(const char *source) {
+typedef struct {
     ReaLexer lexer;
-    reaInitLexer(&lexer, source);
+    ReaToken current;
+    ReaToken previous;
+} ReaParser;
 
-    ReaAST *root = reaNewASTNode(REA_AST_PROGRAM);
+static void advance(ReaParser *p) {
+    p->previous = p->current;
+    p->current = reaNextToken(&p->lexer);
+}
 
-    ReaToken t;
-    do {
-        t = reaNextToken(&lexer);
-        ReaAST *child = reaNewASTNode(REA_AST_TOKEN);
-        child->token.type = t.type;
-        child->token.line = t.line;
-        child->token.length = t.length;
-        char *lex = (char *)malloc(t.length + 1);
+static int match(ReaParser *p, ReaTokenType type) {
+    if (p->current.type != type) return 0;
+    advance(p);
+    return 1;
+}
+
+static ReaToken copyToken(const ReaToken *src) {
+    ReaToken t = *src;
+    t.start = NULL;
+    if (src->start && src->length > 0) {
+        char *lex = (char *)malloc(src->length + 1);
         if (lex) {
-            memcpy(lex, t.start, t.length);
-            lex[t.length] = '\0';
-            child->token.start = lex;
-        } else {
-            child->token.start = NULL;
+            memcpy(lex, src->start, src->length);
+            lex[src->length] = '\0';
+            t.start = lex;
         }
-        reaAddChild(root, child);
-    } while (t.type != REA_TOKEN_EOF);
+    }
+    return t;
+}
 
-    return root;
+static ReaAST *parseExpression(ReaParser *p);
+
+static ReaAST *parsePrimary(ReaParser *p) {
+    if (match(p, REA_TOKEN_NUMBER)) {
+        ReaAST *num = reaNewASTNode(REA_AST_NUMBER);
+        num->token = copyToken(&p->previous);
+        return num;
+    }
+    if (match(p, REA_TOKEN_LEFT_PAREN)) {
+        ReaAST *expr = parseExpression(p);
+        match(p, REA_TOKEN_RIGHT_PAREN); // best effort
+        return expr;
+    }
+    return NULL;
+}
+
+static ReaAST *parseFactor(ReaParser *p) {
+    ReaAST *node = parsePrimary(p);
+    while (p->current.type == REA_TOKEN_STAR || p->current.type == REA_TOKEN_SLASH) {
+        advance(p);
+        ReaToken op = copyToken(&p->previous);
+        ReaAST *right = parsePrimary(p);
+        ReaAST *bin = reaNewASTNode(REA_AST_BINARY);
+        bin->token = op;
+        reaAddChild(bin, node);
+        reaAddChild(bin, right);
+        node = bin;
+    }
+    return node;
+}
+
+static ReaAST *parseTerm(ReaParser *p) {
+    ReaAST *node = parseFactor(p);
+    while (p->current.type == REA_TOKEN_PLUS || p->current.type == REA_TOKEN_MINUS) {
+        advance(p);
+        ReaToken op = copyToken(&p->previous);
+        ReaAST *right = parseFactor(p);
+        ReaAST *bin = reaNewASTNode(REA_AST_BINARY);
+        bin->token = op;
+        reaAddChild(bin, node);
+        reaAddChild(bin, right);
+        node = bin;
+    }
+    return node;
+}
+
+static ReaAST *parseExpression(ReaParser *p) {
+    return parseTerm(p);
+}
+
+ReaAST *parseRea(const char *source) {
+    ReaParser p;
+    reaInitLexer(&p.lexer, source);
+    p.current.type = REA_TOKEN_UNKNOWN;
+    advance(&p);
+
+    ReaAST *program = reaNewASTNode(REA_AST_PROGRAM);
+
+    while (p.current.type != REA_TOKEN_EOF) {
+        ReaAST *expr = parseExpression(&p);
+        if (!expr) break;
+        reaAddChild(program, expr);
+        if (!match(&p, REA_TOKEN_SEMICOLON)) break;
+    }
+
+    return program;
 }
 


### PR DESCRIPTION
## Summary
- Distinguish integer and floating-point literals when translating Rea AST, emitting real tokens and types for non-integer values
- Document floating-point literal handling in Rea README

## Testing
- `cmake -S . -B build`
- `cmake --build build --target rea`
- `cmake --build build --target clike`
- `cmake --build build --target pascal`
- `ctest --test-dir build`
- `./build/bin/rea --dump-bytecode /tmp/test.rea`


------
https://chatgpt.com/codex/tasks/task_e_68b8ee4de2f4832ab2266fec6c607f08