### PR TITLE
ci: compile Rea examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
           set -e
           export SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy
           export REA_LIB_DIR="$GITHUB_WORKSPACE/lib/rea"
+          export PASCAL_LIB_DIR="$GITHUB_WORKSPACE/lib/pascal"
           SDL_ENABLED=$(grep -q '^SDL:BOOL=ON$' build/CMakeCache.txt && echo 1 || echo 0)
           for f in Examples/rea/*.rea; do
             bn=$(basename "$f")


### PR DESCRIPTION
## Summary
- compile Rea examples in CI using dump-bytecode-only
- export Pascal library path so Rea examples locate standard libraries

## Testing
- `yamllint .github/workflows/ci.yml` *(fails: line too long errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c218ba609c832ab7d436f2ee0dc431