### PR TITLE
docs: add Makefile for architecture diagram

### DIFF
--- a/Docs/Makefile
+++ b/Docs/Makefile
@@ -1,0 +1,9 @@
+.PHONY: all clean
+
+all: Architecture.png
+
+Architecture.png: Architecture
+	mmdc -i Architecture -o Architecture.png --width 1920 --height 1080
+
+clean:
+	rm -f Architecture.png


### PR DESCRIPTION
## Summary
- add Makefile in `Docs` to build `Architecture.png` from `Architecture` using mermaid CLI

## Testing
- `make -C Docs` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `make -C Tests test` *(fails: ../build/bin/pascal: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcdf5cfe84832a877d0078784ee64a