### PR TITLE
feat(rea): support character literals

### DIFF
--- a/src/rea/LANGUAGE_SPEC.md
+++ b/src/rea/LANGUAGE_SPEC.md
@@ -30,8 +30,9 @@ The Rea language is a strongly typed, class-based, object-oriented language.
     * **Other:** `const`, `#import`.
 * **Operators:** Common arithmetic and comparison operators are supported,
   including `+`, `-`, `*`, `/`, `%`, `==`, `!=`, `<`, `<=`, `>`, and `>=`.
-* **Literals:** Integer, floating-point, character, and string literals will
-  follow the C-Like language specification.
+* **Literals:** Integer, floating-point, character, and string literals follow
+  C-Like rules. Characters use single quotes (e.g., `'a'`) while strings use
+  double quotes (e.g., "hi"); both forms support standard escape sequences.
 
 #### 1.2. Data Types
 

--- a/src/rea/lexer.c
+++ b/src/rea/lexer.c
@@ -200,6 +200,13 @@ ReaToken reaNextToken(ReaLexer *lexer) {
             }
             if (peek(lexer) == '"') advance(lexer);
             return makeToken(lexer, REA_TOKEN_STRING, start);
+        case '\'':
+            while (peek(lexer) != '\'' && peek(lexer) != '\0') {
+                if (peek(lexer) == '\n') lexer->line++;
+                advance(lexer);
+            }
+            if (peek(lexer) == '\'') advance(lexer);
+            return makeToken(lexer, REA_TOKEN_STRING, start);
         default:
             break;
     }

--- a/src/rea/parser.c
+++ b/src/rea/parser.c
@@ -233,7 +233,8 @@ static AST *parseFactor(ReaParser *p) {
         Token *tok = newToken(TOKEN_STRING_CONST, lex, p->current.line, 0);
         free(lex);
         AST *node = newASTNode(AST_STRING, tok);
-        setTypeAST(node, TYPE_STRING);
+        VarType vtype = (p->current.start[0] == '\'' && (len - 2 == 1)) ? TYPE_CHAR : TYPE_STRING;
+        setTypeAST(node, vtype);
         reaAdvance(p);
         return node;
     } else if (p->current.type == REA_TOKEN_TRUE || p->current.type == REA_TOKEN_FALSE) {


### PR DESCRIPTION
## Summary
- teach the Rea lexer to recognize single-quoted character literals
- distinguish single-quoted chars from strings in the parser and tag them as `TYPE_CHAR`
- document quoting rules for character and string literals in the language spec

## Testing
- `cmake -S . -B build`
- `cmake --build build --target rea -j 4`
- `build/bin/rea --dump-ast-json /tmp/test_char.rea`

------
https://chatgpt.com/codex/tasks/task_e_68bce15c5da4832abd36683f55294765