### PR TITLE
Wrap implicit main call in expression statement

### DIFF
--- a/src/rea/parser.c
+++ b/src/rea/parser.c
@@ -1779,7 +1779,9 @@ AST *parseRea(const char *source) {
     if (has_main && stmts->child_count == 0) {
         Token *mainTok = newToken(TOKEN_IDENTIFIER, "main", 0, 0);
         AST *call = newASTNode(AST_PROCEDURE_CALL, mainTok);
-        addChild(stmts, call);
+        AST *stmt = newASTNode(AST_EXPR_STMT, call->token);
+        setLeft(stmt, call);
+        addChild(stmts, stmt);
     }
 
     return program;


### PR DESCRIPTION
## Summary
- ensure implicit main invocation is emitted by wrapping generated call in an expression statement

## Testing
- `cmake ..`
- `cmake --build . --target rea`
- `bin/rea --dump-bytecode ../Examples/rea/hello.rea`


------
https://chatgpt.com/codex/tasks/task_e_68c0b22c21f0832aa4d803376dc7cadd