### PR TITLE
Avoid shifting record field offsets

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -1161,8 +1161,6 @@ static void compileLValue(AST* node, BytecodeChunk* chunk, int current_line_appr
                 break;
             }
 
-            fieldOffset++;
-
             if (fieldOffset <= 0xFF) {
                 writeBytecodeChunk(chunk, OP_GET_FIELD_OFFSET, line);
                 writeBytecodeChunk(chunk, (uint8_t)fieldOffset, line);


### PR DESCRIPTION
## Summary
- remove unconditional field offset increment in field access compilation

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `(cd Tests && ./run_all_tests)` *(fails: BytecodeVerificationTest, InvalidArrayBounds, PointerTortureTest, constructor_init, field_access_assign, field_access_read, method_this_assign, new_alloc, new_assign_ptr)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfb080648832a801e3715d5c83682