### PR TITLE
Fix class vtable detection for mixed case names

### DIFF
--- a/Tests/rea/class_instantiation.args
+++ b/Tests/rea/class_instantiation.args
@@ -1,0 +1,1 @@
+--dump-bytecode-only

--- a/Tests/rea/class_instantiation.err
+++ b/Tests/rea/class_instantiation.err
@@ -1,5 +1,5 @@
-Loaded cached byte code. Byte code size: 27 bytes, Constants: 5
-== Disassembly: rea/class_instantiation.rea ==
+--- Compiling Main Program AST to Bytecode ---
+== Disassembly: Tests/rea/class_instantiation.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
 0000    2 DEFINE_GLOBAL    NameIdx:0   'd' Type:POINTER ('Dummy')
@@ -15,7 +15,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0020    | CONSTANT            3 '1'
 0022    | CALL_BUILTIN         4 'write' (2 args)
 0026    0 HALT
-== End Disassembly: rea/class_instantiation.rea ==
+== End Disassembly: Tests/rea/class_instantiation.rea ==
 
 Constants (5):\n  0000: STR   "d"
   0001: STR   "Dummy"

--- a/Tests/rea/constructor_init.err
+++ b/Tests/rea/constructor_init.err
@@ -1,34 +1,37 @@
-Compilation successful. Byte code size: 40 bytes, Constants: 4
 --- Compiling Main Program AST to Bytecode ---
-== Disassembly: rea/constructor_init.rea ==
+== Disassembly: Tests/rea/constructor_init.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
 0000    2 DEFINE_GLOBAL    NameIdx:0   'p' Type:POINTER ('Point')
-0005    | ALLOC_OBJECT        2 (fields)
+0005    | ALLOC_OBJECT        3 (fields)
 0007    | DUP
-0008    | CONSTANT            2 '5'
-0010    | CALL             0021 (Point) (2 args)
-0016    | SET_GLOBAL          0 'p'
-0018    1 JUMP                9 (to 0030)
+0008    | GET_FIELD_OFFSET    0 (index)
+0010    | GET_GLOBAL_ADDRESS    2 'Point_vtable'
+0012    | SET_INDIRECT
+0013    | DUP
+0014    | CONSTANT            3 '5'
+0016    | CALL             0027 (Point) (2 args)
+0022    | SET_GLOBAL          0 'p'
+0024    1 JUMP                9 (to 0036)
 
---- Procedure point_point (at 0021) ---
-0021    | GET_LOCAL           1 (slot)
-0023    | GET_LOCAL           0 (slot)
-0025    | GET_FIELD_OFFSET    1 (index)
-0027    | SWAP
-0028    | SET_INDIRECT
-0029    | RETURN
-0030    0 GET_GLOBAL          0 'p'
-0032    | DUP
-0033    | GET_FIELD_OFFSET    0 (index)
-0035    | GET_GLOBAL_ADDRESS    3 'Point_vtable'
-0037    | SET_INDIRECT
-0038    | POP
-0039    | HALT
-== End Disassembly: rea/constructor_init.rea ==
+--- Procedure point_point (at 0027) ---
+0027    | GET_LOCAL           1 (slot)
+0029    | GET_LOCAL           0 (slot)
+0031    | GET_FIELD_OFFSET    2 (index)
+0033    | SWAP
+0034    | SET_INDIRECT
+0035    | RETURN
+0036    0 GET_GLOBAL          0 'p'
+0038    | DUP
+0039    | GET_FIELD_OFFSET    0 (index)
+0041    | GET_GLOBAL_ADDRESS    2 'Point_vtable'
+0043    | SET_INDIRECT
+0044    | POP
+0045    | HALT
+== End Disassembly: Tests/rea/constructor_init.rea ==
 
 Constants (4):\n  0000: STR   "p"
   0001: STR   "Point"
-  0002: INT   5
-  0003: STR   "Point_vtable"
+  0002: STR   "Point_vtable"
+  0003: INT   5
 

--- a/Tests/rea/field_access_assign.err
+++ b/Tests/rea/field_access_assign.err
@@ -1,5 +1,5 @@
-Loaded cached byte code. Byte code size: 14 bytes, Constants: 3
-== Disassembly: rea/field_access_assign.rea ==
+--- Compiling Main Program AST to Bytecode ---
+== Disassembly: Tests/rea/field_access_assign.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
 0000    2 DEFINE_GLOBAL    NameIdx:0   'p' Type:POINTER ('Point')
@@ -9,7 +9,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0011    | SWAP
 0012    | SET_INDIRECT
 0013    0 HALT
-== End Disassembly: rea/field_access_assign.rea ==
+== End Disassembly: Tests/rea/field_access_assign.rea ==
 
 Constants (3):\n  0000: STR   "p"
   0001: STR   "Point"

--- a/Tests/rea/field_access_read.err
+++ b/Tests/rea/field_access_read.err
@@ -1,5 +1,5 @@
-Loaded cached byte code. Byte code size: 18 bytes, Constants: 4
-== Disassembly: rea/field_access_read.rea ==
+--- Compiling Main Program AST to Bytecode ---
+== Disassembly: Tests/rea/field_access_read.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
 0000    2 DEFINE_GLOBAL    NameIdx:0   'p' Type:POINTER ('Point')
@@ -9,7 +9,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0014    | GET_INDIRECT
 0015    | SET_GLOBAL          2 'a'
 0017    0 HALT
-== End Disassembly: rea/field_access_read.rea ==
+== End Disassembly: Tests/rea/field_access_read.rea ==
 
 Constants (4):\n  0000: STR   "p"
   0001: STR   "Point"

--- a/Tests/rea/method_this_assign.err
+++ b/Tests/rea/method_this_assign.err
@@ -1,6 +1,5 @@
-Compilation successful. Byte code size: 29 bytes, Constants: 4
 --- Compiling Main Program AST to Bytecode ---
-== Disassembly: rea/method_this_assign.rea ==
+== Disassembly: Tests/rea/method_this_assign.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
 0000    3 JUMP               11 (to 0014)
@@ -8,7 +7,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 --- Function point_setx (at 0003) ---
 0003    4 GET_LOCAL           1 (slot)
 0005    | GET_LOCAL           0 (slot)
-0007    | GET_FIELD_OFFSET    1 (index)
+0007    | GET_FIELD_OFFSET    2 (index)
 0009    | SWAP
 0010    | SET_INDIRECT
 0011    3 GET_LOCAL           2 (slot)
@@ -17,7 +16,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0016    | DEFINE_GLOBAL    NameIdx:1   'point_vtable' Type:ARRAY Dims:1 [0..0] of INTEGER ('integer')
 0026    | SET_GLOBAL          1 'point_vtable'
 0028    | HALT
-== End Disassembly: rea/method_this_assign.rea ==
+== End Disassembly: Tests/rea/method_this_assign.rea ==
 
 Constants (4):\n  0000: Value type ARRAY
   0001: STR   "point_vtable"

--- a/Tests/rea/new_alloc.err
+++ b/Tests/rea/new_alloc.err
@@ -1,5 +1,5 @@
-Loaded cached byte code. Byte code size: 19 bytes, Constants: 3
-== Disassembly: rea/new_alloc.rea ==
+--- Compiling Main Program AST to Bytecode ---
+== Disassembly: Tests/rea/new_alloc.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
 0000    3 DEFINE_GLOBAL    NameIdx:0   'p' Type:POINTER ('Point')
@@ -12,7 +12,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0016    | SET_INDIRECT
 0017    | POP
 0018    | HALT
-== End Disassembly: rea/new_alloc.rea ==
+== End Disassembly: Tests/rea/new_alloc.rea ==
 
 Constants (3):\n  0000: STR   "p"
   0001: STR   "Point"

--- a/Tests/rea/new_local_vtable.err
+++ b/Tests/rea/new_local_vtable.err
@@ -1,0 +1,34 @@
+--- Compiling Main Program AST to Bytecode ---
+== Disassembly: Tests/rea/new_local_vtable.rea ==
+Offset Line Opcode           Operand  Value / Target (Args)
+------ ---- ---------------- -------- --------------------------
+0000    1 JUMP                1 (to 0004)
+
+--- Procedure mixedcase_hi (at 0003) ---
+0003    | RETURN
+0004    2 JUMP               15 (to 0022)
+
+--- Procedure run (at 0007) ---
+0007    3 INIT_LOCAL_POINTER    0 (slot)    0 'MixedCase'
+0011    | ALLOC_OBJECT        2 (fields)
+0013    | DUP
+0014    | GET_FIELD_OFFSET    0 (index)
+0016    | GET_GLOBAL_ADDRESS    1 'MixedCase_vtable'
+0018    | SET_INDIRECT
+0019    | SET_LOCAL           0 (slot)
+0021    2 RETURN
+0022    0 CONSTANT            2 'Value type ARRAY'
+0024    | DEFINE_GLOBAL    NameIdx:3   'mixedcase_vtable' Type:ARRAY Dims:1 [0..0] of INTEGER ('integer')
+0034    | SET_GLOBAL          3 'mixedcase_vtable'
+0036    5 CALL             0007 (run) (0 args)
+0042    0 HALT
+== End Disassembly: Tests/rea/new_local_vtable.rea ==
+
+Constants (7):\n  0000: STR   "MixedCase"
+  0001: STR   "MixedCase_vtable"
+  0002: Value type ARRAY
+  0003: STR   "mixedcase_vtable"
+  0004: INT   0
+  0005: STR   "integer"
+  0006: STR   "run"
+

--- a/Tests/rea/new_local_vtable.rea
+++ b/Tests/rea/new_local_vtable.rea
@@ -1,0 +1,5 @@
+class MixedCase { void hi() {} }
+void run() {
+  MixedCase mc = new MixedCase();
+}
+run();

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -491,7 +491,7 @@ static bool recordTypeHasVTable(AST* recordType) {
         while (sym) {
             Symbol* base = sym->is_alias ? sym->real_symbol : sym;
             if (base && base->name &&
-                strncmp(base->name, name, len) == 0 &&
+                strncasecmp(base->name, name, len) == 0 &&
                 base->name[len] == '_') {
                 return true;
             }


### PR DESCRIPTION
## Summary
- use case-insensitive comparison when checking for vtables
- add regression test ensuring new objects with mixed-case names get vtables
- refresh Rea test baselines to match repository-relative paths

## Testing
- `./Tests/run_rea_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c078fca4d4832ab93bf3056705d980