### PR TITLE
rea: accept integral array bounds

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -1484,19 +1484,27 @@ static void compileNode(AST* node, BytecodeChunk* chunk, int current_line_approx
                                     Value upper_b = evaluateCompileTimeValue(subrange->right);
                                     
                                     // Use the new helper for the lower bound
-                                    if (lower_b.type == TYPE_INTEGER) {
-                                        emitConstantIndex16(chunk, addIntConstant(chunk, lower_b.i_val), getLine(varNameNode));
+                                    if (IS_INTLIKE(lower_b)) {
+                                        emitConstantIndex16(chunk,
+                                            addIntConstant(chunk, AS_INTEGER(lower_b)),
+                                            getLine(varNameNode));
                                     } else {
-                                        fprintf(stderr, "L%d: Compiler error: Array bound did not evaluate to a constant integer.\n", getLine(varNameNode));
+                                        fprintf(stderr,
+                                            "L%d: Compiler error: Array bound did not evaluate to a constant integer.\n",
+                                            getLine(varNameNode));
                                         compiler_had_error = true;
                                     }
                                     freeValue(&lower_b);
-                                    
+
                                     // Use the new helper for the upper bound
-                                    if (upper_b.type == TYPE_INTEGER) {
-                                        emitConstantIndex16(chunk, addIntConstant(chunk, upper_b.i_val), getLine(varNameNode));
+                                    if (IS_INTLIKE(upper_b)) {
+                                        emitConstantIndex16(chunk,
+                                            addIntConstant(chunk, AS_INTEGER(upper_b)),
+                                            getLine(varNameNode));
                                     } else {
-                                        fprintf(stderr, "L%d: Compiler error: Array bound did not evaluate to a constant integer.\n", getLine(varNameNode));
+                                        fprintf(stderr,
+                                            "L%d: Compiler error: Array bound did not evaluate to a constant integer.\n",
+                                            getLine(varNameNode));
                                         compiler_had_error = true;
                                     }
                                     freeValue(&upper_b);


### PR DESCRIPTION
## Summary
- allow any integral type when emitting array bound constants

## Testing
- `cmake --build build --target rea`
- `Tests/run_rea_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bf17dd93ec832a9e60850faa2d3b10