### PR TITLE
feat(rea): support character literals

### DIFF
--- a/src/rea/LANGUAGE_SPEC.md
+++ b/src/rea/LANGUAGE_SPEC.md
@@ -30,8 +30,9 @@ The Rea language is a strongly typed, class-based, object-oriented language.
     * **Other:** `const`, `#import`.
 * **Operators:** Common arithmetic and comparison operators are supported,
   including `+`, `-`, `*`, `/`, `%`, `==`, `!=`, `<`, `<=`, `>`, and `>=`.
-* **Literals:** Integer, floating-point, character, and string literals will
-  follow the C-Like language specification.
+* **Literals:** Integer, floating-point, character, and string literals follow
+  C-Like rules. Characters use single quotes (e.g., `'a'`) while strings use
+  double quotes (e.g., "hi"); both forms support standard escape sequences.
 
 #### 1.2. Data Types
 

--- a/src/rea/lexer.c
+++ b/src/rea/lexer.c
@@ -194,11 +194,34 @@ ReaToken reaNextToken(ReaLexer *lexer) {
             while (isAlpha(peek(lexer))) advance(lexer);
             return makeToken(lexer, REA_TOKEN_IMPORT, start);
         case '"':
-            while (peek(lexer) != '"' && peek(lexer) != '\0') {
-                if (peek(lexer) == '\n') lexer->line++;
-                advance(lexer);
+            while (peek(lexer) != '\0') {
+                char ch = peek(lexer);
+                if (ch == '\n') lexer->line++;
+                if (ch == '\\') {
+                    advance(lexer);
+                    if (peek(lexer) != '\0') advance(lexer);
+                } else if (ch == '"') {
+                    break;
+                } else {
+                    advance(lexer);
+                }
             }
             if (peek(lexer) == '"') advance(lexer);
+            return makeToken(lexer, REA_TOKEN_STRING, start);
+        case '\'':
+            while (peek(lexer) != '\0') {
+                char ch = peek(lexer);
+                if (ch == '\n') lexer->line++;
+                if (ch == '\\') {
+                    advance(lexer);
+                    if (peek(lexer) != '\0') advance(lexer);
+                } else if (ch == '\'') {
+                    break;
+                } else {
+                    advance(lexer);
+                }
+            }
+            if (peek(lexer) == '\'') advance(lexer);
             return makeToken(lexer, REA_TOKEN_STRING, start);
         default:
             break;

--- a/src/rea/parser.c
+++ b/src/rea/parser.c
@@ -67,6 +67,37 @@ static AST *rewriteContinueWithPost(AST *node, AST *postStmt) {
     return node;
 }
 
+// Unescape standard escape sequences within a string literal segment
+static char *reaUnescapeString(const char *src, size_t len, size_t *out_len) {
+    char *buf = (char *)malloc(len + 1);
+    if (!buf) return NULL;
+    size_t j = 0;
+    for (size_t i = 0; i < len; i++) {
+        char c = src[i];
+        if (c == '\\' && i + 1 < len) {
+            char n = src[++i];
+            switch (n) {
+                case 'n': buf[j++] = '\n'; break;
+                case 'r': buf[j++] = '\r'; break;
+                case 't': buf[j++] = '\t'; break;
+                case '\\': buf[j++] = '\\'; break;
+                case 0x27: buf[j++] = 0x27; break;
+                case '"': buf[j++] = '"'; break;
+                default:
+                    // Preserve unknown escape sequences verbatim
+                    buf[j++] = '\\';
+                    buf[j++] = n;
+                    break;
+            }
+        } else {
+            buf[j++] = c;
+        }
+    }
+    buf[j] = '\0';
+    if (out_len) *out_len = j;
+    return buf;
+}
+
 static AST *parseFactor(ReaParser *p) {
     if (p->current.type == REA_TOKEN_SUPER) {
         // super(...) or super.method(...)
@@ -226,14 +257,15 @@ static AST *parseFactor(ReaParser *p) {
     } else if (p->current.type == REA_TOKEN_STRING) {
         size_t len = p->current.length;
         if (len < 2) return NULL;
-        char *lex = (char *)malloc(len - 1);
+        size_t inner_len = len - 2;
+        size_t unesc_len = 0;
+        char *lex = reaUnescapeString(p->current.start + 1, inner_len, &unesc_len);
         if (!lex) return NULL;
-        memcpy(lex, p->current.start + 1, len - 2);
-        lex[len - 2] = '\0';
         Token *tok = newToken(TOKEN_STRING_CONST, lex, p->current.line, 0);
         free(lex);
         AST *node = newASTNode(AST_STRING, tok);
-        setTypeAST(node, TYPE_STRING);
+        VarType vtype = (p->current.start[0] == '\'' && unesc_len == 1) ? TYPE_CHAR : TYPE_STRING;
+        setTypeAST(node, vtype);
         reaAdvance(p);
         return node;
     } else if (p->current.type == REA_TOKEN_TRUE || p->current.type == REA_TOKEN_FALSE) {


### PR DESCRIPTION
## Summary
- teach the Rea lexer to recognize single-quoted character literals
- distinguish single-quoted chars from strings in the parser and tag them as `TYPE_CHAR`
- document quoting rules for character and string literals in the language spec
- normalize escape sequences before tagging so escaped char literals remain `TYPE_CHAR`
- preserve unknown escape sequences when unescaping so literals like `\0` or `\x41` aren't altered
- skip escaped quotes in the lexer so sequences like `\'` or `\"` don't prematurely terminate literals

## Testing
- `cmake -S . -B build`
- `cmake --build build --target rea -j 4`
- `build/bin/rea --dump-ast-json /tmp/test_char.rea`


------
https://chatgpt.com/codex/tasks/task_e_68bce15c5da4832abd36683f55294765