### PR TITLE
Suppress Terminated message from network tests

### DIFF
--- a/Tests/run_clike_tests.sh
+++ b/Tests/run_clike_tests.sh
@@ -53,6 +53,9 @@ for src in "$SCRIPT_DIR"/clike/*.cl; do
   if [ -f "$server_script" ] && [ "${RUN_NET_TESTS:-0}" = "1" ] && [ -s "$server_script" ]; then
     python3 "$server_script" &
     server_pid=$!
+    # Detach the server process from job control so terminating it later does
+    # not emit noisy "Terminated" messages that interfere with test output.
+    disown "$server_pid" 2>/dev/null || true
     sleep 1
   fi
 


### PR DESCRIPTION
## Summary
- Disown background server in `run_clike_tests.sh` so killing it doesn't emit `Terminated` noise that interferes with tests

## Testing
- `RUN_NET_TESTS=1 ./run_clike_tests.sh` *(fails: clike binary not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcaabce59c832a871dccddb0b8c303