### PR TITLE
Fix vtable name case for object instantiation

### DIFF
--- a/Tests/rea/class_instantiation.err
+++ b/Tests/rea/class_instantiation.err
@@ -8,7 +8,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0009    0 GET_GLOBAL          0 'd'
 0011    | DUP
 0012    | GET_FIELD_OFFSET    0 (index)
-0014    | GET_GLOBAL_ADDRESS    2 'Dummy_vtable'
+0014    | GET_GLOBAL_ADDRESS    2 'dummy_vtable'
 0016    | SET_INDIRECT
 0017    | POP
 0018    3 CONSTANT            3 '1'
@@ -19,7 +19,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 
 Constants (5):\n  0000: STR   "d"
   0001: STR   "Dummy"
-  0002: STR   "Dummy_vtable"
+  0002: STR   "dummy_vtable"
   0003: INT   1
   0004: STR   "write"
 

--- a/Tests/rea/constructor_init.err
+++ b/Tests/rea/constructor_init.err
@@ -6,7 +6,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0005    | ALLOC_OBJECT        2 (fields)
 0007    | DUP
 0008    | CONSTANT            2 '5'
-0010    | CALL             0021 (Point) (2 args)
+0010    | CALL             0021 (point) (2 args)
 0016    | SET_GLOBAL          0 'p'
 0018    1 JUMP                9 (to 0030)
 
@@ -20,14 +20,15 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0030    0 GET_GLOBAL          0 'p'
 0032    | DUP
 0033    | GET_FIELD_OFFSET    0 (index)
-0035    | GET_GLOBAL_ADDRESS    3 'Point_vtable'
+0035    | GET_GLOBAL_ADDRESS    4 'point_vtable'
 0037    | SET_INDIRECT
 0038    | POP
 0039    | HALT
 == End Disassembly: Tests/rea/constructor_init.rea ==
 
-Constants (4):\n  0000: STR   "p"
+Constants (5):\n  0000: STR   "p"
   0001: STR   "Point"
   0002: INT   5
-  0003: STR   "Point_vtable"
+  0003: STR   "point"
+  0004: STR   "point_vtable"
 

--- a/Tests/rea/new_alloc.err
+++ b/Tests/rea/new_alloc.err
@@ -8,7 +8,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0009    0 GET_GLOBAL          0 'p'
 0011    | DUP
 0012    | GET_FIELD_OFFSET    0 (index)
-0014    | GET_GLOBAL_ADDRESS    2 'Point_vtable'
+0014    | GET_GLOBAL_ADDRESS    2 'point_vtable'
 0016    | SET_INDIRECT
 0017    | POP
 0018    | HALT
@@ -16,5 +16,5 @@ Offset Line Opcode           Operand  Value / Target (Args)
 
 Constants (3):\n  0000: STR   "p"
   0001: STR   "Point"
-  0002: STR   "Point_vtable"
+  0002: STR   "point_vtable"
 

--- a/Tests/rea/new_local_vtable.err
+++ b/Tests/rea/new_local_vtable.err
@@ -13,22 +13,21 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0011    | ALLOC_OBJECT        2 (fields)
 0013    | DUP
 0014    | GET_FIELD_OFFSET    0 (index)
-0016    | GET_GLOBAL_ADDRESS    1 'MixedCase_vtable'
+0016    | GET_GLOBAL_ADDRESS    1 'mixedcase_vtable'
 0018    | SET_INDIRECT
 0019    | SET_LOCAL           0 (slot)
 0021    2 RETURN
 0022    0 CONSTANT            2 'Value type ARRAY'
-0024    | DEFINE_GLOBAL    NameIdx:3   'mixedcase_vtable' Type:ARRAY Dims:1 [0..0] of INTEGER ('integer')
-0034    | SET_GLOBAL          3 'mixedcase_vtable'
+0024    | DEFINE_GLOBAL    NameIdx:1   'mixedcase_vtable' Type:ARRAY Dims:1 [0..0] of INTEGER ('integer')
+0034    | SET_GLOBAL          1 'mixedcase_vtable'
 0036    5 CALL             0007 (run) (0 args)
 0042    0 HALT
 == End Disassembly: Tests/rea/new_local_vtable.rea ==
 
-Constants (7):\n  0000: STR   "MixedCase"
-  0001: STR   "MixedCase_vtable"
+Constants (6):\n  0000: STR   "MixedCase"
+  0001: STR   "mixedcase_vtable"
   0002: Value type ARRAY
-  0003: STR   "mixedcase_vtable"
-  0004: INT   0
-  0005: STR   "integer"
-  0006: STR   "run"
+  0003: INT   0
+  0004: STR   "integer"
+  0005: STR   "run"
 

--- a/Tests/rea/super_constructor.err
+++ b/Tests/rea/super_constructor.err
@@ -6,7 +6,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0005    | ALLOC_OBJECT        3 (fields)
 0007    | DUP
 0008    | CONSTANT            2 '42'
-0010    | CALL             0033 (Child) (2 args)
+0010    | CALL             0033 (child) (2 args)
 0016    | SET_GLOBAL          0 'c'
 0018    1 JUMP                9 (to 0030)
 
@@ -27,22 +27,23 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0044    0 GET_GLOBAL          0 'c'
 0046    | DUP
 0047    | GET_FIELD_OFFSET    0 (index)
-0049    | GET_GLOBAL_ADDRESS    4 'Child_vtable'
+0049    | GET_GLOBAL_ADDRESS    5 'child_vtable'
 0051    | SET_INDIRECT
 0052    | POP
-0053    4 CONSTANT            5 '1'
+0053    4 CONSTANT            6 '1'
 0055    | GET_GLOBAL          0 'c'
 0057    | GET_FIELD_OFFSET    1 (index)
 0059    | GET_INDIRECT
-0060    | CALL_BUILTIN         6 'write' (2 args)
+0060    | CALL_BUILTIN         7 'write' (2 args)
 0064    0 HALT
 == End Disassembly: Tests/rea/super_constructor.rea ==
 
-Constants (7):\n  0000: STR   "c"
+Constants (8):\n  0000: STR   "c"
   0001: STR   "Child"
   0002: INT   42
-  0003: STR   "Base_Base"
-  0004: STR   "Child_vtable"
-  0005: INT   1
-  0006: STR   "write"
+  0003: STR   "child"
+  0004: STR   "Base_Base"
+  0005: STR   "child_vtable"
+  0006: INT   1
+  0007: STR   "write"
 

--- a/Tests/rea/super_method.err
+++ b/Tests/rea/super_method.err
@@ -6,7 +6,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0005    | ALLOC_OBJECT        3 (fields)
 0007    | DUP
 0008    | GET_FIELD_OFFSET    0 (index)
-0010    | GET_GLOBAL_ADDRESS    2 'Child_vtable'
+0010    | GET_GLOBAL_ADDRESS    2 'child_vtable'
 0012    | SET_INDIRECT
 0013    | SET_GLOBAL          0 'c'
 0015    1 JUMP                1 (to 0019)
@@ -33,15 +33,15 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0048    | CALL             0022 (Base_speak) (1 args)
 0054    | RETURN
 0055    0 CONSTANT            8 'Value type ARRAY'
-0057    | DEFINE_GLOBAL    NameIdx:9   'child_vtable' Type:ARRAY Dims:1 [0..1] of INTEGER ('integer')
-0067    | SET_GLOBAL          9 'child_vtable'
-0069    | CONSTANT           12 'Value type ARRAY'
-0071    | DEFINE_GLOBAL    NameIdx:13  'base_vtable' Type:ARRAY Dims:1 [0..1] of INTEGER ('integer')
-0081    | SET_GLOBAL         13 'base_vtable'
+0057    | DEFINE_GLOBAL    NameIdx:2   'child_vtable' Type:ARRAY Dims:1 [0..1] of INTEGER ('integer')
+0067    | SET_GLOBAL          2 'child_vtable'
+0069    | CONSTANT           11 'Value type ARRAY'
+0071    | DEFINE_GLOBAL    NameIdx:12  'base_vtable' Type:ARRAY Dims:1 [0..1] of INTEGER ('integer')
+0081    | SET_GLOBAL         12 'base_vtable'
 0083    | GET_GLOBAL          0 'c'
 0085    | DUP
 0086    | GET_FIELD_OFFSET    0 (index)
-0088    | GET_GLOBAL_ADDRESS    2 'Child_vtable'
+0088    | GET_GLOBAL_ADDRESS    2 'child_vtable'
 0090    | SET_INDIRECT
 0091    | POP
 0092    4 GET_GLOBAL          0 'c'
@@ -56,18 +56,17 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0106    0 HALT
 == End Disassembly: Tests/rea/super_method.rea ==
 
-Constants (14):\n  0000: STR   "c"
+Constants (13):\n  0000: STR   "c"
   0001: STR   "Child"
-  0002: STR   "Child_vtable"
+  0002: STR   "child_vtable"
   0003: INT   1
   0004: STR   "base"
   0005: STR   "write"
   0006: STR   "Base_Base"
   0007: STR   "Base_speak"
   0008: Value type ARRAY
-  0009: STR   "child_vtable"
-  0010: INT   0
-  0011: STR   "integer"
-  0012: Value type ARRAY
-  0013: STR   "base_vtable"
+  0009: INT   0
+  0010: STR   "integer"
+  0011: Value type ARRAY
+  0012: STR   "base_vtable"
 


### PR DESCRIPTION
## Summary
- ensure vtable globals use canonical lowercase names when instantiating classes
- normalize pending global vtable initialization names
- update Rea tests for new lowercase vtable symbols

## Testing
- `./Tests/run_rea_tests.sh`
- `./Tests/run_pascal_tests.sh`
- `./Tests/run_tiny_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c0d97d8320832aa10de3d658632ced