### PR TITLE
Ensure FrameDelay is integer for Rea multibouncing balls

### DIFF
--- a/Examples/rea/sdl_multibouncingballs.rea
+++ b/Examples/rea/sdl_multibouncingballs.rea
@@ -79,7 +79,7 @@ class BallsApp {
     randomize();
     this.maxX = getmaxx();
     this.maxY = getmaxy();
-    this.FrameDelay = 1000 / TargetFPS;
+    this.FrameDelay = trunc(1000 / TargetFPS);
     int i = 1;
     while (i <= NumBalls) {
       Ball b = new Ball();


### PR DESCRIPTION
## Summary
- use `trunc` when computing `FrameDelay` so `graphloop` receives an integer

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `build/bin/rea Examples/rea/sdl_multibouncingballs.rea` *(fails: Undefined global variable 'initgraph')*

------
https://chatgpt.com/codex/tasks/task_e_68c17f2aa520832a84020c523a04b23e