### PR TITLE
Canonicalize cache file paths

### DIFF
--- a/src/core/cache.h
+++ b/src/core/cache.h
@@ -11,4 +11,8 @@ bool loadBytecodeFromCache(const char* source_path,
 void saveBytecodeToCache(const char* source_path, const BytecodeChunk* chunk);
 bool loadBytecodeFromFile(const char* file_path, BytecodeChunk* chunk);
 
+// Build the canonical path for the cache file corresponding to a source path.
+// Caller is responsible for freeing the returned string.
+char* buildCachePath(const char* source_path);
+
 #endif // PSCAL_CACHE_H

--- a/src/rea/main.c
+++ b/src/rea/main.c
@@ -3,7 +3,6 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <stdint.h>
 #include <ctype.h>
 #include "vm/vm.h"
 #include "core/cache.h"
@@ -35,35 +34,6 @@ static const char *REA_USAGE =
     "     --dump-ast-json        Dump AST to JSON and exit.\n"
     "     --dump-bytecode        Dump compiled bytecode before execution.\n"
 "     --dump-bytecode-only   Dump compiled bytecode and exit (no execution).\n";
-
-static unsigned long hashPathLocal(const char* path) {
-    uint32_t hash = 2166136261u;
-    for (const unsigned char* p = (const unsigned char*)path; *p; ++p) {
-        hash ^= *p;
-        hash *= 16777619u;
-    }
-    return (unsigned long)hash;
-}
-
-static char* buildCachePathLocal(const char* source_path) {
-    const char* home = getenv("HOME");
-    if (!home) return NULL;
-    size_t dir_len = strlen(home) + 1 + strlen(".pscal_cache") + 1;
-    char* dir = (char*)malloc(dir_len);
-    if (!dir) return NULL;
-    snprintf(dir, dir_len, "%s/%s", home, ".pscal_cache");
-    mkdir(dir, 0777);
-    char* abs_path = realpath(source_path, NULL);
-    const char* hash_src = abs_path ? abs_path : source_path;
-    unsigned long h = hashPathLocal(hash_src);
-    if (abs_path) free(abs_path);
-    size_t path_len = dir_len + 32;
-    char* full = (char*)malloc(path_len);
-    if (!full) { free(dir); return NULL; }
-    snprintf(full, path_len, "%s/%lu.bc", dir, h);
-    free(dir);
-    return full;
-}
 
 static bool isUnitListFresh(List* unit_list, time_t cache_mtime) {
     if (!unit_list) return true;
@@ -337,7 +307,7 @@ int main(int argc, char **argv) {
 #else
 #define PSCAL_STAT_SEC(st) ((st).st_mtim.tv_sec)
 #endif
-        char* cache_path = buildCachePathLocal(path);
+        char* cache_path = buildCachePath(path);
         struct stat cache_stat;
         if (!cache_path || stat(cache_path, &cache_stat) != 0 ||
             !importsAreFresh(program, PSCAL_STAT_SEC(cache_stat))) {

--- a/tools/dpc
+++ b/tools/dpc
@@ -9,8 +9,9 @@ FNV_OFFSET = 2166136261
 FNV_PRIME = 16777619
 
 def hash_path(path: str) -> int:
+    real = os.path.realpath(path)
     h = FNV_OFFSET
-    for b in os.fsencode(path):
+    for b in os.fsencode(real):
         h ^= b
         h = (h * FNV_PRIME) & 0xFFFFFFFF
     return h
@@ -24,11 +25,9 @@ def build_hash_map(search_dirs: list[str]) -> dict[int, list[str]]:
         for file_path in base.rglob("*"):
             if not file_path.is_file():
                 continue
-            rel_str = file_path.relative_to(base).as_posix()
-            abs_str = str(file_path.resolve())
-            for candidate in (rel_str, abs_str):
-                h = hash_path(candidate)
-                mapping.setdefault(h, []).append(str(file_path))
+            abs_str = os.path.realpath(file_path)
+            h = hash_path(abs_str)
+            mapping.setdefault(h, []).append(abs_str)
     return mapping
 
 def main() -> None:

--- a/tools/find_cache_name
+++ b/tools/find_cache_name
@@ -10,8 +10,9 @@ FNV_PRIME = 16777619
 
 def hashPath(path: str) -> int:
     """Replicate the hash function used by Pscal's cache."""
+    real = os.path.realpath(path)
     h = FNV_OFFSET
-    for b in path.encode("utf-8"):
+    for b in real.encode("utf-8"):
         h ^= b
         h = (h * FNV_PRIME) & 0xFFFFFFFF
     return h
@@ -45,10 +46,9 @@ def main() -> None:
         for file_path in base.rglob("*"):
             if not file_path.is_file():
                 continue
-            rel_str = file_path.relative_to(base).as_posix()
-            abs_str = str(file_path.resolve())
-            if hashPath(rel_str) == target_hash or hashPath(abs_str) == target_hash:
-                matches.append(str(file_path))
+            abs_str = os.path.realpath(file_path)
+            if hashPath(abs_str) == target_hash:
+                matches.append(abs_str)
 
     if matches:
         for m in matches:


### PR DESCRIPTION
## Summary
- Use realpath when hashing source paths to generate cache filenames
- Expose `buildCachePath` and share it across front ends
- Ensure Python cache utilities hash canonical paths only

## Testing
- `cmake --build build`
- `Tests/run_pascal_tests.sh`
- `Tests/run_clike_tests.sh`
- `Tests/run_rea_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c3255236f0832a844bdf9652963b29