### PR TITLE
Handle array-based vtable for method dispatch

### DIFF
--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -3418,23 +3418,23 @@ comparison_error_label:
                 }
 
                 FieldValue* current = objVal->record_val;
-                uint16_t* vtable_ptr = NULL;
+                Value* vtable_arr = NULL;
                 while (current) {
                     if (strcmp(current->name, "__vtable") == 0) {
-                        if (current->value.type == TYPE_POINTER) {
-                            vtable_ptr = (uint16_t*)current->value.ptr_val;
+                        if (current->value.type == TYPE_ARRAY) {
+                            vtable_arr = current->value.array_val;
                         }
                         break;
                     }
                     current = current->next;
                 }
 
-                if (!vtable_ptr) {
+                if (!vtable_arr) {
                     runtimeError(vm, "VM Error: Object missing V-table.");
                     return INTERPRET_RUNTIME_ERROR;
                 }
 
-                uint16_t target_address = vtable_ptr[method_index];
+                uint16_t target_address = (uint16_t)vtable_arr[method_index].u_val;
                 if (vm->frameCount >= VM_CALL_STACK_MAX) {
                     runtimeError(vm, "VM Error: Call stack overflow.");
                     return INTERPRET_RUNTIME_ERROR;
@@ -3442,7 +3442,7 @@ comparison_error_label:
                 CallFrame* frame = &vm->frames[vm->frameCount++];
                 frame->return_address = vm->ip;
                 frame->slots = vm->stackTop - declared_arity - 1;
-                frame->vtable = vtable_ptr;
+                frame->vtable = vtable_arr;
 
                 Symbol* method_symbol = NULL;
                 const char* className = NULL;

--- a/src/vm/vm.h
+++ b/src/vm/vm.h
@@ -57,7 +57,7 @@ typedef struct {
     uint8_t upvalue_count;
     Value** upvalues;
     bool discard_result_on_return; // If true, drop any function result on return
-    uint16_t* vtable;            // Reference to class V-table when executing a method
+    Value* vtable;               // Reference to class V-table when executing a method
 } CallFrame;
 
 // Thread structure representing a lightweight VM thread


### PR DESCRIPTION
## Summary
- read hidden `__vtable` field as array of method addresses
- store array pointer in call frame for later lookups

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: static declaration of `emitConstant` follows non-static declaration)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf103bcc8832a88dd1e2c0e1913a5