### PR TITLE
Fix field offset handling for linked records

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -1161,6 +1161,8 @@ static void compileLValue(AST* node, BytecodeChunk* chunk, int current_line_appr
                 break;
             }
 
+            fieldOffset++;
+
             if (fieldOffset <= 0xFF) {
                 writeBytecodeChunk(chunk, OP_GET_FIELD_OFFSET, line);
                 writeBytecodeChunk(chunk, (uint8_t)fieldOffset, line);
@@ -1225,7 +1227,7 @@ static void compileLValue(AST* node, BytecodeChunk* chunk, int current_line_appr
             if (!node || !node->token || !node->token->value) { break; }
             const char* className = node->token->value;
             AST* classType = lookupType(className);
-            int fieldCount = getRecordFieldCount(classType);
+            int fieldCount = getRecordFieldCount(classType) + 1;
             if (fieldCount <= 0xFF) {
                 writeBytecodeChunk(chunk, OP_ALLOC_OBJECT, line);
                 writeBytecodeChunk(chunk, (uint8_t)fieldCount, line);
@@ -2917,7 +2919,7 @@ static void compileRValue(AST* node, BytecodeChunk* chunk, int current_line_appr
             if (!node || !node->token || !node->token->value) { break; }
             const char* className = node->token->value;
             AST* classType = lookupType(className);
-            int fieldCount = getRecordFieldCount(classType);
+            int fieldCount = getRecordFieldCount(classType) + 1;
             if (fieldCount <= 0xFF) {
                 writeBytecodeChunk(chunk, OP_ALLOC_OBJECT, line);
                 writeBytecodeChunk(chunk, (uint8_t)fieldCount, line);

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -2221,8 +2221,14 @@ comparison_error_label:
                     return INTERPRET_RUNTIME_ERROR;
                 }
 
-                FieldValue* fields = record_struct_ptr->record_val;
-                FieldValue* target = &fields[field_index];
+                FieldValue* target = record_struct_ptr->record_val;
+                for (uint16_t i = 0; i < field_index && target; i++) {
+                    target = target->next;
+                }
+                if (target == NULL) {
+                    runtimeError(vm, "VM Error: Field index out of bounds.");
+                    return INTERPRET_RUNTIME_ERROR;
+                }
                 Value popped_base_val = pop(vm);
                 freeValue(&popped_base_val);
                 push(vm, makePointer(&target->value, NULL));
@@ -2252,8 +2258,14 @@ comparison_error_label:
                     return INTERPRET_RUNTIME_ERROR;
                 }
 
-                FieldValue* fields = record_struct_ptr->record_val;
-                FieldValue* target = &fields[field_index];
+                FieldValue* target = record_struct_ptr->record_val;
+                for (uint16_t i = 0; i < field_index && target; i++) {
+                    target = target->next;
+                }
+                if (target == NULL) {
+                    runtimeError(vm, "VM Error: Field index out of bounds.");
+                    return INTERPRET_RUNTIME_ERROR;
+                }
                 Value popped_base_val = pop(vm);
                 freeValue(&popped_base_val);
                 push(vm, makePointer(&target->value, NULL));


### PR DESCRIPTION
## Summary
- Traverse record fields via linked list for offset opcodes
- Reserve hidden `__vtable` slot when allocating objects and shift field offsets

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `(cd Tests && ./run_all_tests)` *(fails: field_access_assign, field_access_read, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf7aa8a2c832a990fa1d2c1c2a9c9