### PR TITLE
Update docs for CMake workflow and Rea example renames

### DIFF
--- a/Docs/project_overview.md
+++ b/Docs/project_overview.md
@@ -68,15 +68,15 @@ The project follows a classic compiler and virtual machine design:
 ## Building
 
 ```sh
-mkdir build && cd build
-cmake ..          # add -DSDL=ON to enable SDL support
-make
+cmake -B build          # add -DSDL=ON to enable SDL support
+cmake --build build
 ```
 
 To explicitly disable SDL support:
 
 ```sh
-cmake -DSDL=OFF ..
+cmake -B build -DSDL=OFF
+cmake --build build
 ```
 
 ---

--- a/Docs/rea_overview.md
+++ b/Docs/rea_overview.md
@@ -31,7 +31,7 @@ writeln("c=", c.n);
 c.inc();
 writeln("c=", c.n);
 ```
-Example program demonstrating field assignment and method calls【F:Examples/rea/method_demo.rea†L3-L19】.
+Example program demonstrating field assignment and method calls【F:Examples/rea/method_demo†L3-L19】.
 
 For additional examples and the full specification, see `rea_language_reference.md` and the sample programs under `Examples/rea`.
 

--- a/Docs/rea_tutorial.md
+++ b/Docs/rea_tutorial.md
@@ -2,7 +2,7 @@
 
 The Rea compiler is an experimental front end for PSCAL. This tutorial walks through
 building the compiler, running the SDL multi bouncing balls sample located at
-`Examples/rea/sdl_multibouncingballs.rea`, and understanding every part of the
+`Examples/rea/sdl_multibouncingballs`, and understanding every part of the
 program.
 
 ## Build the compiler
@@ -38,7 +38,7 @@ export RUN_SDL=1
 ```
 Invoke the compiler with the sample source:
 ```sh
-build/bin/rea Examples/rea/sdl_multibouncingballs.rea
+build/bin/rea Examples/rea/sdl_multibouncingballs
 ```
 
 ## Sample walkthrough


### PR DESCRIPTION
## Summary
- refresh project overview build instructions to modern CMake invocation
- drop obsolete .rea extensions in Rea docs to match executable examples

## Testing
- `cmake -B build`
- `cmake --build build`
- `cd Tests && ./run_all_tests`


------
https://chatgpt.com/codex/tasks/task_e_68c2f929abd0832a96b49e8908e6e070