### PR TITLE
Add timestamps to simple web server logs

### DIFF
--- a/Docs/simple_web_server.md
+++ b/Docs/simple_web_server.md
@@ -11,7 +11,7 @@
 - Path safety: Percent-decodes, strips query string, canonicalizes `.`/`..`, collapses duplicate `/`.
 - Worker pool: Fixed-size pool consumes from a bounded queue; prevents unbounded thread growth.
 - Metrics: Counters for accepted, enqueued, served, dropped; queue depth. Periodic heartbeat logs once/minute.
-- Logging: Per-request line with method, path, status, and detail; periodic heartbeat with throughput.
+- Logging: Per-request line with date/time, method, path, status, and detail; periodic heartbeat with throughput.
 
 ## Usage
 Binary: `build/bin/clike`
@@ -63,8 +63,8 @@ Examples:
 
 ## Metrics & Heartbeat
 - Counters: `accepted`, `enqueued`, `served`, `dropped`; live queue depth.
-- Per‑request log: `[GET] /path -> 200 detail | q=depth served=S enq=E drop=D`.
-- Heartbeat (every 60s): `[HB] q=depth/cap thr=T accepted=A enq=E served=S drop=D dps=ΔS`.
+- Per‑request log: `YYYY-MM-DD HH:MM:SS [GET] /path -> 200 detail | q=depth served=S enq=E drop=D`.
+- Heartbeat (every 60s): `YYYY-MM-DD HH:MM:SS [HB] q=depth/cap thr=T accepted=A enq=E served=S drop=D dps=ΔS`.
 
 ## Tests
 - Network test: `Tests/clike/SimpleWebServerClient.cl` (marked `.net`).

--- a/Examples/clike/simple_web_server
+++ b/Examples/clike/simple_web_server
@@ -111,6 +111,22 @@ str normalizePath(str s) {
   return out;
 }
 
+str pad2(int n) {
+  str s = inttostr(n);
+  if (length(s) < 2) s = "0" + s;
+  return s;
+}
+
+str timestamp() {
+  int yr = 0, mo = 0, dy = 0, dow = 0;
+  int hh = 0, mi = 0, ss = 0, hs = 0;
+  getdate(&yr, &mo, &dy, &dow);
+  gettime(&hh, &mi, &ss, &hs);
+  str ts = inttostr(yr) + "-" + pad2(mo) + "-" + pad2(dy)
+           + " " + pad2(hh) + ":" + pad2(mi) + ":" + pad2(ss);
+  return ts;
+}
+
 void serveConn(int c) {
   // Read request
   mstream req = socketreceive(c, 2048);
@@ -248,7 +264,8 @@ void serveConn(int c) {
   socketsend(c, respBody);
   int depth = 0, served = 0, enq = 0, drop = 0;
   lock(qmu); depth = qCount; served = GServed; enq = GEnqueued; drop = GDropped; unlock(qmu);
-  printf("[%s] %s -> %d %s | q=%d served=%d enq=%d drop=%d\n", method, path, code, logDetail, depth, served, enq, drop);
+  str ts = timestamp();
+  printf("%s [%s] %s -> %d %s | q=%d served=%d enq=%d drop=%d\n", ts, method, path, code, logDetail, depth, served, enq, drop);
   socketclose(c);
 }
 
@@ -299,7 +316,7 @@ void heartbeat() {
     unlock(qmu);
     int dps = served - prevServed;
     prevServed = served;
-    printf("[HB] q=%d/%d thr=%d accepted=%d enq=%d served=%d drop=%d dps=%d\n", depth, cap, thr, acc, enq, served, drop, dps);
+    printf("%s [HB] q=%d/%d thr=%d accepted=%d enq=%d served=%d drop=%d dps=%d\n", timestamp(), depth, cap, thr, acc, enq, served, drop, dps);
   }
 }
 


### PR DESCRIPTION
## Summary
- Prefix simple_web_server request and heartbeat logs with an ISO-like timestamp
- Document updated logging format in simple_web_server docs

## Testing
- `RUN_NET_TESTS=1 Tests/run_clike_tests.sh` *(failed: VM Error: Unimplemented or unknown built-in 'read_port' called)*
- `Tests/run_clike_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bc457cb16c832a80c61f1fe2416f6f