### PR TITLE
docs: expand architecture overview

### DIFF
--- a/Docs/Architecture
+++ b/Docs/Architecture
@@ -1,21 +1,29 @@
 flowchart LR
+    Source[Source files] --> FrontEnds
     subgraph FrontEnds
-        Pascal
-        CLike
-        Tiny
+        Pascal[Pascal]
+        CLike[C-like]
+        Tiny[Tiny]
     end
 
-    FrontEnds --> AST[AST & semantics]
+    FrontEnds --> AST[AST & semantic analysis]
     AST --> Compiler[Bytecode compiler]
-    Compiler --> Bytecode
+    StdLib[Standard library units] --> Compiler
+    Compiler --> Bytecode[Bytecode]
+    Bytecode --> Cache[Bytecode cache]
+    Cache --> VM
     Bytecode --> VM[Stack-based VM]
 
-    VM --> Backend[Core built-ins]
-    Backend --> SDL[SDL2]
-    Backend --> libcurl
+    VM --> CoreBuiltins[Core built-ins]
+    CoreBuiltins --> SDL[SDL2]
+    CoreBuiltins --> Curl[libcurl]
     VM --> ExtBuiltins[Extended built-ins]
 
-    Core[Utilities & symbol tables] --- FrontEnds
+    subgraph Core["Core utilities"]
+        Symbols[Symbol tables]
+        Helpers[Lists & helpers]
+    end
+    Core --- FrontEnds
     Core --- Compiler
     Core --- VM
 


### PR DESCRIPTION
## Summary
- expand architecture diagram with source flow, standard libraries, bytecode cache, and core utilities
- retain Architecture.png to avoid PR creation errors

## Testing
- ⚠️ `make clean && make` (fails: libatk-1.0.so.0: cannot open shared object file)
- ⚠️ `mmdc -p /tmp/pptr.json -i Architecture -o /tmp/Architecture.png --width 1920 --height 1080` (fails: libatk-1.0.so.0 missing)


------
https://chatgpt.com/codex/tasks/task_e_68bce0a75530832aa9c734f743e0a80b