### PR TITLE
Fix class method bundle parsing in Rea

### DIFF
--- a/src/rea/parser.c
+++ b/src/rea/parser.c
@@ -1473,6 +1473,7 @@ static AST *parseStatement(ReaParser *p) {
         }
         // Return both type and methods in a compound so top-level gets both
         AST *bundle = newASTNode(AST_COMPOUND, NULL);
+        bundle->is_global_scope = true; // mark for top-level flattening
         addChild(bundle, typeDecl);
         // append methods
         if (methods && methods->child_count > 0) {
@@ -1576,7 +1577,7 @@ AST *parseRea(const char *source) {
         AST *stmt = parseStatement(&p);
         if (!stmt) break;
 
-        if (stmt->type == AST_COMPOUND) {
+        if (stmt->type == AST_COMPOUND && stmt->is_global_scope) {
             for (int i = 0; i < stmt->child_count; i++) {
                 AST *child = stmt->children[i];
                 if (!child) continue;


### PR DESCRIPTION
## Summary
- mark class bundle compounds for flattening and guard top-level flattening logic

## Testing
- `cmake --build build`
- `REA_DUMP_BYTECODE=1 ./build/bin/rea Tests/rea/method_this_assign.rea > /tmp/test.log 2>&1`


------
https://chatgpt.com/codex/tasks/task_e_68be3c364520832abe5dd8812723c5f3