### PR TITLE
Compile printf using OP_WRITE

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -3413,6 +3413,7 @@ void registerAllBuiltins(void) {
     registerBuiltinFunction("PopScreen", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("Pos", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("Power", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("printf", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("PushScreen", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("QuitRequested", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("Random", AST_FUNCTION_DECL, NULL);

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -374,6 +374,7 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
 static void compileLValue(AST* node, BytecodeChunk* chunk, int current_line_approx);
 static void compileDefinedFunction(AST* func_decl_node, BytecodeChunk* chunk, int line);
 static void compileInlineRoutine(Symbol* proc_symbol, AST* call_node, BytecodeChunk* chunk, int line, bool push_result);
+static void compilePrintf(AST* callNode, BytecodeChunk* chunk, int line);
 
 // --- Global/Module State for Compiler ---
 // For mapping global variable names to an index during this compilation pass.
@@ -1636,6 +1637,60 @@ static void compileInlineRoutine(Symbol* proc_symbol, AST* call_node, BytecodeCh
     }
 }
 
+static void compilePrintf(AST* callNode, BytecodeChunk* chunk, int line) {
+    int argIndex = 0;
+    int writeArgCount = 0;
+    if (callNode->child_count > 0 && callNode->children[0]->type == AST_STRING) {
+        AST* fmtNode = callNode->children[0];
+        const char* fmt = fmtNode->token && fmtNode->token->value ? fmtNode->token->value : "";
+        size_t flen = strlen(fmt);
+        char* seg = malloc(flen + 1);
+        size_t seglen = 0;
+        argIndex = 1;
+        for (size_t i = 0; i < flen; ++i) {
+            if (fmt[i] == '%' && i + 1 < flen) {
+                if (fmt[i + 1] == '%') {
+                    seg[seglen++] = '%';
+                    i++; // skip second %
+                } else {
+                    if (seglen > 0) {
+                        seg[seglen] = '\0';
+                        Value strv = makeString(seg);
+                        int cidx = addConstantToChunk(chunk, &strv);
+                        freeValue(&strv);
+                        emitConstant(chunk, cidx, line);
+                        writeArgCount++;
+                        seglen = 0;
+                    }
+                    if (argIndex < callNode->child_count) {
+                        compileRValue(callNode->children[argIndex], chunk, getLine(callNode->children[argIndex]));
+                        writeArgCount++;
+                        argIndex++;
+                    }
+                    i++; // skip format specifier
+                }
+            } else {
+                seg[seglen++] = fmt[i];
+            }
+        }
+        if (seglen > 0) {
+            seg[seglen] = '\0';
+            Value strv = makeString(seg);
+            int cidx = addConstantToChunk(chunk, &strv);
+            freeValue(&strv);
+            emitConstant(chunk, cidx, line);
+            writeArgCount++;
+        }
+        free(seg);
+    }
+    for (; argIndex < callNode->child_count; ++argIndex) {
+        compileRValue(callNode->children[argIndex], chunk, getLine(callNode->children[argIndex]));
+        writeArgCount++;
+    }
+    writeBytecodeChunk(chunk, OP_WRITE, line);
+    writeBytecodeChunk(chunk, (uint8_t)writeArgCount, line);
+}
+
 static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_approx) {
     if (!node) return;
     int line = getLine(node);
@@ -1660,8 +1715,13 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
         }
         case AST_EXPR_STMT: {
             if (node->left) {
-                compileRValue(node->left, chunk, getLine(node->left));
-                writeBytecodeChunk(chunk, OP_POP, line);
+                if (node->left->type == AST_PROCEDURE_CALL && node->left->token &&
+                    strcasecmp(node->left->token->value, "printf") == 0) {
+                    compilePrintf(node->left, chunk, getLine(node->left));
+                } else {
+                    compileRValue(node->left, chunk, getLine(node->left));
+                    writeBytecodeChunk(chunk, OP_POP, line);
+                }
             }
             break;
         }
@@ -2036,6 +2096,10 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
             break;
         }
         case AST_PROCEDURE_CALL: {
+            if (node->token && strcasecmp(node->token->value, "printf") == 0) {
+                compilePrintf(node, chunk, line);
+                break;
+            }
             const char* calleeName = node->token->value;
 
             // --- NEW, MORE ROBUST LOOKUP LOGIC ---
@@ -2764,7 +2828,15 @@ static void compileRValue(AST* node, BytecodeChunk* chunk, int current_line_appr
         case AST_PROCEDURE_CALL: {
             int line = getLine(node);
             if (line <= 0) line = current_line_approx;
-
+            if (node->token && strcasecmp(node->token->value, "printf") == 0) {
+                compilePrintf(node, chunk, line);
+                Value zero = makeInt(0);
+                int zidx = addConstantToChunk(chunk, &zero);
+                freeValue(&zero);
+                writeBytecodeChunk(chunk, OP_CONSTANT, line);
+                writeBytecodeChunk(chunk, (uint8_t)zidx, line);
+                break;
+            }
             const char* functionName = NULL;
             bool isCallQualified = false;
 


### PR DESCRIPTION
## Summary
- translate `printf` calls into VM `OP_WRITE` during compilation
- drop unused VM builtin implementation for `printf`
- emit string segments with `emitConstant` so large constant pools are handled correctly

## Testing
- `cmake -S . -B build`
- `cmake --build build --target rea`
- `cmake --build build --target pascal`
- `./build/bin/pascal /tmp/test.pas`
- `./build/bin/pascal /tmp/test_printf2.pas`


------
https://chatgpt.com/codex/tasks/task_e_68b9d53fafbc832a9035cccaaca206af