### PR TITLE
Add bytecode caching for Rea and CLike front ends

### DIFF
--- a/Tests/run_clike_tests.sh
+++ b/Tests/run_clike_tests.sh
@@ -20,6 +20,11 @@ if [ ! -x "$CLIKE_BIN" ]; then
   exit 1
 fi
 
+# Use an isolated HOME to avoid interference from existing caches.
+TEST_HOME=$(mktemp -d)
+export HOME="$TEST_HOME"
+trap 'rm -rf "$TEST_HOME"' EXIT
+
 # Ensure tests run from repository root so relative paths resolve correctly
 cd "$ROOT_DIR"
 
@@ -73,6 +78,8 @@ for src in "$SCRIPT_DIR"/clike/*.cl; do
   mv "$actual_out.clean" "$actual_out"
   perl -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]|\e\][^\a]*(?:\a|\e\\)//g' "$actual_err" > "$actual_err.clean"
   mv "$actual_err.clean" "$actual_err"
+  perl -0 -pe 's/^Compilation successful.*\n//m; s/^Loaded cached byte code.*\n//m; s/^--- Compiling Main Program AST to Bytecode ---\n//m' "$actual_err" > "$actual_err.clean"
+  mv "$actual_err.clean" "$actual_err"
 
   # Keep only the first two lines of stderr for deterministic comparisons
   head -n 2 "$actual_err" > "$actual_err.trim"
@@ -121,5 +128,37 @@ for src in "$SCRIPT_DIR"/clike/*.cl; do
   echo
   echo
 done
+
+# Basic cache reuse test for the CLike front end
+echo "---- CacheReuseTest ----"
+tmp_home=$(mktemp -d)
+src_dir=$(mktemp -d)
+cat > "$src_dir/CacheTest.cl" <<'EOF'
+int main() {
+    printf("first\\n");
+    return 0;
+}
+EOF
+sleep 1
+set +e
+(cd "$src_dir" && HOME="$tmp_home" "$CLIKE_BIN" CacheTest.cl > "$tmp_home/out1" 2> "$tmp_home/err1")
+status1=$?
+set -e
+if [ $status1 -eq 0 ] && grep -q 'first' "$tmp_home/out1"; then
+  sleep 2
+  set +e
+  (cd "$src_dir" && HOME="$tmp_home" "$CLIKE_BIN" CacheTest.cl > "$tmp_home/out2" 2> "$tmp_home/err2")
+  status2=$?
+  set -e
+  if [ $status2 -ne 0 ] || ! grep -q 'Loaded cached byte code' "$tmp_home/err2"; then
+    echo "Cache reuse test failed: expected cached bytecode" >&2
+    EXIT_CODE=1
+  fi
+else
+  echo "Cache reuse test failed to run" >&2
+  EXIT_CODE=1
+fi
+rm -rf "$tmp_home" "$src_dir"
+echo
 
 exit $EXIT_CODE

--- a/src/clike/main.c
+++ b/src/clike/main.c
@@ -160,12 +160,29 @@ int main(int argc, char **argv) {
         return EXIT_FAILURE;
     }
 
-    BytecodeChunk chunk; clikeCompile(prog, &chunk);
-    if (dump_bytecode_flag) {
-        fprintf(stderr, "--- Compiling Main Program AST to Bytecode ---\n");
-        disassembleBytecodeChunk(&chunk, path ? path : "CompiledChunk", procedure_table);
-        if (!dump_bytecode_only_flag) {
-            fprintf(stderr, "\n--- executing Program with VM ---\n");
+    BytecodeChunk chunk;
+    initBytecodeChunk(&chunk);
+    bool used_cache = loadBytecodeFromCache(path, &chunk);
+    if (!used_cache) {
+        clikeCompile(prog, &chunk);
+        saveBytecodeToCache(path, &chunk);
+        fprintf(stderr, "Compilation successful. Byte code size: %d bytes, Constants: %d\n",
+                chunk.count, chunk.constants_count);
+        if (dump_bytecode_flag) {
+            fprintf(stderr, "--- Compiling Main Program AST to Bytecode ---\n");
+            disassembleBytecodeChunk(&chunk, path ? path : "CompiledChunk", procedure_table);
+            if (!dump_bytecode_only_flag) {
+                fprintf(stderr, "\n--- executing Program with VM ---\n");
+            }
+        }
+    } else {
+        fprintf(stderr, "Loaded cached byte code. Byte code size: %d bytes, Constants: %d\n",
+                chunk.count, chunk.constants_count);
+        if (dump_bytecode_flag) {
+            disassembleBytecodeChunk(&chunk, path ? path : "CompiledChunk", procedure_table);
+            if (!dump_bytecode_only_flag) {
+                fprintf(stderr, "\n--- executing Program with VM (cached) ---\n");
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- enable bytecode cache load/save in Rea front end
- enable bytecode cache load/save in CLike front end
- add basic cache reuse tests for Rea and CLike runners

## Testing
- `HOME=$TMPHOME ../build/bin/rea /tmp/cache_test.rea > /tmp/rea_first.out 2> /tmp/rea_first.err` (first run)
- `HOME=$TMPHOME ../build/bin/rea /tmp/cache_test.rea > /tmp/rea_second.out 2> /tmp/rea_second.err`
- `cat /tmp/rea_second.err`
- `HOME=$TMPHOME ../build/bin/clike /tmp/cache_test.cl > /tmp/clike_first.out 2> /tmp/clike_first.err` (first run)
- `HOME=$TMPHOME ../build/bin/clike /tmp/cache_test.cl > /tmp/clike_second.out 2> /tmp/clike_second.err`
- `cat /tmp/clike_second.err`


------
https://chatgpt.com/codex/tasks/task_e_68be5860e5e8832ab787a909534b20e6