### PR TITLE
Fix cache loading to account for dependencies

### DIFF
--- a/src/clike/main.c
+++ b/src/clike/main.c
@@ -226,7 +226,11 @@ int main(int argc, char **argv) {
     }
     BytecodeChunk chunk;
     initBytecodeChunk(&chunk);
-    bool used_cache = loadBytecodeFromCache(path, &chunk);
+    bool used_cache = loadBytecodeFromCache(path, (const char**)dep_paths, clike_import_count, &chunk);
+    if (dep_paths) {
+        for (int i = 0; i < clike_import_count; ++i) free(dep_paths[i]);
+        free(dep_paths);
+    }
     if (used_cache) {
 #if defined(__APPLE__)
 #define PSCAL_STAT_SEC(st) ((st).st_mtimespec.tv_sec)

--- a/src/rea/main.c
+++ b/src/rea/main.c
@@ -313,7 +313,8 @@ int main(int argc, char **argv) {
 
     BytecodeChunk chunk;
     initBytecodeChunk(&chunk);
-    bool used_cache = loadBytecodeFromCache(path, &chunk);
+    bool used_cache = loadBytecodeFromCache(path, dep_array, dep_count, &chunk);
+    if (dep_array) free(dep_array);
     if (used_cache) {
 #if defined(__APPLE__)
 #define PSCAL_STAT_SEC(st) ((st).st_mtimespec.tv_sec)


### PR DESCRIPTION
## Summary
- pass dependency paths when loading bytecode from cache in clike and rea frontends
- free dependency path arrays after loading from cache

## Testing
- `cmake --build build --target clike`
- `cmake --build build --target rea`


------
https://chatgpt.com/codex/tasks/task_e_68be635b9064832a881cbae094e4569b