### PR TITLE
Fix method lookup for array fields in Rea

### DIFF
--- a/src/rea/semantic.c
+++ b/src/rea/semantic.c
@@ -358,8 +358,14 @@ static const char *resolveExprClass(AST *expr, ClassInfo *currentClass) {
             pascal_semantic_error_count++;
             return NULL;
         }
-        if (fs->type_def && fs->type_def->token) {
-            return fs->type_def->token->value;
+        if (fs->type_def) {
+            AST *type = fs->type_def;
+            while (type && (type->type == AST_ARRAY_TYPE || type->type == AST_POINTER_TYPE)) {
+                type = type->right;
+            }
+            if (type && type->token) {
+                return type->token->value;
+            }
         }
         return NULL;
     }


### PR DESCRIPTION
## Summary
- ensure resolveExprClass unwraps array/pointer field types when determining class for method resolution
- prevents incorrect vtable index when calling methods on array elements

## Testing
- `./Tests/run_rea_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c0fc0ed0f4832a822f5b56764d1c6d