### PR TITLE
Add cache dump utility

### DIFF
--- a/tools/dpc
+++ b/tools/dpc
@@ -10,7 +10,7 @@ FNV_PRIME = 16777619
 
 def hash_path(path: str) -> int:
     h = FNV_OFFSET
-    for b in path.encode("utf-8"):
+    for b in os.fsencode(path):
         h ^= b
         h = (h * FNV_PRIME) & 0xFFFFFFFF
     return h


### PR DESCRIPTION
## Summary
- add `dpc` tool to decode entries in `~/.pscal_cache`
- derive cache path hash using filesystem encoding to match runtime

## Testing
- `python -m py_compile tools/dpc`
- `tools/dpc --help`
- `Tests/run_clike_tests.sh` *(fails: clike binary not found)*
- `Tests/run_pascal_tests.sh` *(fails: pascal binary not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be4f68d140832aacec7cf688e749e8