### PR TITLE
Fix compiler warnings on Linux

### DIFF
--- a/src/Pascal/parser.c
+++ b/src/Pascal/parser.c
@@ -1397,7 +1397,11 @@ AST *typeSpecifier(Parser *parser, int allowAnonymous) {
         if (isFunction) {
             if (!parser->current_token || parser->current_token->type != TOKEN_COLON) {
                 errorParser(parser, "Expected ':' and return type for function type");
-                if (kwTok) freeToken(kwTok); freeAST(paramsList); return NULL;
+                if (kwTok) {
+                    freeToken(kwTok);
+                }
+                freeAST(paramsList);
+                return NULL;
             }
             eat(parser, TOKEN_COLON);
             retType = typeSpecifier(parser, 0);

--- a/src/backend_ast/builtin_network_api.c
+++ b/src/backend_ast/builtin_network_api.c
@@ -1607,7 +1607,7 @@ static size_t headerAccumJob(char *buffer, size_t size, size_t nitems, void *use
     return real_size;
 }
 
-#ifdef CURLOPT_XFERINFOFUNCTION
+#if LIBCURL_VERSION_NUM >= 0x072000
 static int xferInfoCallback(void* clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow) {
     (void)ultotal; (void)ulnow;
     HttpAsyncJob* j = (HttpAsyncJob*)clientp;
@@ -1748,7 +1748,7 @@ static void* httpAsyncThread(void* arg) {
         if (job->proxy_type) curl_easy_setopt(eh, CURLOPT_PROXYTYPE, job->proxy_type);
     }
     // Progress + cancel
-#ifdef CURLOPT_XFERINFOFUNCTION
+#if LIBCURL_VERSION_NUM >= 0x072000
     curl_easy_setopt(eh, CURLOPT_XFERINFOFUNCTION, xferInfoCallback);
     curl_easy_setopt(eh, CURLOPT_XFERINFODATA, job);
     curl_easy_setopt(eh, CURLOPT_NOPROGRESS, 0L);
@@ -2059,7 +2059,9 @@ Value vmBuiltinHttpRequestAsyncToFile(VM* vm, int arg_count, Value* args) {
     if (args[4].type != TYPE_STRING || !args[4].s_val) {
         runtimeError(vm, "httpRequestAsyncToFile: out must be a filename string.");
         // free partial
-        if (job->method) free(job->method); if (job->url) free(job->url); if (job->body) free(job->body);
+        if (job->method) free(job->method);
+        if (job->url) free(job->url);
+        if (job->body) free(job->body);
         job->active = 0;
         pthread_mutex_unlock(&g_http_async_mutex);
         return makeInt(-1);

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -3700,9 +3700,10 @@ static void compileRValue(AST* node, BytecodeChunk* chunk, int current_line_appr
             } else {
                 char original_display_name[MAX_SYMBOL_LENGTH * 2 + 2];
                 if (isCallQualified) {
-                    snprintf(original_display_name, sizeof(original_display_name), "%s.%s", node->left->token->value, functionName);
+                    snprintf(original_display_name, sizeof(original_display_name), "%.*s.%.*s", MAX_SYMBOL_LENGTH - 1, node->left->token->value, MAX_SYMBOL_LENGTH - 1, functionName);
                 } else {
-                    strncpy(original_display_name, functionName, sizeof(original_display_name)-1); original_display_name[sizeof(original_display_name)-1] = '\0';
+                    strncpy(original_display_name, functionName, sizeof(original_display_name)-1);
+                    original_display_name[sizeof(original_display_name)-1] = '\0';
                 }
                 
                 if (func_symbol) {


### PR DESCRIPTION
## Summary
- resolve misleading-indentation warnings in parser and network API
- guard libcurl progress callbacks by version to avoid deprecation warnings
- cap display name formatting to avoid snprintf truncation warning

## Testing
- `cmake --build build`
- `cd Tests && ./run_all_tests`


------
https://chatgpt.com/codex/tasks/task_e_68bf3b2b9b7c832aacb38d5b36d19403