### PR TITLE
Compile printf using OP_WRITE

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -3413,6 +3413,7 @@ void registerAllBuiltins(void) {
     registerBuiltinFunction("PopScreen", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("Pos", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("Power", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("printf", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("PushScreen", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("QuitRequested", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("Random", AST_FUNCTION_DECL, NULL);


### PR DESCRIPTION
## Summary
- translate `printf` calls into VM `OP_WRITE` during compilation
- drop unused VM builtin implementation for `printf`
- emit string segments with `emitConstant` so large constant pools are handled correctly
- encode printf's expression return value with `emitConstant` to avoid constant index truncation
- skip flags, width, precision, and length modifiers when compiling `printf` format strings

## Testing
- `cmake -S . -B build`
- `cmake --build build --target rea`
- `cmake --build build --target pascal`
- `./build/bin/pascal /tmp/test.pas`
- `./build/bin/pascal /tmp/test_printf2.pas`
- `./build/bin/pascal /tmp/test_printf_width.pas`


------
https://chatgpt.com/codex/tasks/task_e_68b9d53fafbc832a9035cccaaca206af