### PR TITLE
Hash cache entries by absolute path

### DIFF
--- a/src/clike/main.c
+++ b/src/clike/main.c
@@ -55,7 +55,10 @@ static char* buildCachePathLocal(const char* source_path) {
     if (!dir) return NULL;
     snprintf(dir, dir_len, "%s/%s", home, ".pscal_cache");
     mkdir(dir, 0777);
-    unsigned long h = hashPathLocal(source_path);
+    char* abs_path = realpath(source_path, NULL);
+    const char* hash_src = abs_path ? abs_path : source_path;
+    unsigned long h = hashPathLocal(hash_src);
+    if (abs_path) free(abs_path);
     size_t path_len = dir_len + 32;
     char* full = (char*)malloc(path_len);
     if (!full) { free(dir); return NULL; }

--- a/src/core/cache.c
+++ b/src/core/cache.c
@@ -37,7 +37,10 @@ static char* buildCachePath(const char* source_path) {
     snprintf(dir, dir_len, "%s/%s", home, CACHE_DIR);
     mkdir(dir, 0777); // ensure directory exists
 
-    unsigned long h = hashPath(source_path);
+    char* abs_path = realpath(source_path, NULL);
+    const char* hash_src = abs_path ? abs_path : source_path;
+    unsigned long h = hashPath(hash_src);
+    if (abs_path) free(abs_path);
     size_t path_len = dir_len + 32;
     char* full = (char*)malloc(path_len);
     if (!full) { free(dir); return NULL; }

--- a/src/rea/main.c
+++ b/src/rea/main.c
@@ -53,7 +53,10 @@ static char* buildCachePathLocal(const char* source_path) {
     if (!dir) return NULL;
     snprintf(dir, dir_len, "%s/%s", home, ".pscal_cache");
     mkdir(dir, 0777);
-    unsigned long h = hashPathLocal(source_path);
+    char* abs_path = realpath(source_path, NULL);
+    const char* hash_src = abs_path ? abs_path : source_path;
+    unsigned long h = hashPathLocal(hash_src);
+    if (abs_path) free(abs_path);
     size_t path_len = dir_len + 32;
     char* full = (char*)malloc(path_len);
     if (!full) { free(dir); return NULL; }


### PR DESCRIPTION
## Summary
- Ensure cache file names are derived from canonical absolute paths
- Update Rea and Clike frontends to hash absolute paths for cache lookup

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./Tests/run_pascal_tests.sh`
- `./Tests/run_tiny_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68be6c43f2cc832a8d9afaee57a586a9