### PR TITLE
Embed current VM version in bytecode at runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,7 +298,7 @@ set(CLIKE_SOURCES
     src/clike/opt.c
     src/clike/preproc.c
     src/Pascal/globals.c
-    src/core/utils.c src/core/types.c src/core/list.c src/core/cache.c
+    src/core/utils.c src/core/types.c src/core/list.c src/core/version.c src/core/cache.c
     src/compiler/bytecode.c
     src/vm/vm.c
     src/backend_ast/builtin.c src/backend_ast/builtin_network_api.c


### PR DESCRIPTION
## Summary
- Provide `pscal_vm_version()` for runtime VM bytecode version lookup
- Use runtime VM version when initializing bytecode and reporting `vmversion`
- Load cached and file bytecode using the runtime VM version instead of a macro
- Include `version.c` in clike build to resolve VM version lookup

## Testing
- `cmake -S . -B build`
- `cmake --build build --target clike`


------
https://chatgpt.com/codex/tasks/task_e_68bede58c5c8832a964c46474127b7cc