### PR TITLE
Handle array element record types

### DIFF
--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -777,7 +777,7 @@ resolved_field: ;
                         AST *elemType = resolveTypeAlias(arrayType->right);
                         if (elemType) {
                             node->type_def = elemType;
-                            if (elemType->type == AST_RECORD_TYPE) {
+                            if (elemType->type == AST_POINTER_TYPE) {
                                 node->var_type = TYPE_POINTER;
                             } else {
                                 node->var_type = elemType->var_type;


### PR DESCRIPTION
## Summary
- avoid treating array-of-record elements as pointers
- maintain pointer annotation only for arrays of pointer elements

## Testing
- `Tests/run_rea_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68bf5490acb4832aa8ab2e64f80b8337