### PR TITLE
Fix Rea cast builtins

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -190,8 +190,10 @@ static const VmBuiltinMapping vmBuiltinDispatchTable[] = {
     {"biwherey", vmBuiltinWherey},
     {"blinktext", vmBuiltinBlinktext},
     {"boldtext", vmBuiltinBoldtext},
+    {"bool", vmBuiltinToBool},
     {"bytecodeversion", vmBuiltinBytecodeVersion},
     {"ceil", vmBuiltinCeil},
+    {"char", vmBuiltinToChar},
     {"chr", vmBuiltinChr},
 #ifdef SDL
     {"cleardevice", vmBuiltinCleardevice},
@@ -229,6 +231,7 @@ static const VmBuiltinMapping vmBuiltinDispatchTable[] = {
     {"dosGettime", vmBuiltinDosGettime},
     {"dosMkdir", vmBuiltinDosMkdir},
     {"dosRmdir", vmBuiltinDosRmdir},
+    {"double", vmBuiltinToDouble},
 #ifdef SDL
     {"drawcircle", vmBuiltinDrawcircle}, // Moved
     {"drawline", vmBuiltinDrawline}, // Moved
@@ -246,6 +249,7 @@ static const VmBuiltinMapping vmBuiltinDispatchTable[] = {
 #endif
     {"findfirst", vmBuiltinDosFindfirst},
     {"findnext", vmBuiltinDosFindnext},
+    {"float", vmBuiltinToFloat},
     {"floor", vmBuiltinFloor},
 #ifdef SDL
     {"freesound", vmBuiltinFreesound},
@@ -280,6 +284,7 @@ static const VmBuiltinMapping vmBuiltinDispatchTable[] = {
     {"inittextsystem", vmBuiltinInittextsystem},
 #endif
     {"insline", vmBuiltinInsline},
+    {"int", vmBuiltinToInt},
     {"inttostr", vmBuiltinInttostr},
     {"invertcolors", vmBuiltinInvertcolors},
     {"ioresult", vmBuiltinIoresult},
@@ -3905,13 +3910,7 @@ void registerAllBuiltins(void) {
 
     /* Allow externally linked modules to add more builtins. */
     registerExtendedBuiltins();
-    /* CLike-style cast helpers (exposed as lowercase names): */
-    registerVmBuiltin("int",     vmBuiltinToInt);
-    registerVmBuiltin("double",  vmBuiltinToDouble);
-    registerVmBuiltin("float",   vmBuiltinToFloat);
-    registerVmBuiltin("char",    vmBuiltinToChar);
-    registerVmBuiltin("bool",    vmBuiltinToBool);
-    /* synonyms for CLike to avoid keyword collisions */
+    /* CLike-style cast helper synonyms to avoid keyword collisions */
     registerVmBuiltin("toint",    vmBuiltinToInt);
     registerVmBuiltin("todouble", vmBuiltinToDouble);
     registerVmBuiltin("tofloat",  vmBuiltinToFloat);

--- a/src/rea/main.c
+++ b/src/rea/main.c
@@ -286,6 +286,18 @@ int main(int argc, char **argv) {
 
     initSymbolSystem();
     registerAllBuiltins();
+    /* C-like style cast helpers */
+    registerBuiltinFunction("int", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("double", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("float", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("char", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("bool", AST_FUNCTION_DECL, NULL);
+    /* synonyms to avoid keyword collisions */
+    registerBuiltinFunction("toint", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("todouble", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("tofloat", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("tochar", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("tobool", AST_FUNCTION_DECL, NULL);
 
     AST *program = parseRea(src);
     if (!program) {


### PR DESCRIPTION
## Summary
- expose bool/char/double/float/int cast helpers to the VM builtin table
- register cast helper functions in the Rea front end to avoid undefined variable errors

## Testing
- `cmake --build build -j8`
- `Tests/run_rea_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c1ef550064832abf24f1da73c27089