### PR TITLE
Support constructor shorthand in Rea frontend

### DIFF
--- a/Tests/rea/constructor_init.err
+++ b/Tests/rea/constructor_init.err
@@ -1,0 +1,29 @@
+--- Compiling Main Program AST to Bytecode ---
+== Disassembly: Tests/rea/constructor_init.rea ==
+Offset Line Opcode           Operand  Value / Target (Args)
+------ ---- ---------------- -------- --------------------------
+0000    2 OP_DEFINE_GLOBAL NameIdx:0   'p' Type:POINTER ('Point')
+0005    | OP_CONSTANT         1 'Point'
+0007    | OP_CALL_BUILTIN      2 'newobj' (1 args)
+0011    | OP_DUP
+0012    | OP_CONSTANT         3 '5'
+0014    | OP_CALL          0025 (Point) (2 args)
+0020    | OP_SET_GLOBAL       0 'p'
+0022    1 OP_JUMP             9 (to 0034)
+
+--- Procedure point_point (at 0025) ---
+0025    | OP_GET_LOCAL        1 (slot)
+0027    | OP_GET_LOCAL_ADDRESS    0 (slot)
+0029    | OP_GET_FIELD_ADDRESS    4 'x'
+0031    | OP_SWAP
+0032    | OP_SET_INDIRECT
+0033    | OP_RETURN
+0034    0 OP_HALT
+== End Disassembly: Tests/rea/constructor_init.rea ==
+
+Constants (5):\n  0000: STR   "p"
+  0001: STR   "Point"
+  0002: STR   "newobj"
+  0003: INT   5
+  0004: STR   "x"
+

--- a/Tests/rea/constructor_init.rea
+++ b/Tests/rea/constructor_init.rea
@@ -1,0 +1,2 @@
+class Point { int x; Point(int v) { this.x = v; } }
+Point p = new Point(5);

--- a/Tests/rea/switch_stmt.err
+++ b/Tests/rea/switch_stmt.err
@@ -1,0 +1,40 @@
+--- Compiling Main Program AST to Bytecode ---
+== Disassembly: Tests/rea/switch_stmt.rea ==
+Offset Line Opcode           Operand  Value / Target (Args)
+------ ---- ---------------- -------- --------------------------
+0000    1 OP_DEFINE_GLOBAL NameIdx:0   'x' Type:INT64 ('int')
+0005    | OP_CONSTANT         2 '2'
+0007    | OP_SET_GLOBAL       0 'x'
+0009    2 OP_GET_GLOBAL       0 'x'
+0011    | OP_DUP
+0012    3 OP_CONSTANT         3 '1'
+0014    2 OP_EQUAL
+0015    | OP_JUMP_IF_FALSE   12 (to 0030)
+0018    | OP_POP
+0019    4 OP_CONSTANT         3 '1'
+0021    | OP_CONSTANT         3 '1'
+0023    | OP_CALL_BUILTIN      4 'write' (2 args)
+0027    2 OP_JUMP            28 (to 0058)
+0030    | OP_DUP
+0031    6 OP_CONSTANT         2 '2'
+0033    2 OP_EQUAL
+0034    | OP_JUMP_IF_FALSE   12 (to 0049)
+0037    | OP_POP
+0038    7 OP_CONSTANT         3 '1'
+0040    | OP_CONSTANT         2 '2'
+0042    | OP_CALL_BUILTIN      4 'write' (2 args)
+0046    2 OP_JUMP             9 (to 0058)
+0049    | OP_POP
+0050   10 OP_CONSTANT         3 '1'
+0052    | OP_CONSTANT         5 '3'
+0054    | OP_CALL_BUILTIN      4 'write' (2 args)
+0058    0 OP_HALT
+== End Disassembly: Tests/rea/switch_stmt.rea ==
+
+Constants (6):\n  0000: STR   "x"
+  0001: STR   "int"
+  0002: INT   2
+  0003: INT   1
+  0004: STR   "write"
+  0005: INT   3
+

--- a/Tests/rea/switch_stmt.rea
+++ b/Tests/rea/switch_stmt.rea
@@ -1,0 +1,11 @@
+int x = 2;
+switch (x) {
+  case 1:
+    writeln(1);
+    break;
+  case 2:
+    writeln(2);
+    break;
+  default:
+    writeln(3);
+}


### PR DESCRIPTION
## Summary
- allow constructors to omit return types in Rea parser
- type implicit `this` parameter when expanding `super` calls
- add regression test for constructing and initializing an object

## Testing
- `cmake --build build --target rea`
- `Tests/run_rea_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bcd6dc9a28832a9b94d127d17c3d19