### PR TITLE
Fix Rea field access type propagation

### DIFF
--- a/src/rea/semantic.c
+++ b/src/rea/semantic.c
@@ -414,9 +414,15 @@ static void validateNodeInternal(AST *node, ClassInfo *currentClass) {
         if (cls) {
             ClassInfo *ci = lookupClass(cls);
             const char *fname = node->right && node->right->token ? node->right->token->value : NULL;
-            if (ci && !lookupField(ci, fname)) {
-                fprintf(stderr, "Unknown field '%s' on class '%s'\n", fname ? fname : "(null)", cls);
-                pascal_semantic_error_count++;
+            if (ci) {
+                Symbol *fs = lookupField(ci, fname);
+                if (!fs) {
+                    fprintf(stderr, "Unknown field '%s' on class '%s'\n", fname ? fname : "(null)", cls);
+                    pascal_semantic_error_count++;
+                } else if (fs->type_def) {
+                    node->var_type = fs->type_def->var_type;
+                    node->type_def = copyAST(fs->type_def);
+                }
             }
         }
     } else if (node->type == AST_PROCEDURE_CALL) {


### PR DESCRIPTION
## Summary
- ensure Rea semantic analysis annotates field accesses with the field's type so expressions like `this.balls[i]` have the proper pointer type

## Testing
- `./Tests/run_rea_tests.sh` *(fails: class_instantiation, constructor_init, field_access_assign, field_access_read, method_this_assign, new_alloc)*
- `build/bin/rea --dump-bytecode-only Examples/rea/sdl_multibouncingballs.rea`

------
https://chatgpt.com/codex/tasks/task_e_68c024c90f78832ab5305951a7036690