### PR TITLE
Fix unused clsName warning

### DIFF
--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -503,7 +503,7 @@ void annotateTypes(AST *node, AST *currentScopeNode, AST *globalProgramNode) {
                                 memcpy(tmp, fn, len);
                                 tmp[len] = '\0';
                                 clsName = tmp;
-                                AST* ctype = lookupType(tmp);
+                                AST* ctype = lookupType(clsName);
                                 ctype = resolveTypeAlias(ctype);
                                 if (ctype && ctype->type == AST_RECORD_TYPE) {
                                     for (int i = 0; i < ctype->child_count; i++) {


### PR DESCRIPTION
## Summary
- use `clsName` when resolving class field types to avoid unused variable warnings

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `./run_all_tests`

------
https://chatgpt.com/codex/tasks/task_e_68c213f25d18832a8503646727873df1