### PR TITLE
Embed current VM version in bytecode at runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,7 +400,7 @@ set(REA_SOURCES
     src/Pascal/parser.c
     src/ast/ast.c
     src/Pascal/globals.c
-    src/core/utils.c src/core/types.c src/core/list.c src/core/cache.c
+    src/core/utils.c src/core/types.c src/core/list.c src/core/version.c src/core/cache.c
     src/compiler/bytecode.c
     src/compiler/compiler.c
     src/vm/vm.c


### PR DESCRIPTION
## Summary
- Provide `pscal_vm_version()` for runtime VM bytecode version lookup
- Use runtime VM version when initializing bytecode and reporting `vmversion`
- Load cached and file bytecode using the runtime VM version instead of a macro
- Include `src/core/version.c` when building the Rea front-end so the version helper links

## Testing
- `cmake -S . -B build`
- `cmake --build build --target clike`
- `cmake --build build --target rea`


------
https://chatgpt.com/codex/tasks/task_e_68bee6998074832ab6c6dd7cf6a95ebc