### PR TITLE
Fix cache file format mismatch to enable bytecode reuse

### DIFF
--- a/src/core/cache.c
+++ b/src/core/cache.c
@@ -658,9 +658,6 @@ void saveBytecodeToCache(const char* source_path, const BytecodeChunk* chunk) {
                 fwrite(&sym->locals_count, sizeof(sym->locals_count), 1, f);
                 fwrite(&sym->upvalue_count, sizeof(sym->upvalue_count), 1, f);
                 fwrite(&sym->type, sizeof(sym->type), 1, f);
-                int parent_len = (sym->enclosing && sym->enclosing->name) ? (int)strlen(sym->enclosing->name) : 0;
-                fwrite(&parent_len, sizeof(parent_len), 1, f);
-                if (parent_len > 0) fwrite(sym->enclosing->name, 1, parent_len, f);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Stop writing unused parent procedure metadata into cached bytecode
- Ensures cache files load correctly so unmodified programs run from cache

## Testing
- `cmake --build build`
- `Tests/run_pascal_tests.sh`
- `build/bin/pascal Tests/Pascal/BoolTest` (twice to verify cache reuse)


------
https://chatgpt.com/codex/tasks/task_e_68c2f3a3358c832abe8fcaa658756b30