### PR TITLE
fix test script SKIP_TESTS

### DIFF
--- a/Tests/run_rea_tests.sh
+++ b/Tests/run_rea_tests.sh
@@ -7,7 +7,14 @@ REA_BIN="$ROOT_DIR/build/bin/rea"
 RUNNER_PY="$ROOT_DIR/Tests/tools/run_with_timeout.py"
 TEST_TIMEOUT="${TEST_TIMEOUT:-25}"
 
-IFS=' ' read -r -a SKIP_TESTS <<< "${REA_SKIP_TESTS:-}"
+# Initialize array of tests to skip. When REA_SKIP_TESTS is unset or empty,
+# avoid "unbound variable" errors under `set -u` by explicitly declaring an
+# empty array. Otherwise, split the space-separated environment variable into
+# an array.
+SKIP_TESTS=()
+if [[ -n "${REA_SKIP_TESTS:-}" ]]; then
+  IFS=' ' read -r -a SKIP_TESTS <<< "$REA_SKIP_TESTS"
+fi
 
 should_skip() {
   local t="$1"


### PR DESCRIPTION
## Summary
- prevent `run_rea_tests.sh` from failing with an unbound `SKIP_TESTS` array when `REA_SKIP_TESTS` is unset

## Testing
- `Tests/run_rea_tests.sh` *(fails: expected test binary and fixtures not present)*

------
https://chatgpt.com/codex/tasks/task_e_68be2c0ce410832a991aa9481c30e36c