### PR TITLE
Add dependency tracking to bytecode cache

### DIFF
--- a/src/Pascal/main.c
+++ b/src/Pascal/main.c
@@ -111,7 +111,7 @@ int runProgram(const char *source, const char *programName, int dump_ast_json_fl
             overall_success_status = true;
         } else {
             GlobalAST = optimizePascalAST(GlobalAST);
-            used_cache = loadBytecodeFromCache(programName, &chunk);
+            used_cache = loadBytecodeFromCache(programName, NULL, 0, &chunk);
             bool compilation_ok_for_vm = true;
             if (!used_cache) {
                 if (dump_bytecode_flag) {

--- a/src/core/cache.c
+++ b/src/core/cache.c
@@ -275,7 +275,10 @@ static bool readValue(FILE* f, Value* out) {
     return true;
 }
 
-bool loadBytecodeFromCache(const char* source_path, BytecodeChunk* chunk) {
+bool loadBytecodeFromCache(const char* source_path,
+                           const char** dependencies,
+                           int dep_count,
+                           BytecodeChunk* chunk) {
     char* cache_path = buildCachePath(source_path);
     if (!cache_path) return false;
     if (chunk && chunk->count > 0) {
@@ -289,6 +292,12 @@ bool loadBytecodeFromCache(const char* source_path, BytecodeChunk* chunk) {
     if (!isCacheFresh(cache_path, source_path)) {
         free(cache_path);
         return false;
+    }
+    for (int i = 0; dependencies && i < dep_count; ++i) {
+        if (!isCacheFresh(cache_path, dependencies[i])) {
+            free(cache_path);
+            return false;
+        }
     }
 
     FILE* f = fopen(cache_path, "rb");

--- a/src/core/cache.h
+++ b/src/core/cache.h
@@ -4,7 +4,10 @@
 #include <stdbool.h>
 #include "compiler/bytecode.h"
 
-bool loadBytecodeFromCache(const char* source_path, BytecodeChunk* chunk);
+bool loadBytecodeFromCache(const char* source_path,
+                           const char** dependencies,
+                           int dep_count,
+                           BytecodeChunk* chunk);
 void saveBytecodeToCache(const char* source_path, const BytecodeChunk* chunk);
 bool loadBytecodeFromFile(const char* file_path, BytecodeChunk* chunk);
 


### PR DESCRIPTION
## Summary
- allow cache loader to validate dependency mtimes
- track imported module paths in Rea and CLike front ends
- update Pascal entry point for new cache API

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `HOME=$TMPHOME build/bin/rea /tmp/cache_test.rea > /tmp/rea_first.out 2> /tmp/rea_first.err`
- `HOME=$TMPHOME build/bin/rea /tmp/cache_test.rea > /tmp/rea_second.out 2> /tmp/rea_second.err`
- `cat /tmp/rea_second.err`
- `HOME=$TMPHOME build/bin/clike /tmp/cache_test.cl > /tmp/clike_first.out 2> /tmp/clike_first.err`
- `HOME=$TMPHOME build/bin/clike /tmp/cache_test.cl > /tmp/clike_second.out 2> /tmp/clike_second.err`
- `cat /tmp/clike_second.err`
- `HOME=$TMPHOME /workspace/pscal/build/bin/clike cache_test.cl > third.out 2> third.err`
- `cat third.err`
- `sed -n '1p' third.out`


------
https://chatgpt.com/codex/tasks/task_e_68be5d466d74832a9cad67d85890c14d