### PR TITLE
feat(rea): support character literals

### DIFF
--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -770,7 +770,7 @@ void annotateTypes(AST *node, AST *currentScopeNode, AST *globalProgramNode) {
                 node->var_type = (node->token && node->token->type == TOKEN_REAL_CONST) ? TYPE_REAL : TYPE_INTEGER;
                 break;
             case AST_STRING:
-                if (node->token && node->token->value && strlen(node->token->value) == 1) {
+                if (node->token && node->token->value && node->i_val == 1) {
                     node->var_type = TYPE_CHAR;
                     node->type_def = lookupType("char");
                 } else {

--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -477,6 +477,29 @@ Value makeString(const char *val) {
     return v;
 }
 
+Value makeStringLen(const char *val, size_t len) {
+    Value v;
+    memset(&v, 0, sizeof(Value));
+    v.type = TYPE_STRING;
+    v.max_length = (int)len;
+    if (val && len > 0) {
+        v.s_val = (char*)malloc(len + 1);
+        if (!v.s_val) {
+            fprintf(stderr, "FATAL: Memory allocation failed in makeStringLen\n");
+            EXIT_FAILURE_HANDLER();
+        }
+        memcpy(v.s_val, val, len);
+        v.s_val[len] = '\0';
+    } else {
+        v.s_val = strdup("");
+        if (!v.s_val) {
+            fprintf(stderr, "FATAL: Memory allocation failed in makeStringLen (empty)\n");
+            EXIT_FAILURE_HANDLER();
+        }
+    }
+    return v;
+}
+
 Value makeChar(int c) {
     Value v;
     memset(&v, 0, sizeof(Value));

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -199,6 +199,7 @@ Value makeNil(void);
 // Used by the 'new' builtin.
 Value makePointer(void* address, AST* base_type_node); // <<< ADD THIS PROTOTYPE >>>
 Value makeString(const char *val);
+Value makeStringLen(const char *val, size_t len);
 Value makeChar(int c);
 Value makeBoolean(int b);
 Value makeFile(FILE *f);

--- a/src/rea/LANGUAGE_SPEC.md
+++ b/src/rea/LANGUAGE_SPEC.md
@@ -30,8 +30,11 @@ The Rea language is a strongly typed, class-based, object-oriented language.
     * **Other:** `const`, `#import`.
 * **Operators:** Common arithmetic and comparison operators are supported,
   including `+`, `-`, `*`, `/`, `%`, `==`, `!=`, `<`, `<=`, `>`, and `>=`.
-* **Literals:** Integer, floating-point, character, and string literals will
-  follow the C-Like language specification.
+* **Literals:** Integer, floating-point, character, and string literals follow
+  C-Like rules. Characters use single quotes (e.g., `'a'`) while strings use
+  double quotes (e.g., "hi"); both forms support standard escape sequences
+  such as `\n`, `\r`, `\t`, `\\`, `\'`, `\"`, and numeric forms like
+  `\0` or `\x41`.
 
 #### 1.2. Data Types
 

--- a/src/rea/lexer.c
+++ b/src/rea/lexer.c
@@ -194,11 +194,34 @@ ReaToken reaNextToken(ReaLexer *lexer) {
             while (isAlpha(peek(lexer))) advance(lexer);
             return makeToken(lexer, REA_TOKEN_IMPORT, start);
         case '"':
-            while (peek(lexer) != '"' && peek(lexer) != '\0') {
-                if (peek(lexer) == '\n') lexer->line++;
-                advance(lexer);
+            while (peek(lexer) != '\0') {
+                char ch = peek(lexer);
+                if (ch == '\n') lexer->line++;
+                if (ch == '\\') {
+                    advance(lexer);
+                    if (peek(lexer) != '\0') advance(lexer);
+                } else if (ch == '"') {
+                    break;
+                } else {
+                    advance(lexer);
+                }
             }
             if (peek(lexer) == '"') advance(lexer);
+            return makeToken(lexer, REA_TOKEN_STRING, start);
+        case '\'':
+            while (peek(lexer) != '\0') {
+                char ch = peek(lexer);
+                if (ch == '\n') lexer->line++;
+                if (ch == '\\') {
+                    advance(lexer);
+                    if (peek(lexer) != '\0') advance(lexer);
+                } else if (ch == '\'') {
+                    break;
+                } else {
+                    advance(lexer);
+                }
+            }
+            if (peek(lexer) == '\'') advance(lexer);
             return makeToken(lexer, REA_TOKEN_STRING, start);
         default:
             break;

--- a/src/rea/parser.c
+++ b/src/rea/parser.c
@@ -67,6 +67,69 @@ static AST *rewriteContinueWithPost(AST *node, AST *postStmt) {
     return node;
 }
 
+// Unescape standard escape sequences within a string literal segment
+static char *reaUnescapeString(const char *src, size_t len, size_t *out_len) {
+    char *buf = (char *)malloc(len + 1);
+    if (!buf) return NULL;
+    size_t j = 0;
+    for (size_t i = 0; i < len; i++) {
+        char c = src[i];
+        if (c == '\\' && i + 1 < len) {
+            char n = src[++i];
+            switch (n) {
+                case 'n': buf[j++] = '\n'; break;
+                case 'r': buf[j++] = '\r'; break;
+                case 't': buf[j++] = '\t'; break;
+                case '\\': buf[j++] = '\\'; break;
+                case 0x27: buf[j++] = 0x27; break;
+                case '"': buf[j++] = '"'; break;
+                case 'x':
+                case 'X': {
+                    int val = 0;
+                    size_t digits = 0;
+                    while (i + 1 < len && digits < 2) {
+                        char h = src[i + 1];
+                        if ((h >= '0' && h <= '9') || (h >= 'a' && h <= 'f') || (h >= 'A' && h <= 'F')) {
+                            i++;
+                            digits++;
+                            val = val * 16 + (h >= '0' && h <= '9' ? h - '0' : (h & 0x5f) - 'A' + 10);
+                        } else {
+                            break;
+                        }
+                    }
+                    if (digits > 0) {
+                        buf[j++] = (char)val;
+                    } else {
+                        buf[j++] = '\\';
+                        buf[j++] = n;
+                    }
+                    break;
+                }
+                default:
+                    if (n >= '0' && n <= '7') {
+                        int val = n - '0';
+                        size_t digits = 1;
+                        while (i + 1 < len && digits < 3 && src[i + 1] >= '0' && src[i + 1] <= '7') {
+                            val = (val << 3) + (src[++i] - '0');
+                            digits++;
+                        }
+                        buf[j++] = (char)val;
+                    } else {
+                        // Preserve unknown escape sequences verbatim
+                        buf[j++] = '\\';
+                        buf[j++] = n;
+                    }
+                    break;
+            }
+        } else {
+            buf[j++] = c;
+        }
+    }
+    buf[j] = '\0';
+    if (out_len) *out_len = j;
+    return buf;
+}
+
 static AST *parseFactor(ReaParser *p) {
     if (p->current.type == REA_TOKEN_SUPER) {
         // super(...) or super.method(...)
@@ -226,14 +289,20 @@ static AST *parseFactor(ReaParser *p) {
     } else if (p->current.type == REA_TOKEN_STRING) {
         size_t len = p->current.length;
         if (len < 2) return NULL;
-        char *lex = (char *)malloc(len - 1);
+        size_t inner_len = len - 2;
+        size_t unesc_len = 0;
+        char *lex = reaUnescapeString(p->current.start + 1, inner_len, &unesc_len);
         if (!lex) return NULL;
-        memcpy(lex, p->current.start + 1, len - 2);
-        lex[len - 2] = '\0';
-        Token *tok = newToken(TOKEN_STRING_CONST, lex, p->current.line, 0);
-        free(lex);
+        Token *tok = (Token*)malloc(sizeof(Token));
+        if (!tok) { free(lex); return NULL; }
+        tok->type = TOKEN_STRING_CONST;
+        tok->value = lex; // already NUL-terminated by reaUnescapeString
+        tok->line = p->current.line;
+        tok->column = 0;
         AST *node = newASTNode(AST_STRING, tok);
-        setTypeAST(node, TYPE_STRING);
+        node->i_val = (int)unesc_len; // track literal length explicitly
+        VarType vtype = (p->current.start[0] == '\'' && unesc_len == 1) ? TYPE_CHAR : TYPE_STRING;
+        setTypeAST(node, vtype);
         reaAdvance(p);
         return node;
     } else if (p->current.type == REA_TOKEN_TRUE || p->current.type == REA_TOKEN_FALSE) {


### PR DESCRIPTION
## Summary
- teach the Rea lexer to recognize single-quoted character literals
- distinguish single-quoted chars from strings in the parser and tag them as `TYPE_CHAR`
- document quoting rules and numeric escape sequences for character and string literals in the language spec
- normalize escape sequences before tagging so escaped char literals remain `TYPE_CHAR`
- preserve unknown escape sequences when unescaping so literals like `\0` or `\x41` aren't altered
- skip escaped quotes in the lexer so sequences like `\'` or `\"` don't prematurely terminate literals
- decode octal (`\0`) and hexadecimal (`\xNN`) escapes so numeric char codes are handled as single characters
- track literal length separately and store unescaped bytes so `\0` escapes no longer truncate token values

## Testing
- `cmake -S . -B build`
- `cmake --build build --target rea -j 4`
- `build/bin/rea --dump-ast-json /tmp/test_char.rea`


------
https://chatgpt.com/codex/tasks/task_e_68bce15c5da4832abd36683f55294765