### PR TITLE
Fix variables in Rea Mandelbrot example

### DIFF
--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -419,7 +419,7 @@ void annotateTypes(AST *node, AST *currentScopeNode, AST *globalProgramNode) {
     }
 
     if (node->type == AST_BLOCK) {
-        node->is_global_scope = (node->parent && node->parent->type == AST_PROGRAM);
+        // Preserve is_global_scope as set during parsing; do not override here.
     }
 
     if (node->left) annotateTypes(node->left, childScopeNode, globalProgramNode);
@@ -431,7 +431,7 @@ void annotateTypes(AST *node, AST *currentScopeNode, AST *globalProgramNode) {
          }
     }
 
-    if (node->var_type == TYPE_VOID) {
+    if (node->var_type == TYPE_VOID || node->var_type == TYPE_UNKNOWN) {
         switch(node->type) {
             case AST_ADDR_OF: {
                 // Address-of: ensure left is an identifier referencing a procedure/function

--- a/src/rea/main.c
+++ b/src/rea/main.c
@@ -299,6 +299,7 @@ int main(int argc, char **argv) {
         return vmExitWithCleanup(EXIT_FAILURE);
     }
     if (dump_ast_json) {
+        annotateTypes(program, NULL, program);
         dumpASTJSON(program, stdout);
         freeAST(program);
         free(src);


### PR DESCRIPTION
## Summary
- annotate Rea AST before JSON dumping so tests see resolved variable types
- leave block `is_global_scope` flag unchanged during annotation
- relax pointer type checks to accept subclass and unknown pointer arguments

## Testing
- `cmake --build build -j4`
- `cd Tests && ./run_rea_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c19dd31558832a9ad62564f0eb2a75