### PR TITLE
Fix pointer field access and update Rea tests

### DIFF
--- a/Tests/rea/constructor_init.err
+++ b/Tests/rea/constructor_init.err
@@ -3,27 +3,24 @@
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
 0000    2 OP_DEFINE_GLOBAL NameIdx:0   'p' Type:POINTER ('Point')
-0005    | OP_CONSTANT         1 'Point'
-0007    | OP_CALL_BUILTIN      2 'newobj' (1 args)
-0011    | OP_DUP
-0012    | OP_CONSTANT         3 '5'
-0014    | OP_CALL          0025 (Point) (2 args)
-0020    | OP_SET_GLOBAL       0 'p'
-0022    1 OP_JUMP             9 (to 0034)
+0005    | OP_ALLOC_OBJECT     2 (fields)
+0007    | OP_DUP
+0008    | OP_CONSTANT         2 '5'
+0010    | OP_CALL          0021 (Point) (2 args)
+0016    | OP_SET_GLOBAL       0 'p'
+0018    1 OP_JUMP             9 (to 0030)
 
---- Procedure point_point (at 0025) ---
-0025    | OP_GET_LOCAL        1 (slot)
-0027    | OP_GET_LOCAL_ADDRESS    0 (slot)
-0029    | OP_GET_FIELD_ADDRESS    4 'x'
-0031    | OP_SWAP
-0032    | OP_SET_INDIRECT
-0033    | OP_RETURN
-0034    0 OP_HALT
+--- Procedure point_point (at 0021) ---
+0021    | OP_GET_LOCAL        1 (slot)
+0023    | OP_GET_LOCAL_ADDRESS    0 (slot)
+0025    | OP_GET_FIELD_OFFSET    1 (index)
+0027    | OP_SWAP
+0028    | OP_SET_INDIRECT
+0029    | OP_RETURN
+0030    0 OP_HALT
 == End Disassembly: Tests/rea/constructor_init.rea ==
 
-Constants (5):\n  0000: STR   "p"
+Constants (3):\n  0000: STR   "p"
   0001: STR   "Point"
-  0002: STR   "newobj"
-  0003: INT   5
-  0004: STR   "x"
+  0002: INT   5
 

--- a/Tests/rea/field_access_assign.err
+++ b/Tests/rea/field_access_assign.err
@@ -2,13 +2,16 @@
 == Disassembly: Tests/rea/field_access_assign.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
-0000    3 OP_CONSTANT         0 '1'
-0002    | OP_GET_GLOBAL       1 'p'
-0004    | OP_SET_FIELD        2 'x'
-0006    0 OP_HALT
+0000    2 OP_DEFINE_GLOBAL NameIdx:0   'p' Type:POINTER ('Point')
+0005    4 OP_CONSTANT         2 '1'
+0007    | OP_GET_GLOBAL_ADDRESS    0 'p'
+0009    | OP_GET_FIELD_OFFSET    1 (index)
+0011    | OP_SWAP
+0012    | OP_SET_INDIRECT
+0013    0 OP_HALT
 == End Disassembly: Tests/rea/field_access_assign.rea ==
 
-Constants (3):\n  0000: INT   1
-  0001: STR   "p"
-  0002: STR   "x"
+Constants (3):\n  0000: STR   "p"
+  0001: STR   "Point"
+  0002: INT   1
 

--- a/Tests/rea/field_access_assign.rea
+++ b/Tests/rea/field_access_assign.rea
@@ -1,4 +1,5 @@
 class Point { int x; int y; }
+Point p;
 // LHS field assignment
 p.x = 1;
 

--- a/Tests/rea/field_access_read.err
+++ b/Tests/rea/field_access_read.err
@@ -2,15 +2,17 @@
 == Disassembly: Tests/rea/field_access_read.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
-0000    3 OP_DEFINE_GLOBAL NameIdx:0   'a' Type:INT64 ('int')
-0005    | OP_GET_GLOBAL       2 'p'
-0007    | OP_GET_FIELD        3 'x'
-0009    | OP_SET_GLOBAL       0 'a'
-0011    0 OP_HALT
+0000    2 OP_DEFINE_GLOBAL NameIdx:0   'p' Type:POINTER ('Point')
+0005    4 OP_DEFINE_GLOBAL NameIdx:2   'a' Type:INT64 ('int')
+0010    | OP_GET_GLOBAL_ADDRESS    0 'p'
+0012    | OP_GET_FIELD_OFFSET    1 (index)
+0014    | OP_GET_INDIRECT
+0015    | OP_SET_GLOBAL       2 'a'
+0017    0 OP_HALT
 == End Disassembly: Tests/rea/field_access_read.rea ==
 
-Constants (4):\n  0000: STR   "a"
-  0001: STR   "int"
-  0002: STR   "p"
-  0003: STR   "x"
+Constants (4):\n  0000: STR   "p"
+  0001: STR   "Point"
+  0002: STR   "a"
+  0003: STR   "int"
 

--- a/Tests/rea/field_access_read.rea
+++ b/Tests/rea/field_access_read.rea
@@ -1,4 +1,5 @@
 class Point { int x; int y; }
-// Read field as rvalue (no declaration for p; we only dump bytecode)
+Point p;
+// Read field as rvalue
 int a = p.x;
 

--- a/Tests/rea/method_this_assign.err
+++ b/Tests/rea/method_this_assign.err
@@ -2,18 +2,20 @@
 == Disassembly: Tests/rea/method_this_assign.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
-0000    3 OP_JUMP            11 (to 0014)
+0000    0 OP_CONSTANT         0 'Value type ARRAY'
+0002    | OP_DEFINE_GLOBAL NameIdx:1   'point_vtable' Type:UINT64 
 
---- Function point_setx (at 0003) ---
-0003    4 OP_GET_LOCAL        1 (slot)
-0005    | OP_GET_LOCAL_ADDRESS    0 (slot)
-0007    | OP_GET_FIELD_ADDRESS    0 'x'
-0009    | OP_SWAP
-0010    | OP_SET_INDIRECT
-0011    3 OP_GET_LOCAL        2 (slot)
-0013    | OP_RETURN
-0014    0 OP_HALT
+--- Function point_setx (at 0007) ---
+0007    4 OP_GET_LOCAL        1 (slot)
+0009    | OP_GET_LOCAL_ADDRESS    0 (slot)
+0011    | OP_GET_FIELD_OFFSET    1 (index)
+0013    | OP_SWAP
+0014    | OP_SET_INDIRECT
+0015    3 OP_GET_LOCAL        2 (slot)
+0017    | OP_RETURN
+0018    0 OP_HALT
 == End Disassembly: Tests/rea/method_this_assign.rea ==
 
-Constants (1):\n  0000: STR   "x"
+Constants (2):\n  0000: Value type ARRAY
+  0001: STR   "point_vtable"
 

--- a/Tests/rea/new_alloc.err
+++ b/Tests/rea/new_alloc.err
@@ -3,13 +3,11 @@
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
 0000    3 OP_DEFINE_GLOBAL NameIdx:0   'p' Type:POINTER ('Point')
-0005    | OP_CONSTANT         1 'Point'
-0007    | OP_CALL_BUILTIN      2 'newobj' (1 args)
-0011    | OP_SET_GLOBAL       0 'p'
-0013    0 OP_HALT
+0005    | OP_ALLOC_OBJECT     3 (fields)
+0007    | OP_SET_GLOBAL       0 'p'
+0009    0 OP_HALT
 == End Disassembly: Tests/rea/new_alloc.rea ==
 
-Constants (3):\n  0000: STR   "p"
+Constants (2):\n  0000: STR   "p"
   0001: STR   "Point"
-  0002: STR   "newobj"
 

--- a/Tests/rea/new_assign_ptr.err
+++ b/Tests/rea/new_assign_ptr.err
@@ -3,15 +3,13 @@
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
 0000    2 OP_DEFINE_GLOBAL NameIdx:0   'p' Type:POINTER ('Point')
-0005    3 OP_CONSTANT         1 'Point'
-0007    | OP_CALL_BUILTIN      2 'newobj' (1 args)
-0011    | OP_GET_GLOBAL_ADDRESS    0 'p'
-0013    | OP_SWAP
-0014    | OP_SET_INDIRECT
-0015    0 OP_HALT
+0005    3 OP_ALLOC_OBJECT     2 (fields)
+0007    | OP_GET_GLOBAL_ADDRESS    0 'p'
+0009    | OP_SWAP
+0010    | OP_SET_INDIRECT
+0011    0 OP_HALT
 == End Disassembly: Tests/rea/new_assign_ptr.rea ==
 
-Constants (3):\n  0000: STR   "p"
+Constants (2):\n  0000: STR   "p"
   0001: STR   "Point"
-  0002: STR   "newobj"
 


### PR DESCRIPTION
## Summary
- handle field access through pointers by resolving record types from pointer expressions
- track program root for declaration lookup during compilation
- update Rea bytecode tests for new object allocation and field access semantics

## Testing
- `Tests/run_rea_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68be0381fd10832a87a27ffa0dc97e03