### PR TITLE
Fix Hangman5 dictionary loading

### DIFF
--- a/Examples/rea/hangman5.rea
+++ b/Examples/rea/hangman5.rea
@@ -1,25 +1,24 @@
+// CRT routines like GotoXY and TextColor are available as built-ins,
+// but color constants come from the CRT unit.
 #import "crt";
 
 // --- Game configuration ---
 const int MAX_WRONG = 8;
 
-const int HEADER_ROW = 2;
-const int SUBTITLE_ROW = 3;
-const int WORD_ROW = 5;
-const int HANGMAN_ROW = 7;
+// Layout rows relative to the top margin
+const int HEADER_ROW = 1;
+const int SUBTITLE_ROW = 2;
+const int WORD_ROW = 4;
+const int HANGMAN_ROW = 6;
 const int GUESSBAR_ROW = 15;
 const int GUESSED_ROW = 17;
 const int PROMPT_ROW = 19;
 const int MSG_ROW = 21;
 
-const int BORDER_LEFT = 10;
-const int BORDER_RIGHT = 70;
-const int BORDER_TOP = 1;
-const int BORDER_BOTTOM = 24;
-
-const int CENTER_COL = BORDER_LEFT + 5;
-const int HANGMAN_COL = BORDER_LEFT + 20;
+const int GAME_HEIGHT = 24;
 const int MAX_ELEMENT_WIDTH = 40;
+const int HANGMAN_WIDTH = 12;
+const int BORDER_PADDING = 2;
 
 const char CornerTL = '╔';
 const char CornerTR = '╗';
@@ -56,54 +55,135 @@ str sortString(str s) {
 
 // --- Word repository ---
 class WordRepository {
-  str words[32];
+  // store up to 2048 words loaded from the system dictionary
+  str words[2048];
   int count;
 
   void WordRepository() {
-    myself.count = 0;
-    add("APPLE");
-    add("BANANA");
-    add("ORANGE");
-    add("GRAPES");
-    add("PEACH");
+    my.count = 0;
+
+    bool ok = false;
+    if (paramcount() > 0) {
+      ok = my.load(paramstr(1));
+    }
+    if (!ok) {
+      ok = my.load("/usr/local/pscal/etc/words");
+    }
+    if (!ok) {
+      ok = my.load("etc/words");
+    }
+    if (!ok) {
+      ok = my.load("../etc/words");
+    }
+    if (!ok) {
+      my.load("../../etc/words");
+    }
   }
 
-  void add(str w) {
-    myself.count = myself.count + 1;
-    myself.words[myself.count] = w;
+  bool load(str path) {
+    if (!fileexists(path)) {
+      return false;
+    }
+    text f;
+    assign(f, path);
+    reset(f);
+    str line;
+    while (!eof(f) && my.count < 2048) {
+      readln(f, line);
+      int wordLen = length(line);
+      if (wordLen >= 6 && wordLen <= 9) {
+        bool valid = true;
+        str w = "";
+        setlength(w, wordLen);
+        int j = 1;
+        while (j <= wordLen) {
+          char ch = line[j];
+          if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')) {
+            w[j] = toupper(ch);
+          } else {
+            valid = false;
+          }
+          j = j + 1;
+        }
+        if (valid) {
+          my.count = my.count + 1;
+          my.words[my.count] = w;
+        }
+      }
+    }
+    close(f);
+    return my.count > 0;
   }
 
   str randomWord() {
-    return myself.words[random(myself.count) + 1];
+    int cnt = my.count;
+    if (cnt == 0) return "";
+    int idx = random(cnt) + 1;
+    return my.words[idx];
   }
 }
 
 // --- View class handles all rendering ---
 class HangmanView {
-  void drawBorder() {
-    GotoXY(BORDER_LEFT, BORDER_TOP); write(CornerTL);
-    GotoXY(BORDER_RIGHT, BORDER_TOP); write(CornerTR);
-    GotoXY(BORDER_LEFT, BORDER_BOTTOM); write(CornerBL);
-    GotoXY(BORDER_RIGHT, BORDER_BOTTOM); write(CornerBR);
+  int vHeaderRow, vSubtitleRow, vWordRow, vHangmanRow, vGuessBarRow, vGuessedRow, vPromptRow, vMsgRow;
+  int borderTop, borderBottom, borderLeft, borderRight;
+  int centerCol, hangmanCol, effectiveWidth;
 
-    int x = BORDER_LEFT + 1;
-    while (x < BORDER_RIGHT) {
-      GotoXY(x, BORDER_TOP); write(LineH);
-      GotoXY(x, BORDER_BOTTOM); write(LineH);
+  void HangmanView() {
+    int cols = screencols();
+    int rows = screenrows();
+    int topMargin = int((rows - GAME_HEIGHT) / 2);
+
+    my.vHeaderRow = topMargin + HEADER_ROW;
+    my.vSubtitleRow = topMargin + SUBTITLE_ROW;
+    my.vWordRow = topMargin + WORD_ROW;
+    my.vHangmanRow = topMargin + HANGMAN_ROW;
+    my.vGuessBarRow = topMargin + GUESSBAR_ROW;
+    my.vGuessedRow = topMargin + GUESSED_ROW;
+    my.vPromptRow = topMargin + PROMPT_ROW;
+    my.vMsgRow = topMargin + MSG_ROW;
+
+    my.borderTop = topMargin;
+    my.borderBottom = topMargin + GAME_HEIGHT;
+    my.centerCol = int(cols / 2);
+    my.hangmanCol = my.centerCol - int(HANGMAN_WIDTH / 2);
+    my.borderLeft = my.centerCol - int(MAX_ELEMENT_WIDTH / 2) - BORDER_PADDING;
+    my.borderRight = my.centerCol + int(MAX_ELEMENT_WIDTH / 2) + BORDER_PADDING;
+    my.effectiveWidth = my.borderRight - my.borderLeft - 1;
+  }
+
+  int centerPadding(str s) {
+    int pad = int((my.effectiveWidth - length(s)) / 2);
+    if (pad < 0) pad = 0;
+    return pad;
+  }
+
+  void drawBorder() {
+    TextColor(LightGreen);
+    GotoXY(my.borderLeft, my.borderTop); write(CornerTL);
+    GotoXY(my.borderRight, my.borderTop); write(CornerTR);
+    GotoXY(my.borderLeft, my.borderBottom); write(CornerBL);
+    GotoXY(my.borderRight, my.borderBottom); write(CornerBR);
+
+    int x = my.borderLeft + 1;
+    while (x < my.borderRight) {
+      GotoXY(x, my.borderTop); write(LineH);
+      GotoXY(x, my.borderBottom); write(LineH);
       x = x + 1;
     }
 
-    int y = BORDER_TOP + 1;
-    while (y < BORDER_BOTTOM) {
-      GotoXY(BORDER_LEFT, y); write(LineV);
-      GotoXY(BORDER_RIGHT, y); write(LineV);
+    int y = my.borderTop + 1;
+    while (y < my.borderBottom) {
+      GotoXY(my.borderLeft, y); write(LineV);
+      GotoXY(my.borderRight, y); write(LineV);
       y = y + 1;
     }
+    TextColor(White);
   }
 
   void drawHangman(int wrong) {
-    int r = HANGMAN_ROW;
-    int c = HANGMAN_COL + 2;
+    int r = my.vHangmanRow;
+    int c = my.hangmanCol + 2;
     GotoXY(c, r); write(" +---+  ");
     r = r + 1;
     GotoXY(c, r); write(" |   |  ");
@@ -169,14 +249,12 @@ class HangmanView {
 
   void drawGuessesBar(int wrong) {
     int remaining = MAX_WRONG - wrong;
-    int padding = (MAX_ELEMENT_WIDTH - (14 + MAX_WRONG + 5)) / 2;
+    int padding = int((my.effectiveWidth - (14 + MAX_WRONG + 6)) / 2);
     if (padding < 0) padding = 0;
-    GotoXY(BORDER_LEFT + 1, GUESSBAR_ROW);
+    GotoXY(my.borderLeft + 1 + padding, my.vGuessBarRow);
     int i = 1;
-    while (i <= padding) { write(" "); i = i + 1; }
     write("Guesses Left: ");
     TextColor(LightGreen);
-    i = 1;
     while (i <= remaining) { write("#"); i = i + 1; }
     TextColor(LightRed);
     i = 1;
@@ -187,23 +265,29 @@ class HangmanView {
 
   void render(str display, str guessed, int wrong) {
     ClrScr();
-    drawBorder();
-    GotoXY(CENTER_COL, HEADER_ROW); TextColor(LightGreen); writeln("Welcome to Hangman!"); TextColor(White);
-    GotoXY(CENTER_COL, SUBTITLE_ROW); writeln("(Guess a letter or ? for hint)");
-    GotoXY(CENTER_COL, WORD_ROW); writeln(display);
-    drawHangman(wrong);
-    drawGuessesBar(wrong);
+    my.drawBorder();
+    int pad;
+    pad = my.centerPadding("Welcome to Hangman!");
+    GotoXY(my.borderLeft + 1 + pad, my.vHeaderRow); TextColor(LightGreen); writeln("Welcome to Hangman!"); TextColor(White);
+    pad = my.centerPadding("(Guess a letter or ? for hint)");
+    GotoXY(my.borderLeft + 1 + pad, my.vSubtitleRow); writeln("(Guess a letter or ? for hint)");
+    pad = my.centerPadding(display);
+    GotoXY(my.borderLeft + 1 + pad, my.vWordRow); writeln(display);
+    my.drawHangman(wrong);
+    my.drawGuessesBar(wrong);
     if (length(guessed) > 0) {
       str g = sortString(guessed);
-      GotoXY(BORDER_LEFT + 2, GUESSED_ROW);
-      write("Letters chosen so far: "); writeln(g);
+      str msg = "Letters chosen so far: " + g;
+      pad = my.centerPadding(msg);
+      GotoXY(my.borderLeft + 1 + pad, my.vGuessedRow); writeln(msg);
     }
   }
 
   bool showHint(str word, str display, bool hintUsed) {
-    GotoXY(BORDER_LEFT + 2, MSG_ROW);
+    int pad;
     if (hintUsed) {
-      writeln("Hint used already.");
+      pad = my.centerPadding("Hint used already.");
+      GotoXY(my.borderLeft + 1 + pad, my.vMsgRow); writeln("Hint used already.");
     } else {
       int hintIndex = -1;
       int attempts = 0;
@@ -213,21 +297,29 @@ class HangmanView {
         attempts = attempts + 1;
       }
       if (hintIndex == -1) {
-        writeln("No more hints available.");
+        pad = my.centerPadding("No more hints available.");
+        GotoXY(my.borderLeft + 1 + pad, my.vMsgRow); writeln("No more hints available.");
       } else {
-        write("Hint: letter at position "); write(hintIndex); write(" is '");
-        write(word[hintIndex]); writeln("'");
+        str hintMsg = "Hint: letter at position " + inttostr(hintIndex) + " is '" + word[hintIndex] + "'";
+        pad = my.centerPadding(hintMsg);
+        GotoXY(my.borderLeft + 1 + pad, my.vMsgRow); writeln(hintMsg);
         hintUsed = true;
       }
     }
-    writeln("Press Enter to continue...");
+    pad = my.centerPadding("Press Enter to continue...");
+    GotoXY(my.borderLeft + 1 + pad, my.vMsgRow + 1); writeln("Press Enter to continue...");
     str pause; readln(pause);
     return hintUsed;
   }
 
   void showMessage(str msg) {
-    GotoXY(BORDER_LEFT + 2, MSG_ROW);
-    writeln(msg);
+    int pad = my.centerPadding(msg);
+    GotoXY(my.borderLeft + 1 + pad, my.vMsgRow); writeln(msg);
+  }
+
+  void showMessageAt(str msg, int row) {
+    int pad = my.centerPadding(msg);
+    GotoXY(my.borderLeft + 1 + pad, row); writeln(msg);
   }
 }
 
@@ -244,87 +336,98 @@ class HangmanGame {
   int losses;
 
   void HangmanGame() {
-    myself.repo = new WordRepository();
-    myself.view = new HangmanView();
-    myself.wins = 0;
-    myself.losses = 0;
+    my.repo = new WordRepository();
+    my.repo.WordRepository();
+    my.view = new HangmanView();
+    my.view.HangmanView();
+    my.chosen = "";
+    my.display = "";
+    my.guessed = "";
+    my.wins = 0;
+    my.losses = 0;
   }
 
   void startRound() {
     randomize();
-    myself.chosen = myself.repo.randomWord();
-    myself.display = "";
+    my.chosen = my.repo.randomWord();
+    my.display = "";
     int i = 1;
-    while (i <= length(myself.chosen)) {
-      myself.display = myself.display + "_";
+    while (i <= length(my.chosen)) {
+      my.display = my.display + "_";
       i = i + 1;
     }
-    myself.guessed = "";
-    myself.wrong = 0;
-    myself.hintUsed = false;
+    my.guessed = "";
+    my.wrong = 0;
+    my.hintUsed = false;
   }
 
   bool handleGuess(char c) {
     bool hit = false;
     int i = 1;
-    while (i <= length(myself.chosen)) {
-      if (myself.chosen[i] == c) {
-        myself.display[i] = c;
+    while (i <= length(my.chosen)) {
+      if (my.chosen[i] == c) {
+        my.display[i] = c;
         hit = true;
       }
       i = i + 1;
     }
-    if (!hit) myself.wrong = myself.wrong + 1;
-    myself.guessed = myself.guessed + c;
-    return myself.display == myself.chosen;
+    if (!hit) my.wrong = my.wrong + 1;
+    my.guessed = my.guessed + c;
+    return my.display == my.chosen;
   }
 
   void playRound() {
     bool win = false;
     str msg;
-    while (myself.wrong < MAX_WRONG && myself.display != myself.chosen) {
-      myself.view.render(myself.display, myself.guessed, myself.wrong);
-      GotoXY(BORDER_LEFT + 2, PROMPT_ROW);
+    while (my.wrong < MAX_WRONG && my.display != my.chosen) {
+      my.view.render(my.display, my.guessed, my.wrong);
+      int pad = my.view.centerPadding("Enter a letter: ");
+      GotoXY(my.view.borderLeft + 1 + pad, my.view.vPromptRow);
       write("Enter a letter: ");
       str line; readln(line);
       if (length(line) == 0) continue;
       char g = toupper(line[1]);
       if (g == '?') {
-        myself.hintUsed = myself.view.showHint(myself.chosen, myself.display, myself.hintUsed);
+        my.hintUsed = my.view.showHint(my.chosen, my.display, my.hintUsed);
         continue;
       }
-      if (contains(myself.guessed, g)) {
-        myself.view.showMessage("Already guessed.");
+      if (contains(my.guessed, g)) {
+        my.view.showMessage("Already guessed.");
         continue;
       }
-      win = handleGuess(g);
+      win = my.handleGuess(g);
     }
 
-    myself.view.render(myself.display, myself.guessed, myself.wrong);
-    if (myself.display == myself.chosen) {
+    my.view.render(my.display, my.guessed, my.wrong);
+    if (my.display == my.chosen) {
       TextColor(Green);
-      myself.view.showMessage("You guessed the word!");
+      my.view.showMessage("You guessed the word!");
       TextColor(White);
-      myself.wins = myself.wins + 1;
+      my.wins = my.wins + 1;
     } else {
       TextColor(LightRed);
-      msg = "Sorry, the word was " + myself.chosen;
-      myself.view.showMessage(msg);
+      msg = "Sorry, the word was " + my.chosen;
+      my.view.showMessage(msg);
       TextColor(White);
-      myself.losses = myself.losses + 1;
+      my.losses = my.losses + 1;
     }
-    GotoXY(BORDER_LEFT + 2, MSG_ROW + 1);
-    write("Score: "); write(myself.wins); write(" wins / "); write(myself.losses); writeln(" losses");
-    GotoXY(BORDER_LEFT + 2, MSG_ROW + 2); writeln("Press Enter...");
+    str scoreMsg = "Score: " + inttostr(my.wins) + " wins / " + inttostr(my.losses) + " losses";
+    my.view.showMessageAt(scoreMsg, my.view.vMsgRow + 1);
+    my.view.showMessageAt("Press Enter...", my.view.vMsgRow + 2);
     str pause; readln(pause);
   }
 
   void play() {
     bool again = true;
     while (again) {
-      startRound();
-      playRound();
-      GotoXY(BORDER_LEFT + 2, MSG_ROW + 3);
+      my.startRound();
+      my.playRound();
+      // Clear previous prompt line and ask inside border
+      GotoXY(my.view.borderLeft + 1, my.view.vMsgRow + 2);
+      int i = 1;
+      while (i <= my.view.effectiveWidth) { write(" "); i = i + 1; }
+      int pad = my.view.centerPadding("Play again? (Y/N): ");
+      GotoXY(my.view.borderLeft + 1 + pad, my.view.vMsgRow + 2);
       write("Play again? (Y/N): ");
       str ans; readln(ans);
       if (length(ans) == 0) { again = true; }
@@ -337,4 +440,5 @@ class HangmanGame {
 }
 
 HangmanGame game = new HangmanGame();
+game.HangmanGame();
 game.play();

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -3337,6 +3337,9 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
             }
             break;
         }
+        case AST_USES_CLAUSE:
+            // Uses clauses are processed by the REA front end and don't emit code
+            break;
         default: {
             // This case should now only be hit for unhandled statement types, not expressions.
             fprintf(stderr, "L%d: Compiler WARNING: Unhandled AST node type %s in compileStatement's default case.\n", line, astTypeToString(node->type));


### PR DESCRIPTION
## Summary
- Import CRT unit for color constants
- Load dictionary using text file I/O and select words randomly
- Keep replay prompt inside the game border
- Center hangman display based on terminal size and center all messages within the border
- Increase game window height so score and replay prompts stay inside the border
- Preserve green border color throughout redraws
- Replace `myself` with `my` for object references and center score messages

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `printf "A\nA\nN\n" | env PASCAL_LIB_DIR=lib/pascal build/bin/rea Examples/rea/hangman5.rea | head -c 1000 | strings`


------
https://chatgpt.com/codex/tasks/task_e_68c2335063f0832a98b96aa040f86d65