### PR TITLE
Handle shebang lines in Rea lexer

### DIFF
--- a/src/rea/lexer.c
+++ b/src/rea/lexer.c
@@ -46,6 +46,16 @@ static void skipWhitespace(ReaLexer *lexer) {
                 lexer->line++;
                 lexer->pos++;
                 break;
+            case '#':
+                if (lexer->pos == 0 && peekNext(lexer) == '!') {
+                    lexer->pos += 2;
+                    while (peek(lexer) != '\n' && peek(lexer) != '\0') {
+                        lexer->pos++;
+                    }
+                } else {
+                    return;
+                }
+                break;
             case '/':
                 if (peekNext(lexer) == '/') {
                     lexer->pos += 2;


### PR DESCRIPTION
## Summary
- Skip initial shebang lines in `rea` lexer so `#!/usr/bin/env rea` scripts don't break tokenization

## Testing
- `cmake ..`
- `cmake --build .`
- `./run_all_tests`
- `build/bin/rea polymorphism.rea`


------
https://chatgpt.com/codex/tasks/task_e_68c2dd983064832abdc33a310e66fd72