### PR TITLE
Add printf builtin to runtime

### DIFF
--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -43,6 +43,7 @@ Value vmBuiltinChr(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinSucc(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinUpcase(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinPos(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinPrintf(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinCopy(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinSetlength(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinRealtostr(struct VM_s* vm, int arg_count, Value* args);


### PR DESCRIPTION
## Summary
- Register printf as a VM builtin and add implementation that parses format strings at runtime
- Expose builtin in header and dispatch table so the Rea front end can resolve printf correctly

## Testing
- `Tests/run_rea_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ba0449ff38832ab38a8573e3c5496c