### PR TITLE
Add extended primitive type support to Rea parser

### DIFF
--- a/Tests/rea/types.args
+++ b/Tests/rea/types.args
@@ -1,0 +1,1 @@
+--dump-bytecode-only

--- a/Tests/rea/types.err
+++ b/Tests/rea/types.err
@@ -1,0 +1,41 @@
+--- Compiling Main Program AST to Bytecode ---
+== Disassembly: Tests/rea/types.rea ==
+Offset Line Opcode           Operand  Value / Target (Args)
+------ ---- ---------------- -------- --------------------------
+0000    1 OP_DEFINE_GLOBAL NameIdx:0   'a' Type:INT64 ('int64')
+0005    2 OP_DEFINE_GLOBAL NameIdx:2   'b' Type:INTEGER ('int32')
+0010    3 OP_DEFINE_GLOBAL NameIdx:4   'c' Type:INT16 ('int16')
+0015    4 OP_DEFINE_GLOBAL NameIdx:6   'd' Type:INT8 ('int8')
+0020    5 OP_DEFINE_GLOBAL NameIdx:8   'e' Type:REAL ('float32')
+0025    6 OP_DEFINE_GLOBAL NameIdx:10  'f' Type:LONG_DOUBLE ('long double')
+0030    7 OP_DEFINE_GLOBAL NameIdx:12  'g' Type:CHAR ('char')
+0035    8 OP_DEFINE_GLOBAL NameIdx:14  'h' Type:BYTE ('byte')
+0040    9 OP_DEFINE_GLOBAL NameIdx:16  't' Type:FILE ('text')
+0045   10 OP_DEFINE_GLOBAL NameIdx:18  'ms' Type:MEMORY_STREAM ('mstream')
+0050   11 OP_DEFINE_GLOBAL NameIdx:20  'v' Type:VOID ('void')
+0055    0 OP_HALT
+== End Disassembly: Tests/rea/types.rea ==
+
+Constants (22):\n  0000: STR   "a"
+  0001: STR   "int64"
+  0002: STR   "b"
+  0003: STR   "int32"
+  0004: STR   "c"
+  0005: STR   "int16"
+  0006: STR   "d"
+  0007: STR   "int8"
+  0008: STR   "e"
+  0009: STR   "float32"
+  0010: STR   "f"
+  0011: STR   "long double"
+  0012: STR   "g"
+  0013: STR   "char"
+  0014: STR   "h"
+  0015: STR   "byte"
+  0016: STR   "t"
+  0017: STR   "text"
+  0018: STR   "ms"
+  0019: STR   "mstream"
+  0020: STR   "v"
+  0021: STR   "void"
+

--- a/Tests/rea/types.rea
+++ b/Tests/rea/types.rea
@@ -1,0 +1,11 @@
+int64 a;
+int32 b;
+int16 c;
+int8 d;
+float32 e;
+long double f;
+char g;
+byte h;
+text t;
+mstream ms;
+void v;

--- a/src/rea/parser.c
+++ b/src/rea/parser.c
@@ -383,21 +383,66 @@ static AST *parseExpression(ReaParser *p) {
 
 static VarType mapType(ReaTokenType t) {
     switch (t) {
-        case REA_TOKEN_INT: return TYPE_INT64;
-        case REA_TOKEN_FLOAT: return TYPE_DOUBLE;
-        case REA_TOKEN_STR: return TYPE_STRING;
-        case REA_TOKEN_BOOL: return TYPE_BOOLEAN;
-        default: return TYPE_VOID;
+        case REA_TOKEN_INT:
+        case REA_TOKEN_INT64:    return TYPE_INT64;
+        case REA_TOKEN_INT32:    return TYPE_INT32;
+        case REA_TOKEN_INT16:    return TYPE_INT16;
+        case REA_TOKEN_INT8:     return TYPE_INT8;
+        case REA_TOKEN_FLOAT:    return TYPE_DOUBLE;
+        case REA_TOKEN_FLOAT32:  return TYPE_FLOAT;
+        case REA_TOKEN_LONG_DOUBLE: return TYPE_LONG_DOUBLE;
+        case REA_TOKEN_STR:      return TYPE_STRING;
+        case REA_TOKEN_TEXT:     return TYPE_FILE;
+        case REA_TOKEN_MSTREAM:  return TYPE_MEMORYSTREAM;
+        case REA_TOKEN_CHAR:     return TYPE_CHAR;
+        case REA_TOKEN_BYTE:     return TYPE_BYTE;
+        case REA_TOKEN_BOOL:     return TYPE_BOOLEAN;
+        case REA_TOKEN_VOID:     return TYPE_VOID;
+        default:                 return TYPE_VOID;
     }
 }
 
 static const char *typeName(ReaTokenType t) {
     switch (t) {
-        case REA_TOKEN_INT: return "int";
-        case REA_TOKEN_FLOAT: return "float";
-        case REA_TOKEN_STR: return "str";
-        case REA_TOKEN_BOOL: return "bool";
-        default: return "";
+        case REA_TOKEN_INT:       return "int";
+        case REA_TOKEN_INT64:     return "int64";
+        case REA_TOKEN_INT32:     return "int32";
+        case REA_TOKEN_INT16:     return "int16";
+        case REA_TOKEN_INT8:      return "int8";
+        case REA_TOKEN_FLOAT:     return "float";
+        case REA_TOKEN_FLOAT32:   return "float32";
+        case REA_TOKEN_LONG_DOUBLE: return "long double";
+        case REA_TOKEN_STR:       return "str";
+        case REA_TOKEN_TEXT:      return "text";
+        case REA_TOKEN_MSTREAM:   return "mstream";
+        case REA_TOKEN_CHAR:      return "char";
+        case REA_TOKEN_BYTE:      return "byte";
+        case REA_TOKEN_BOOL:      return "bool";
+        case REA_TOKEN_VOID:      return "void";
+        default:                  return "";
+    }
+}
+
+static bool isTypeToken(ReaTokenType t) {
+    switch (t) {
+        case REA_TOKEN_INT:
+        case REA_TOKEN_INT64:
+        case REA_TOKEN_INT32:
+        case REA_TOKEN_INT16:
+        case REA_TOKEN_INT8:
+        case REA_TOKEN_FLOAT:
+        case REA_TOKEN_FLOAT32:
+        case REA_TOKEN_LONG_DOUBLE:
+        case REA_TOKEN_STR:
+        case REA_TOKEN_TEXT:
+        case REA_TOKEN_MSTREAM:
+        case REA_TOKEN_BOOL:
+        case REA_TOKEN_CHAR:
+        case REA_TOKEN_BYTE:
+        case REA_TOKEN_VOID:
+            return true;
+        default:
+            return false;
     }
 }
 
@@ -678,8 +723,7 @@ static AST *parseStatement(ReaParser *p) {
             reaAdvance(p); // consume '{'
             while (p->current.type != REA_TOKEN_RIGHT_BRACE && p->current.type != REA_TOKEN_EOF) {
                 // Field or method: both start with a type keyword
-                if (p->current.type == REA_TOKEN_INT || p->current.type == REA_TOKEN_FLOAT ||
-                    p->current.type == REA_TOKEN_STR || p->current.type == REA_TOKEN_BOOL) {
+                if (isTypeToken(p->current.type)) {
                     // Peek ahead to decide var vs method based on presence of '('
                     ReaToken save = p->current;
                     // Consume type and identifier into a fake varDecl to reuse existing parser
@@ -735,8 +779,7 @@ static AST *parseStatement(ReaParser *p) {
     if (p->current.type == REA_TOKEN_RETURN) {
         return parseReturn(p);
     }
-    if (p->current.type == REA_TOKEN_INT || p->current.type == REA_TOKEN_FLOAT ||
-        p->current.type == REA_TOKEN_STR || p->current.type == REA_TOKEN_BOOL) {
+    if (isTypeToken(p->current.type)) {
         return parseVarDecl(p);
     }
     AST *expr = parseExpression(p);


### PR DESCRIPTION
## Summary
- map additional Rea type tokens (`int64`, `int32`, `int16`, `int8`, `float32`, `long double`, `char`, `byte`, `text`, `mstream`, `void`) to internal VarType values
- tokenize new keywords and handle multi-word `long double`
- cover new primitive keywords with regression test

## Testing
- `cmake --build .`
- `./Tests/run_rea_tests.sh` *(fails: field_access_assign, field_access_read, method_this_assign)*
- `tmpfile=$(mktemp); ./build/bin/rea --dump-bytecode-only Tests/rea/types.rea 2> $tmpfile; perl -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]|\e\][^\a]*(?:\a|\e\\)//g' $tmpfile > $tmpfile.clean; diff -u Tests/rea/types.err $tmpfile.clean`


------
https://chatgpt.com/codex/tasks/task_e_68bcc6197a8c832a8c50dc921723c994