### PR TITLE
Add Rea front end documentation

### DIFF
--- a/Docs/rea_language_reference.md
+++ b/Docs/rea_language_reference.md
@@ -1,0 +1,131 @@
+# Rea Language Specification
+
+### **Introduction and Design Philosophy**
+
+Rea is an object‑oriented front end for the PSCAL virtual machine (VM).  It
+balances readability with direct access to the VM's stack‑based runtime,
+bridging the gap between the Pascal and C‑Like syntaxes with a concise,
+class‑centric language.  The design emphasizes simple, explicit semantics and a
+single dispatch model so that compiled programs map cleanly onto PSCAL
+bytecode.
+
+### **Lexical Structure**
+
+#### **Comments**
+
+* `//` introduces a single‑line comment.
+* `/* ... */` encloses a multi‑line comment.
+
+#### **Identifiers**
+
+Identifiers are case‑sensitive.  They must begin with a letter or `_` and may be
+followed by letters, digits, or underscores.
+
+#### **Keywords**
+
+Reserved words may not be used as identifiers.
+
+* **Types:** `int`, `int32`, `int16`, `int8`, `float`, `float32`, `long double`,
+  `str`, `bool`, `void`
+* **Classes:** `class`, `new`, `extends`, `this`, `super`
+* **Control flow:** `if`, `else`, `while`, `for`, `do`, `switch`, `case`,
+  `default`, `break`, `continue`, `return`
+* **Other:** `const`, `#import`
+
+#### **Literals**
+
+* **Integer and floating point:** follow C‑style forms with optional prefixes
+  and exponents.  Unsuffixed numbers are 64‑bit signed integers or doubles.
+* **Character:** single quotes with C escape sequences, e.g. `'\n'`, `'\x41'`.
+* **String:** double quotes with the same escape sequences, e.g. "hello".
+
+### **Data Types**
+
+Rea reuses the VM's primitive types.  By default integers are 64‑bit and floats
+are 64‑bit doubles.
+
+| Rea Keyword | VM Type | Description |
+| :--- | :--- | :--- |
+| `int` | `TYPE_INT64` | 64‑bit signed integer |
+| `int32` | `TYPE_INT32` | 32‑bit signed integer |
+| `int16` | `TYPE_INT16` | 16‑bit signed integer |
+| `int8` | `TYPE_INT8` | 8‑bit signed integer |
+| `float` | `TYPE_DOUBLE` | 64‑bit floating point |
+| `float32` | `TYPE_FLOAT` | 32‑bit floating point |
+| `long double` | `TYPE_LONG_DOUBLE` | Extended precision float |
+| `str` | `TYPE_STRING` | Dynamically sized string |
+| `bool` | `TYPE_BOOLEAN` | `true` or `false` |
+| `void` | `TYPE_VOID` | No value (procedures) |
+
+### **Variables and Constants**
+
+Variables must be declared with a type.  Constants use `const` and require a
+compile‑time value.
+
+```rea
+int x;
+const int LIMIT = 10;
+```
+
+### **Expressions and Operators**
+
+Rea supports the common arithmetic and comparison operators `+ - * / % == != <
+<= > >=` plus logical `&&` and `||`.  Assignment forms such as `+=` and `-=` are
+also available.  Operator precedence mirrors that of C.
+
+### **Statements**
+
+* **Expression statement:** `expr;`
+* **Block:** `{ statement* }`
+* **`if` / `else`:** standard conditional selection
+* **Loops:** `while`, `do … while`, and `for` loops
+* **`switch`:** multi‑way branch with `case` and `default`
+* **`break` / `continue`:** loop control
+* **`return`:** exit a function and optionally yield a value
+
+### **Functions and Methods**
+
+Functions declare a return type followed by a name and parameter list.  Methods
+follow the same pattern but are nested inside classes.
+
+```rea
+int add(int a, int b) { return a + b; }
+```
+
+### **Classes and Objects**
+
+* **Definition:** `class Name { field; method() { … } }`
+* **Fields:** declared like variables; each instance holds its own copy.
+* **Methods:** may access instance members through `this`.
+* **Constructors:** a method sharing the class name initializes new objects.
+* **Instantiation:** `new Name(args)` allocates an object and calls the
+  constructor.
+* **Inheritance:** `class B extends A { … }` creates a subclass.
+* **`super`:** accesses the parent class constructor or overridden methods.
+* **Dispatch:** all non‑static methods are virtual and resolved via per‑class
+  V‑tables.
+
+### **Built‑in Routines**
+
+Rea code can call any PSCAL VM built‑in, including I/O (`writeln`, `printf`),
+string helpers, math functions, and threading primitives such as `spawn`,
+`join`, `mutex`, `lock`, and `unlock`.
+
+### **Example**
+
+```rea
+class Counter {
+  int n;
+  void inc() { this.n = this.n + 1; }
+  int set(int v) { this.n = v; return this.n; }
+}
+
+Counter c = new Counter();
+c.set(3);
+writeln("c=", c.n);
+c.inc();
+writeln("c=", c.n);
+```
+
+This program demonstrates field updates and virtual method calls on a simple
+class.

--- a/Docs/rea_overview.md
+++ b/Docs/rea_overview.md
@@ -1,0 +1,36 @@
+# Rea Front End Overview
+
+### Front End
+The experimental Rea front end emits PSCAL AST nodes directly, mirroring the Pascal pipeline so that code can be compiled without a translation layer. It currently handles basic expressions while paving the way for a complete compiler【F:src/rea/README.md†L3-L7】.
+
+Numeric literals default to 64-bit integers or doubles to preserve their full range, and the command line offers diagnostic flags such as `--dump-ast-json`, `--dump-bytecode` and `--dump-bytecode-only` to inspect compilation artifacts【F:src/rea/README.md†L9-L20】.
+
+### Bytecode Compiler
+Planned work includes building a dedicated lexer and recursive‑descent parser, performing semantic analysis with a class‑aware symbol table, and generating PSCAL bytecode that supports object allocation, field access and virtual method dispatch. Integrating the compiler into the existing build and test infrastructure rounds out the roadmap【F:src/rea/README.md†L22-L31】.
+
+### Virtual Machine
+Rea targets the existing PSCAL virtual machine. Dynamic dispatch will rely on per-class V‑tables so that overridden methods are resolved at runtime, extending the VM's call frame and symbol table as needed【F:src/rea/LANGUAGE_SPEC.md†L76-L83】.
+
+## The Language
+
+Rea is a strongly typed, class‑based language with C‑like tokens. Comments may be written using `//` or `/* ... */`, identifiers are case‑sensitive, and keywords cover data types (`int`, `float`, `str`, `bool`, etc.), class constructs (`class`, `new`, `extends`, `this`, `super`), and control flow (`if`, `while`, `for`, `switch`, `break`, `continue`, `return`). Common arithmetic and comparison operators are supported, and string and character literals follow C conventions with escape sequences【F:src/rea/LANGUAGE_SPEC.md†L14-L37】.
+
+Primitive types map directly onto VM representations, standardizing on 64‑bit integers and doubles by default. Object‑oriented features include classes with fields and methods, constructors invoked via `new`, dot‑based field and method access, `this` and `super` references, single inheritance through `extends`, and dynamic dispatch through V‑tables. Method overloading is deliberately omitted; each method and function must have a unique name. The language has access to the VM's built‑in routines for I/O, math, strings, and threading【F:src/rea/LANGUAGE_SPEC.md†L41-L90】.
+
+### Example: Simple Counter
+```rea
+class Counter {
+  int n;
+  void inc() { this.n = this.n + 1; }
+  int set(int v) { this.n = v; return this.n; }
+}
+
+Counter c = new Counter();
+c.set(3);
+writeln("c=", c.n);
+c.inc();
+writeln("c=", c.n);
+```
+Example program demonstrating field assignment and method calls【F:Examples/rea/method_demo.rea†L3-L19】.
+
+For additional examples and the full specification, see `rea_language_reference.md` and the sample programs under `Examples/rea`.


### PR DESCRIPTION
## Summary
- Document the experimental Rea front end with an overview and detailed language reference covering syntax, types, classes, and built-ins
- Provide a simple counter example showing class fields and methods

## Testing
- `cd Tests && ./run_all_tests` (fails: pascal, clike, rea, pscalvm binaries not found)


------
https://chatgpt.com/codex/tasks/task_e_68be5f3ce720832aa136a9fc5df7f561