### PR TITLE
Refactor write/writeln as VM builtin

### DIFF
--- a/Docs/pscal_vm_overview.md
+++ b/Docs/pscal_vm_overview.md
@@ -156,8 +156,9 @@ end;
    * `OP_LESS`
    * `OP_JUMP_IF_FALSE <exit_offset>`
 4. loop_body:
+   * `OP_CONSTANT <index_of_true>` – newline flag
    * `OP_GET_GLOBAL <index_of_i>`
-   * `OP_WRITE_LN 1`
+   * `OP_CALL_BUILTIN <index_of_write> 2`
    * `OP_GET_GLOBAL <index_of_i>`
    * `OP_CONSTANT <index_of_1>`
    * `OP_ADD`
@@ -313,9 +314,6 @@ MyFunction(a, b);
 
 #### **I/O and Miscellaneous Opcodes**
 
-* **`OP_WRITE_LN`** / **`OP_WRITE`**:
-    * **Operands:** 1-byte argument count.
-    * **Action:** Pops the specified number of arguments from the stack and prints them to the console. `OP_WRITE_LN` adds a newline.
 * **`OP_CALL_HOST`**:
     * **Operands:** 1-byte host function ID.
     * **Action:** Calls a C function that is registered with the VM.

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -30,6 +30,9 @@
 #include <stdio.h>   // For printf, fprintf
 #include <pthread.h>
 
+// Maximum number of arguments allowed for write/writeln
+#define MAX_WRITE_ARGS_VM 32
+
 // Per-thread state to keep core builtins thread-safe
 static _Thread_local DIR* dos_dir = NULL; // Used by dosFindfirst/findnext
 static _Thread_local unsigned int rand_seed = 1;
@@ -395,9 +398,10 @@ static const VmBuiltinMapping vmBuiltinDispatchTable[] = {
 #ifdef SDL
     {"waitkeyevent", vmBuiltinWaitkeyevent}, // Moved
 #endif
-    {"window", vmBuiltinWindow},
     {"wherex", vmBuiltinWherex},
     {"wherey", vmBuiltinWherey},
+    {"window", vmBuiltinWindow},
+    {"write", vmBuiltinWrite},
     {"to be filled", NULL}
 };
 
@@ -2589,6 +2593,83 @@ Value vmBuiltinReadln(VM* vm, int arg_count, Value* args) {
     return makeVoid();
 }
 
+Value vmBuiltinWrite(VM* vm, int arg_count, Value* args) {
+    if (arg_count < 1) {
+        runtimeError(vm, "Write expects at least a newline flag.");
+        return makeVoid();
+    }
+
+    bool newline = false;
+    Value flag = args[0];
+    if (isRealType(flag.type)) {
+        newline = (AS_REAL(flag) != 0.0);
+    } else if (IS_INTLIKE(flag)) {
+        newline = (AS_INTEGER(flag) != 0);
+    } else if (flag.type == TYPE_BOOLEAN) {
+        newline = flag.i_val != 0;
+    } else if (flag.type == TYPE_CHAR) {
+        newline = flag.c_val != 0;
+    }
+
+    FILE* output_stream = stdout;
+    int start_index = 1;
+    bool first_arg_is_file_by_value = false;
+
+    if (arg_count > 1) {
+        const Value* first = &args[1];
+        if (first->type == TYPE_POINTER && first->ptr_val) first = (const Value*)first->ptr_val;
+        if (first->type == TYPE_FILE) {
+            if (!first->f_val) {
+                runtimeError(vm, "File not open for writing.");
+                return makeVoid();
+            }
+            output_stream = first->f_val;
+            start_index = 2;
+            if (args[1].type == TYPE_FILE) first_arg_is_file_by_value = true;
+        }
+    }
+
+    int print_arg_count = arg_count - start_index;
+    if (print_arg_count > MAX_WRITE_ARGS_VM) {
+        runtimeError(vm, "VM Error: Too many arguments for WRITE/WRITELN (max %d).", MAX_WRITE_ARGS_VM);
+        return makeVoid();
+    }
+
+    bool color_was_applied = false;
+    if (output_stream == stdout) {
+        color_was_applied = applyCurrentTextAttributes(output_stream);
+    }
+
+    for (int i = start_index; i < arg_count; i++) {
+        Value val = args[i];
+        if (val.type == TYPE_STRING) {
+            if (output_stream == stdout) {
+                fputs(val.s_val ? val.s_val : "", output_stream);
+            } else {
+                size_t len = val.s_val ? strlen(val.s_val) : 0;
+                fwrite(val.s_val ? val.s_val : "", 1, len, output_stream);
+            }
+        } else if (val.type == TYPE_CHAR) {
+            fputc(val.c_val, output_stream);
+        } else {
+            printValueToStream(val, output_stream);
+        }
+    }
+
+    if (newline) {
+        fprintf(output_stream, "\n");
+    }
+
+    if (color_was_applied) {
+        resetTextAttributes(output_stream);
+    }
+
+    fflush(output_stream);
+    if (first_arg_is_file_by_value) { args[1].type = TYPE_NIL; args[1].f_val = NULL; }
+
+    return makeVoid();
+}
+
 
 Value vmBuiltinIoresult(VM* vm, int arg_count, Value* args) {
     if (arg_count != 0) { runtimeError(vm, "IOResult requires 0 arguments."); return makeInt(0); }
@@ -3464,6 +3545,7 @@ void registerAllBuiltins(void) {
     registerBuiltinFunction("ValReal", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("VMVersion", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("Window", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("Write", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("WhereX", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("BIWhereX", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("WhereY", AST_FUNCTION_DECL, NULL);

--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -97,6 +97,7 @@ Value vmBuiltinRename(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinErase(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinRead(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinReadln(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinWrite(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinEof(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinIoresult(struct VM_s* vm, int arg_count, Value* args);
 

--- a/src/clike/codegen.c
+++ b/src/clike/codegen.c
@@ -1078,6 +1078,12 @@ static void compileExpression(ASTNodeClike *node, BytecodeChunk *chunk, FuncCont
             if (strcasecmp(name, "printf") == 0) {
                 int arg_index = 0;
                 int write_arg_count = 0;
+                Value nl = makeInt(0);
+                int nlidx = addConstantToChunk(chunk, &nl);
+                freeValue(&nl);
+                writeBytecodeChunk(chunk, OP_CONSTANT, node->token.line);
+                writeBytecodeChunk(chunk, (uint8_t)nlidx, node->token.line);
+                write_arg_count++;
                 if (node->child_count > 0 && node->children[0]->type == TCAST_STRING) {
                     arg_index = 1;
                     char* fmt = tokenStringToCString(node->children[0]->token);
@@ -1154,7 +1160,9 @@ static void compileExpression(ASTNodeClike *node, BytecodeChunk *chunk, FuncCont
                     compileExpression(node->children[arg_index], chunk, ctx);
                     write_arg_count++;
                 }
-                writeBytecodeChunk(chunk, OP_WRITE, node->token.line);
+                int nameIndex = addStringConstant(chunk, "write");
+                writeBytecodeChunk(chunk, OP_CALL_BUILTIN, node->token.line);
+                emitShort(chunk, (uint16_t)nameIndex, node->token.line);
                 writeBytecodeChunk(chunk, (uint8_t)write_arg_count, node->token.line);
                 Value zero = makeInt(0);
                 int zidx = addConstantToChunk(chunk, &zero);

--- a/src/compiler/bytecode.c
+++ b/src/compiler/bytecode.c
@@ -152,8 +152,6 @@ int getInstructionLength(BytecodeChunk* chunk, int offset) {
         case OP_GET_FIELD_ADDRESS:
         case OP_GET_ELEMENT_ADDRESS:
         case OP_GET_CHAR_ADDRESS:
-        case OP_WRITE:
-        case OP_WRITE_LN:
         case OP_INIT_LOCAL_FILE:
             return 2; // 1-byte opcode + 1-byte operand
         case OP_INIT_LOCAL_POINTER:
@@ -654,16 +652,6 @@ int disassembleInstruction(BytecodeChunk* chunk, int offset, HashTable* procedur
              fprintf(stderr, "%-16s (not fully impl.)\n", "OP_CALL_USER_PROC");
              return offset + 3;
 
-        case OP_WRITE_LN: {
-            uint8_t arg_count = chunk->code[offset + 1];
-            fprintf(stderr, "%-16s %4d (args)\n", "OP_WRITE_LN", arg_count);
-            return offset + 2;
-        }
-        case OP_WRITE: {
-            uint8_t arg_count = chunk->code[offset + 1];
-            fprintf(stderr, "%-16s %4d (args)\n", "OP_WRITE", arg_count);
-            return offset + 2;
-        }
         case OP_CALL_HOST: {
             uint8_t host_fn_id_val = chunk->code[offset + 1];
             fprintf(stderr, "%-16s %4d (ID: %d)\n", "OP_CALL_HOST", host_fn_id_val, host_fn_id_val);

--- a/src/compiler/bytecode.h
+++ b/src/compiler/bytecode.h
@@ -86,9 +86,6 @@ typedef enum {
     OP_CALL_BUILTIN_PROC, // For void built-in procedures. Operand1: builtin_id, Operand2: arg_count
     OP_CALL_USER_PROC,    // For user-defined procedures/functions. Operand1: name_const_idx, Operand2: arg_count
 
-    OP_WRITE_LN,      // Specific opcode for WriteLn for now (simpler than generic call)
-                      // Operand: number of arguments to pop from stack for writeln
-    OP_WRITE,         // Specific opcode for Write
     OP_CALL_HOST,
 
     OP_POP,           // Pop the top value from the stack (e.g., after an expression statement)

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -1676,8 +1676,12 @@ static void compilePrintf(AST* node, BytecodeChunk* chunk, int line) {
             freeValue(&sv);
             free(processed);
 
+            Value nl = makeInt(0);
+            int nlidx = addConstantToChunk(chunk, &nl);
+            freeValue(&nl);
+            emitConstant(chunk, nlidx, line);
             emitConstant(chunk, cidx, line);
-            int write_arg_count = 1;
+            int write_arg_count = 2;
 
             for (int i = 1; i < node->child_count; i++) {
                 AST* arg = node->children[i];
@@ -1685,7 +1689,9 @@ static void compilePrintf(AST* node, BytecodeChunk* chunk, int line) {
                 write_arg_count++;
             }
 
-            writeBytecodeChunk(chunk, OP_WRITE, line);
+            int nameIndex = addStringConstant(chunk, "write");
+            writeBytecodeChunk(chunk, OP_CALL_BUILTIN, line);
+            emitShort(chunk, (uint16_t)nameIndex, line);
             writeBytecodeChunk(chunk, (uint8_t)write_arg_count, line);
 
             Value zero = makeInt(0);
@@ -1752,11 +1758,17 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
         }
         case AST_WRITELN: {
             int argCount = node->child_count;
+            Value nl = makeInt(1);
+            int nlidx = addConstantToChunk(chunk, &nl);
+            freeValue(&nl);
+            emitConstant(chunk, nlidx, line);
             for (int i = 0; i < argCount; i++) {
                 compileRValue(node->children[i], chunk, getLine(node->children[i]));
             }
-            writeBytecodeChunk(chunk, OP_WRITE_LN, line);
-            writeBytecodeChunk(chunk, (uint8_t)argCount, line);
+            int nameIndex = addStringConstant(chunk, "write");
+            writeBytecodeChunk(chunk, OP_CALL_BUILTIN, line);
+            emitShort(chunk, (uint16_t)nameIndex, line);
+            writeBytecodeChunk(chunk, (uint8_t)(argCount + 1), line);
             break;
         }
         case AST_WHILE: {
@@ -1958,11 +1970,17 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
         }
         case AST_WRITE: {
             int argCount = node->child_count;
+            Value nl = makeInt(0);
+            int nlidx = addConstantToChunk(chunk, &nl);
+            freeValue(&nl);
+            emitConstant(chunk, nlidx, line);
             for (int i = 0; i < argCount; i++) {
                 compileRValue(node->children[i], chunk, getLine(node->children[i]));
             }
-            writeBytecodeChunk(chunk, OP_WRITE, line);
-            writeBytecodeChunk(chunk, (uint8_t)argCount, line);
+            int nameIndex = addStringConstant(chunk, "write");
+            writeBytecodeChunk(chunk, OP_CALL_BUILTIN, line);
+            emitShort(chunk, (uint16_t)nameIndex, line);
+            writeBytecodeChunk(chunk, (uint8_t)(argCount + 1), line);
             break;
         }
         case AST_ASSIGN: {

--- a/tools/tiny
+++ b/tools/tiny
@@ -318,6 +318,9 @@ class tinyCompiler:
         self.vars: Set[str] = set()
         self.var_name_idx: Dict[str, int] = {}
         self.read_idx = self.builder.add_constant(TYPE_STRING, "read")
+        self.write_idx = self.builder.add_constant(TYPE_STRING, "write")
+        self.const_true_idx = self.builder.add_constant(TYPE_INTEGER, 1)
+        self.const_false_idx = self.builder.add_constant(TYPE_INTEGER, 0)
         self.type_integer_idx = self.builder.add_constant(TYPE_STRING, "integer")
 
     # --- AST Traversal to collect variables ---
@@ -352,8 +355,11 @@ class tinyCompiler:
             self.compile_statement(stmt)
 
         # Ensure every program terminates with a newline for clean output
-        self.builder.emit(self.opcodes["OP_WRITE_LN"])
-        self.builder.emit(0)
+        self.builder.emit(self.opcodes["OP_CONSTANT"])
+        self.builder.emit(self.const_true_idx)
+        self.builder.emit(self.opcodes["OP_CALL_BUILTIN"])
+        self.builder.emit_short(self.write_idx)
+        self.builder.emit(1)
         self.builder.emit(self.opcodes["OP_HALT"])
         return self.builder
 
@@ -373,12 +379,18 @@ class tinyCompiler:
             self.builder.emit(1)  # argument count
         elif isinstance(stmt, Write):
             if stmt.expr is None:
-                self.builder.emit(self.opcodes["OP_WRITE_LN"])
-                self.builder.emit(0)
-            else:
-                self.compile_expression(stmt.expr)
-                self.builder.emit(self.opcodes["OP_WRITE"])
+                self.builder.emit(self.opcodes["OP_CONSTANT"])
+                self.builder.emit(self.const_true_idx)
+                self.builder.emit(self.opcodes["OP_CALL_BUILTIN"])
+                self.builder.emit_short(self.write_idx)
                 self.builder.emit(1)
+            else:
+                self.builder.emit(self.opcodes["OP_CONSTANT"])
+                self.builder.emit(self.const_false_idx)
+                self.compile_expression(stmt.expr)
+                self.builder.emit(self.opcodes["OP_CALL_BUILTIN"])
+                self.builder.emit_short(self.write_idx)
+                self.builder.emit(2)
         elif isinstance(stmt, If):
             self.compile_expression(stmt.cond)
             self.builder.emit(self.opcodes["OP_JUMP_IF_FALSE"])


### PR DESCRIPTION
## Summary
- Replace OP_WRITE/OP_WRITE_LN with a vmBuiltinWrite routine that accepts a newline flag
- Register the write builtin and update dispatch/prototype tables
- Emit OP_CALL_BUILTIN for write and writeln in Pascal/C-like front ends and remove old opcode docs

## Testing
- ⚠️ `make test` *(fails: No rule to make target 'test')*
- ⚠️ `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0c46de08832a99729c20d5a920f0