### PR TITLE
Fix bytecode cache for array constants

### DIFF
--- a/src/core/cache.c
+++ b/src/core/cache.c
@@ -257,10 +257,14 @@ static bool writeValue(FILE* f, const Value* v) {
                 fwrite(&ub, sizeof(ub), 1, f);
             }
             int total = 1;
-            for (int i = 0; i < dims; i++) {
-                int span = (v->upper_bounds[i] - v->lower_bounds[i] + 1);
-                if (span <= 0) { total = 0; break; }
-                total *= span;
+            if (!v->lower_bounds || !v->upper_bounds) {
+                total = 0;
+            } else {
+                for (int i = 0; i < dims; i++) {
+                    int span = (v->upper_bounds[i] - v->lower_bounds[i] + 1);
+                    if (span <= 0) { total = 0; break; }
+                    total *= span;
+                }
             }
             for (int i = 0; i < total; i++) {
                 if (!writeValue(f, &v->array_val[i])) return false;


### PR DESCRIPTION
## Summary
- serialize and deserialize TYPE_ARRAY values so cached bytecode handles vtables and other arrays
- relax procedure lookup to match by address without requiring AST nodes
- embed canonical source path in cache entries and verify it on load for consistent file mapping
- guard against missing bounds in TYPE_ARRAY serialization to avoid null pointer dereferences

## Testing
- `cmake -S . -B build`
- `cmake --build build -j $(nproc)`
- `tmp_home=$(mktemp -d); echo 'writeln("first");' > /tmp/CacheTest.rea; HOME=$tmp_home build/bin/rea /tmp/CacheTest.rea; HOME=$tmp_home build/bin/rea /tmp/CacheTest.rea`


------
https://chatgpt.com/codex/tasks/task_e_68c323feee68832abee926afb06b554f