### PR TITLE
Ensure Rea programs invoke main automatically

### DIFF
--- a/src/rea/parser.c
+++ b/src/rea/parser.c
@@ -1779,7 +1779,9 @@ AST *parseRea(const char *source) {
     if (has_main && stmts->child_count == 0) {
         Token *mainTok = newToken(TOKEN_IDENTIFIER, "main", 0, 0);
         AST *call = newASTNode(AST_PROCEDURE_CALL, mainTok);
-        addChild(stmts, call);
+        AST *stmt = newASTNode(AST_EXPR_STMT, call->token);
+        setLeft(stmt, call);
+        addChild(stmts, stmt);
     }
 
     return program;


### PR DESCRIPTION
## Summary
- Automatically insert an implicit call to `main` when a Rea program declares a `main` routine but has no top-level statements
- Include `<strings.h>` in the Rea parser for case-insensitive checks

## Testing
- `cmake ..`
- `cmake --build . --target rea`
- `bin/rea --dump-bytecode ../hello.rea`


------
https://chatgpt.com/codex/tasks/task_e_68c0af386e70832aa8accce0daf43322