### PR TITLE
Fix variables in Rea Mandelbrot example

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -2486,15 +2486,15 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
                                  getLine(varNameNode), false);
                     }
                 }
-                if (node->left && node->child_count > 0) {
-                    compileRValue(node->left, chunk, getLine(node->left));
-                    int slot = resolveLocal(current_function_compiler,
-                                            node->children[0]->token->value);
-                    if (slot != -1) {
-                        writeBytecodeChunk(chunk, SET_LOCAL, getLine(node));
-                        writeBytecodeChunk(chunk, (uint8_t)slot, getLine(node));
-                    }
-                }
+                /*
+                 * After registering locals, delegate to compileNode so that
+                 * type-specific initialization opcodes (e.g. INIT_LOCAL_ARRAY)
+                 * and per-variable initializers are emitted for each declared
+                 * variable. This restores the previous behavior where every
+                 * local variable receives proper backing storage and zeroing
+                 * before first use.
+                 */
+                compileNode(node, chunk, line);
             }
             break;
         }


### PR DESCRIPTION
## Summary
- allow `double` keyword in Rea lexer so field-based initializers compile directly
- simplify Mandelbrot example to declare scaling and zoom factors with inline initializers
- restore initialization for local variable declarations so arrays, strings, pointers, and files receive proper backing storage

## Testing
- `cmake --build build -j4`
- `./build/bin/rea Examples/rea/sdl_mandelbrot_interactive.rea --dump-bytecode-only`
- `cd Tests && ./run_all_tests` *(stdout/stderr mismatches: array_decl, block_decl, constructor_init, continue_for, expr, field_access_assign, field_access_read, if, method_this_assign, super_constructor, super_method)*

------
https://chatgpt.com/codex/tasks/task_e_68c19a3ae2b8832a8d8b67e91c81c48b