### PR TITLE
fix: handle empty REA_SKIP_TESTS in run_rea_tests.sh

### DIFF
--- a/Tests/run_rea_tests.sh
+++ b/Tests/run_rea_tests.sh
@@ -10,11 +10,23 @@ if [ ! -x "$REA_BIN" ]; then
   exit 1
 fi
 
+# Read space-separated list of tests to skip from REA_SKIP_TESTS. When the
+# variable is empty or unset, ensure the script still runs all tests.
+SKIP_TESTS=()
+if [[ -n "${REA_SKIP_TESTS:-}" ]]; then
+  # shellcheck disable=SC2206  # We intentionally split the string into an array
+  read -r -a SKIP_TESTS <<< "$REA_SKIP_TESTS"
+fi
+
 cd "$ROOT_DIR"
 EXIT_CODE=0
 
 for src in "$SCRIPT_DIR"/rea/*.rea; do
   test_name=$(basename "$src" .rea)
+  if [[ " ${SKIP_TESTS[*]} " == *" ${test_name} "* ]]; then
+    echo "---- $test_name (skipped) ----"
+    continue
+  fi
   in_file="$SCRIPT_DIR/rea/$test_name.in"
   out_file="$SCRIPT_DIR/rea/$test_name.out"
   err_file="$SCRIPT_DIR/rea/$test_name.err"


### PR DESCRIPTION
## Summary
- guard parsing of REA_SKIP_TESTS so script runs when the variable is unset or empty
- skip tests listed in REA_SKIP_TESTS and show when a test is skipped

## Testing
- `bash -n Tests/run_rea_tests.sh`
- `REA_SKIP_TESTS="$(for f in Tests/rea/*.rea; do basename "$f" .rea; done | paste -sd' ' -)" Tests/run_rea_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68be08c26a98832aa80fc9f34080b782