### PR TITLE
Fix ball direction in SDL multibouncingballs demo

### DIFF
--- a/Examples/rea/sdl_multibouncingballs.rea
+++ b/Examples/rea/sdl_multibouncingballs.rea
@@ -19,7 +19,8 @@ class Ball {
     myself.y = myself.radius + random(h - 2 * myself.radius);
     int speedRange = trunc(maxSpeed - minSpeed + 1);
     float speed = minSpeed + random(speedRange);
-    float angle = random(360) * (3.14159265 / 180.0);
+    // Rea's trig functions operate in degrees, so do not convert.
+    float angle = random(360);
     myself.dx = cos(angle) * speed / 60.0;
     myself.dy = sin(angle) * speed / 60.0;
     if ((abs(myself.dx) < 0.1) && (abs(myself.dy) < 0.1)) {


### PR DESCRIPTION
## Summary
- prevent balls from clustering by using degrees for angle calculation in SDL demo

## Testing
- `./run_all_tests` (fails: pascal binary not found)


------
https://chatgpt.com/codex/tasks/task_e_68c214a4526c832aabd9df3dd03d01f0