### PR TITLE
Fix Rea super constructor dispatch

### DIFF
--- a/Tests/rea/super_method.err
+++ b/Tests/rea/super_method.err
@@ -1,0 +1,73 @@
+--- Compiling Main Program AST to Bytecode ---
+== Disassembly: Tests/rea/super_method.rea ==
+Offset Line Opcode           Operand  Value / Target (Args)
+------ ---- ---------------- -------- --------------------------
+0000    3 DEFINE_GLOBAL    NameIdx:0   'c' Type:POINTER ('Child')
+0005    | ALLOC_OBJECT        3 (fields)
+0007    | DUP
+0008    | GET_FIELD_OFFSET    0 (index)
+0010    | GET_GLOBAL_ADDRESS    2 'Child_vtable'
+0012    | SET_INDIRECT
+0013    | SET_GLOBAL          0 'c'
+0015    1 JUMP                1 (to 0019)
+
+--- Procedure base_base (at 0018) ---
+0018    | RETURN
+0019    | JUMP                9 (to 0031)
+
+--- Procedure base_speak (at 0022) ---
+0022    | CONSTANT            3 '1'
+0024    | CONSTANT            4 'base'
+0026    | CALL_BUILTIN         5 'write' (2 args)
+0030    | RETURN
+0031    2 JUMP                9 (to 0043)
+
+--- Procedure child_child (at 0034) ---
+0034    | GET_LOCAL           0 (slot)
+0036    | CALL             0018 (Base_Base) (1 args)
+0042    | RETURN
+0043    | JUMP                9 (to 0055)
+
+--- Procedure child_speak (at 0046) ---
+0046    | GET_LOCAL           0 (slot)
+0048    | CALL             0022 (Base_speak) (1 args)
+0054    | RETURN
+0055    0 CONSTANT            8 'Value type ARRAY'
+0057    | DEFINE_GLOBAL    NameIdx:9   'child_vtable' Type:ARRAY Dims:1 [0..1] of INTEGER ('integer')
+0067    | SET_GLOBAL          9 'child_vtable'
+0069    | CONSTANT           12 'Value type ARRAY'
+0071    | DEFINE_GLOBAL    NameIdx:13  'base_vtable' Type:ARRAY Dims:1 [0..1] of INTEGER ('integer')
+0081    | SET_GLOBAL         13 'base_vtable'
+0083    | GET_GLOBAL          0 'c'
+0085    | DUP
+0086    | GET_FIELD_OFFSET    0 (index)
+0088    | GET_GLOBAL_ADDRESS    2 'Child_vtable'
+0090    | SET_INDIRECT
+0091    | POP
+0092    4 GET_GLOBAL          0 'c'
+0094    | DUP
+0095    | GET_FIELD_OFFSET    0 (index)
+0097    | GET_INDIRECT
+0098    | CONSTANT            3 '1'
+0100    | SWAP
+0101    | GET_ELEMENT_ADDRESS    1 (dims)
+0103    | GET_INDIRECT
+0104    | PROC_CALL_INDIRECT (args=1)
+0106    0 HALT
+== End Disassembly: Tests/rea/super_method.rea ==
+
+Constants (14):\n  0000: STR   "c"
+  0001: STR   "Child"
+  0002: STR   "Child_vtable"
+  0003: INT   1
+  0004: STR   "base"
+  0005: STR   "write"
+  0006: STR   "Base_Base"
+  0007: STR   "Base_speak"
+  0008: Value type ARRAY
+  0009: STR   "child_vtable"
+  0010: INT   0
+  0011: STR   "integer"
+  0012: Value type ARRAY
+  0013: STR   "base_vtable"
+

--- a/Tests/rea/super_method.rea
+++ b/Tests/rea/super_method.rea
@@ -1,0 +1,4 @@
+class Base { void Base() {} void speak() { writeln("base"); } }
+class Child extends Base { void Child() { super(); } void speak() { super.speak(); } }
+Child c = new Child();
+c.speak();

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -2764,7 +2764,7 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
                 proc_symbol = proc_symbol->real_symbol;
             }
 
-            bool isVirtualMethod = (node->child_count > 0 && proc_symbol && proc_symbol->type_def && proc_symbol->type_def->is_virtual);
+            bool isVirtualMethod = (node->child_count > 0 && node->i_val == 0 && proc_symbol && proc_symbol->type_def && proc_symbol->type_def->is_virtual);
 
 #ifdef FRONTEND_REA
             // Fallback: receiver-aware method call mangle (Rea-only)
@@ -3751,7 +3751,7 @@ static void compileRValue(AST* node, BytecodeChunk* chunk, int current_line_appr
                 func_symbol = func_symbol->real_symbol;
             }
 
-            bool isVirtualMethod = isCallQualified && func_symbol && func_symbol->type_def && func_symbol->type_def->is_virtual;
+            bool isVirtualMethod = isCallQualified && node->i_val == 0 && func_symbol && func_symbol->type_def && func_symbol->type_def->is_virtual;
 
             // Inline function calls directly when marked inline.
             if (func_symbol && func_symbol->type_def && func_symbol->type_def->is_inline) {

--- a/src/rea/semantic.c
+++ b/src/rea/semantic.c
@@ -426,7 +426,20 @@ static void validateNodeInternal(AST *node, ClassInfo *currentClass) {
             }
         }
     } else if (node->type == AST_PROCEDURE_CALL) {
-        if (node->left) {
+        if (node->i_val == 1) {
+            /* super constructor/method call already has implicit 'this' */
+            if (node->token && node->token->value && !strchr(node->token->value, '_')) {
+                const char *pname = node->token->value;
+                size_t ln = strlen(pname) + 1 + strlen(pname) + 1;
+                char *m = (char*)malloc(ln);
+                if (m) {
+                    snprintf(m, ln, "%s_%s", pname, pname);
+                    free(node->token->value);
+                    node->token->value = m;
+                    node->token->length = strlen(m);
+                }
+            }
+        } else if (node->left) {
             const char *cls = resolveExprClass(node->left, clsContext);
             const char *name = node->token ? node->token->value : NULL;
             if (cls && name) {
@@ -487,7 +500,7 @@ static void validateNodeInternal(AST *node, ClassInfo *currentClass) {
                     node->children[0] = thisVar;
                     thisVar->parent = node;
                     setLeft(node, thisVar);
-                } else if (firstIsThis) {
+                } else if (firstIsThis && node->i_val == 0) {
                     setLeft(node, node->children[0]);
                 }
             }


### PR DESCRIPTION
## Summary
- prevent double `this` and avoid virtual dispatch in Rea `super` calls
- treat super constructor/method invocations as direct calls
- add regression test for calling parent methods with `super`

## Testing
- `Tests/run_rea_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c0b6e6b974832a864b6fd3bcba93ac