### PR TITLE
Embed current VM version in bytecode at runtime

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -434,6 +434,7 @@ static bool compareTypeNodes(AST* a, AST* b) {
     a = resolveTypeAlias(a);
     b = resolveTypeAlias(b);
     if (!a || !b) return a == b;
+    if (a == b) return true;
     if (a->var_type != b->var_type) return false;
     switch (a->var_type) {
         case TYPE_ARRAY:


### PR DESCRIPTION
## Summary
- Provide `pscal_vm_version()` for runtime VM bytecode version lookup
- Use runtime VM version when initializing bytecode and reporting `vmversion`
- Load cached and file bytecode using the runtime VM version instead of a macro
- Include VM version helper in clike and Rea builds
- Avoid infinite recursion when comparing recursive Pascal types to prevent bytecode compilation crashes

## Testing
- `cmake --build build --target pascal`
- `cmake --build build --target clike`
- `cmake --build build --target rea`
- `bash Tests/run_pascal_tests.sh`
- `PASCAL_LIB_DIR=lib/pascal build/bin/pascal --dump-bytecode-only Examples/Pascal/hangman5`


------
https://chatgpt.com/codex/tasks/task_e_68beea254240832a9198b12b39fb30ee