### PR TITLE
Fix mangled method names in Rea parser

### DIFF
--- a/Tests/rea/method_this_assign.err
+++ b/Tests/rea/method_this_assign.err
@@ -1,1 +1,21 @@
-L3: Compiler Error: Procedure implementation for 'Poin' (looked up as 'poin') does not have a corresponding interface declaration.
+--- Compiling Main Program AST to Bytecode ---
+== Disassembly: Tests/rea/method_this_assign.rea ==
+Offset Line Opcode           Operand  Value / Target (Args)
+------ ---- ---------------- -------- --------------------------
+0000    0 CONSTANT            0 'Value type ARRAY'
+0002    | DEFINE_GLOBAL    NameIdx:1   'point_vtable' Type:UINT64 
+
+--- Function point_setx (at 0007) ---
+0007    4 GET_LOCAL           1 (slot)
+0009    | GET_LOCAL_ADDRESS    0 (slot)
+0011    | GET_FIELD_OFFSET    1 (index)
+0013    | SWAP
+0014    | SET_INDIRECT
+0015    3 GET_LOCAL           2 (slot)
+0017    | RETURN
+0018    0 HALT
+== End Disassembly: Tests/rea/method_this_assign.rea ==
+
+Constants (2):\n  0000: Value type ARRAY
+  0001: STR   "point_vtable"
+

--- a/src/rea/parser.c
+++ b/src/rea/parser.c
@@ -875,6 +875,7 @@ static AST *parseFunctionDecl(ReaParser *p, Token *nameTok, AST *typeNode, VarTy
             snprintf(m, ln, "%s_%s", p->currentClassName, nameTok->value);
             free(nameTok->value);
             nameTok->value = m;
+            nameTok->length = strlen(m); // keep token length in sync with new name
         }
     }
 


### PR DESCRIPTION
## Summary
- fix token length after mangling method names so lookup uses full identifier
- update `method_this_assign` regression test to expect successful bytecode dump

## Testing
- `Tests/run_rea_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68be2d9a878c832aa7262dffda4270c3