### PR TITLE
Fix Rea assignment token lexeme for regression tests

### DIFF
--- a/src/rea/parser.c
+++ b/src/rea/parser.c
@@ -805,6 +805,7 @@ static const char *opLexeme(TokenType t) {
         case TOKEN_GREATER_EQUAL: return ">=";
         case TOKEN_LESS: return "<";
         case TOKEN_LESS_EQUAL: return "<=";
+        case TOKEN_ASSIGN: return "=";
         default: return "";
     }
 }


### PR DESCRIPTION
## Summary
- return '=' lexeme for simple assignments so token serialization matches expectations

## Testing
- `ctest --test-dir build -R rea_tests -V`


------
https://chatgpt.com/codex/tasks/task_e_68c1e30ad434832aadb9c15f4acf0e5c