### PR TITLE
Update Rea tests for address opcodes

### DIFF
--- a/Tests/rea/field_access_assign.err
+++ b/Tests/rea/field_access_assign.err
@@ -3,7 +3,7 @@
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
 0000    3 OP_CONSTANT         0 '1'
-0002    | OP_GET_GLOBAL       1 'p'
+0002    | OP_GET_GLOBAL_ADDRESS    1 'p'
 0004    | OP_GET_FIELD_ADDRESS    2 'x'
 0006    | OP_SWAP
 0007    | OP_SET_INDIRECT

--- a/Tests/rea/field_access_read.err
+++ b/Tests/rea/field_access_read.err
@@ -3,7 +3,7 @@
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
 0000    3 OP_DEFINE_GLOBAL NameIdx:0   'a' Type:INT64 ('int')
-0005    | OP_GET_GLOBAL       2 'p'
+0005    | OP_GET_GLOBAL_ADDRESS    2 'p'
 0007    | OP_GET_FIELD_ADDRESS    3 'x'
 0009    | OP_GET_INDIRECT
 0010    | OP_SET_GLOBAL       0 'a'

--- a/Tests/rea/method_this_assign.err
+++ b/Tests/rea/method_this_assign.err
@@ -6,7 +6,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 
 --- Function point_setx (at 0003) ---
 0003    4 OP_GET_LOCAL        1 (slot)
-0005    | OP_GET_LOCAL        0 (slot)
+0005    | OP_GET_LOCAL_ADDRESS    0 (slot)
 0007    | OP_GET_FIELD_ADDRESS    0 'x'
 0009    | OP_SWAP
 0010    | OP_SET_INDIRECT


### PR DESCRIPTION
## Summary
- adjust Rea field access tests to expect `OP_GET_GLOBAL_ADDRESS`
- update method assignment test to expect `OP_GET_LOCAL_ADDRESS`

## Testing
- `./Tests/run_rea_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bc9e986414832aa82ef13327f227b1