### PR TITLE
Fix Rea dynamic dispatch for expression receivers

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -3611,8 +3611,6 @@ static void compileRValue(AST* node, BytecodeChunk* chunk, int current_line_appr
             bool isCallQualified = false;
 
             if (node->left &&
-                node->left->type == AST_VARIABLE &&
-                node->left->token && node->left->token->value &&
                 node->token && node->token->value && node->token->type == TOKEN_IDENTIFIER) {
                 functionName = node->token->value;
                 isCallQualified = true;


### PR DESCRIPTION
## Summary
- Ensure compileRValue marks calls with any receiver expression as qualified
- Enables V-table based dispatch when receiver isn't a simple variable

## Testing
- `build/bin/rea --dump-bytecode /tmp/polymorphism.rea`
- `(cd Tests && ./run_all_tests)`

------
https://chatgpt.com/codex/tasks/task_e_68c0c52651e4832aaa343ef577eae40c