### PR TITLE
Fix runtime error offset reporting

### DIFF
--- a/Tests/Pascal/RealIntOverflowTest.err
+++ b/Tests/Pascal/RealIntOverflowTest.err
@@ -1,2 +1,2 @@
 Warning: Range check error assigning REAL 100000000000000000000.000000 to INTEGER.
-[Error Location] Offset: 47, Line: 15
+[Error Location] Offset: 51, Line: 15

--- a/Tests/clike/StringIndexBounds.err
+++ b/Tests/clike/StringIndexBounds.err
@@ -1,2 +1,2 @@
 Runtime Error: String index (9) out of bounds for string of length 8.
-[Error Location] Offset: 26, Line: 5
+[Error Location] Offset: 25, Line: 5

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -545,20 +545,22 @@ void runtimeError(VM* vm, const char* format, ...) {
     va_end(args);
     fputc('\n', stderr);
 
-    // Get approximate instruction offset and line for the error
+    // Get precise instruction offset and line for the error.
+    // vm->lastInstruction points at the start of the instruction that ran last
+    // (the one that triggered the runtime error).
     size_t instruction_offset = 0;
     int error_line = 0;
-    if (vm && vm->chunk && vm->ip && vm->chunk->code && vm->chunk->lines) {
-        // The instruction that *caused* the error is usually the one *before* vm->ip
-        if (vm->ip > vm->chunk->code) {
-            instruction_offset = (vm->ip - vm->chunk->code) - 1;
+    if (vm && vm->chunk && vm->lastInstruction && vm->chunk->code && vm->chunk->lines) {
+        if (vm->lastInstruction >= vm->chunk->code) {
+            instruction_offset = (size_t)(vm->lastInstruction - vm->chunk->code);
             if (instruction_offset < (size_t)vm->chunk->count) {
                 error_line = vm->chunk->lines[instruction_offset];
             }
-        } else if (vm->chunk->count > 0) { // Special case: error on the very first byte
-            instruction_offset = 0;
-            error_line = vm->chunk->lines[0];
         }
+    } else if (vm && vm->chunk && vm->chunk->count > 0) {
+        // Special case: error on the very first instruction
+        instruction_offset = 0;
+        error_line = vm->chunk->lines[0];
     }
     fprintf(stderr, "[Error Location] Offset: %zu, Line: %d\n", instruction_offset, error_line);
 
@@ -825,6 +827,7 @@ void initVM(VM* vm) { // As in all.txt, with frameCount
     resetStack(vm);
     vm->chunk = NULL;
     vm->ip = NULL;
+    vm->lastInstruction = NULL;
     vm->vmGlobalSymbols = NULL;              // Will be set by interpretBytecode
     vm->vmConstGlobalSymbols = NULL;
     vm->procedureTable = NULL;
@@ -1212,6 +1215,7 @@ InterpretResult interpretBytecode(VM* vm, BytecodeChunk* chunk, HashTable* globa
 
     vm->chunk = chunk;
     vm->ip = vm->chunk->code + entry;
+    vm->lastInstruction = vm->ip;
 
     vm->vmGlobalSymbols = globals;    // Store globals table (ensure this is the intended one)
     vm->vmConstGlobalSymbols = const_globals; // Table of constant globals (no locking)
@@ -1460,6 +1464,7 @@ InterpretResult interpretBytecode(VM* vm, BytecodeChunk* chunk, HashTable* globa
 
     uint8_t instruction_val;
     for (;;) {
+        vm->lastInstruction = vm->ip;
 /* #ifdef DEBUG
         if (dumpExec) {
             fprintf(stderr,"VM Stack: ");

--- a/src/vm/vm.h
+++ b/src/vm/vm.h
@@ -75,6 +75,7 @@ typedef struct {
 typedef struct VM_s {
     BytecodeChunk* chunk;     // The chunk of bytecode to execute
     uint8_t* ip;              // Instruction Pointer: points to the *next* byte to be read
+    uint8_t* lastInstruction; // Start of the last executed instruction
 
     Value stack[VM_STACK_MAX]; // The operand stack
     Value* stackTop;          // Pointer to the element just above the top of the stack


### PR DESCRIPTION
## Summary
- track start of last executed VM instruction and use it when reporting runtime errors
- update error location expectations in failing tests

## Testing
- `Tests/run_pascal_tests.sh`
- `Tests/run_clike_tests.sh`
- `Tests/run_rea_tests.sh`
- `Tests/run_tiny_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ba1243d258832ab4afd3b2496c6021