### PR TITLE
Skip vtable init when class has no methods

### DIFF
--- a/Tests/rea/class_instantiation.err
+++ b/Tests/rea/class_instantiation.err
@@ -5,21 +5,14 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0000    2 DEFINE_GLOBAL    NameIdx:0   'd' Type:POINTER ('Dummy')
 0005    | ALLOC_OBJECT        1 (fields)
 0007    | SET_GLOBAL          0 'd'
-0009    0 GET_GLOBAL          0 'd'
-0011    | DUP
-0012    | GET_FIELD_OFFSET    0 (index)
-0014    | GET_GLOBAL_ADDRESS    2 'dummy_vtable'
-0016    | SET_INDIRECT
-0017    | POP
-0018    3 CONSTANT            3 '1'
-0020    | CONSTANT            3 '1'
-0022    | CALL_BUILTIN         4 'write' (2 args)
-0026    0 HALT
+0009    3 CONSTANT            2 '1'
+0011    | CONSTANT            2 '1'
+0013    | CALL_BUILTIN         3 'write' (2 args)
+0017    0 HALT
 == End Disassembly: Tests/rea/class_instantiation.rea ==
 
-Constants (5):\n  0000: STR   "d"
+Constants (4):\n  0000: STR   "d"
   0001: STR   "Dummy"
-  0002: STR   "dummy_vtable"
-  0003: INT   1
-  0004: STR   "write"
+  0002: INT   1
+  0003: STR   "write"
 

--- a/Tests/rea/constructor_init.err
+++ b/Tests/rea/constructor_init.err
@@ -17,18 +17,11 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0027    | SWAP
 0028    | SET_INDIRECT
 0029    | RETURN
-0030    0 GET_GLOBAL          0 'p'
-0032    | DUP
-0033    | GET_FIELD_OFFSET    0 (index)
-0035    | GET_GLOBAL_ADDRESS    4 'point_vtable'
-0037    | SET_INDIRECT
-0038    | POP
-0039    | HALT
+0030    0 HALT
 == End Disassembly: Tests/rea/constructor_init.rea ==
 
-Constants (5):\n  0000: STR   "p"
+Constants (4):\n  0000: STR   "p"
   0001: STR   "Point"
   0002: INT   5
   0003: STR   "point"
-  0004: STR   "point_vtable"
 

--- a/Tests/rea/new_alloc.err
+++ b/Tests/rea/new_alloc.err
@@ -5,16 +5,9 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0000    3 DEFINE_GLOBAL    NameIdx:0   'p' Type:POINTER ('Point')
 0005    | ALLOC_OBJECT        3 (fields)
 0007    | SET_GLOBAL          0 'p'
-0009    0 GET_GLOBAL          0 'p'
-0011    | DUP
-0012    | GET_FIELD_OFFSET    0 (index)
-0014    | GET_GLOBAL_ADDRESS    2 'point_vtable'
-0016    | SET_INDIRECT
-0017    | POP
-0018    | HALT
+0009    0 HALT
 == End Disassembly: Tests/rea/new_alloc.rea ==
 
-Constants (3):\n  0000: STR   "p"
+Constants (2):\n  0000: STR   "p"
   0001: STR   "Point"
-  0002: STR   "point_vtable"
 

--- a/Tests/rea/super_constructor.err
+++ b/Tests/rea/super_constructor.err
@@ -24,26 +24,19 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0035    | GET_LOCAL           1 (slot)
 0037    | CALL             0021 (Base_Base) (2 args)
 0043    | RETURN
-0044    0 GET_GLOBAL          0 'c'
-0046    | DUP
-0047    | GET_FIELD_OFFSET    0 (index)
-0049    | GET_GLOBAL_ADDRESS    5 'child_vtable'
-0051    | SET_INDIRECT
-0052    | POP
-0053    4 CONSTANT            6 '1'
-0055    | GET_GLOBAL          0 'c'
-0057    | GET_FIELD_OFFSET    1 (index)
-0059    | GET_INDIRECT
-0060    | CALL_BUILTIN         7 'write' (2 args)
-0064    0 HALT
+0044    4 CONSTANT            5 '1'
+0046    | GET_GLOBAL          0 'c'
+0048    | GET_FIELD_OFFSET    1 (index)
+0050    | GET_INDIRECT
+0051    | CALL_BUILTIN         6 'write' (2 args)
+0055    0 HALT
 == End Disassembly: Tests/rea/super_constructor.rea ==
 
-Constants (8):\n  0000: STR   "c"
+Constants (7):\n  0000: STR   "c"
   0001: STR   "Child"
   0002: INT   42
   0003: STR   "child"
   0004: STR   "Base_Base"
-  0005: STR   "child_vtable"
-  0006: INT   1
-  0007: STR   "write"
+  0005: INT   1
+  0006: STR   "write"
 

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -1836,14 +1836,21 @@ static void compileNode(AST* node, BytecodeChunk* chunk, int current_line_approx
                                 compileRValue(node->left, chunk, getLine(node->left));
                                 if (set_global_guard) compiling_global_var_init = prev_global_init;
                                 if (set_global_guard && node->left->token && node->left->token->value) {
-                                    pending_global_vtables = realloc(pending_global_vtables,
-                                        sizeof(PendingGlobalVTableInit) * (pending_global_vtable_count + 1));
-                                    pending_global_vtables[pending_global_vtable_count].var_name =
-                                        strdup(varNameNode->token->value);
                                     char* lower_cls = strdup(node->left->token->value);
                                     toLowerString(lower_cls);
-                                    pending_global_vtables[pending_global_vtable_count].class_name = lower_cls;
-                                    pending_global_vtable_count++;
+                                    AST* clsType = lookupType(lower_cls);
+                                    if (recordTypeHasVTable(clsType)) {
+                                        pending_global_vtables = realloc(
+                                            pending_global_vtables,
+                                            sizeof(PendingGlobalVTableInit) *
+                                                (pending_global_vtable_count + 1));
+                                        pending_global_vtables[pending_global_vtable_count].var_name =
+                                            strdup(varNameNode->token->value);
+                                        pending_global_vtables[pending_global_vtable_count].class_name = lower_cls;
+                                        pending_global_vtable_count++;
+                                    } else {
+                                        free(lower_cls);
+                                    }
                                 }
                             }
                             int name_idx_set = addStringConstant(chunk, varNameNode->token->value);


### PR DESCRIPTION
## Summary
- avoid emitting pending global vtable setup for classes without methods
- update REA tests to match absence of vtables for simple classes

## Testing
- `Tests/run_rea_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c33ea8633c832aae9f4dc9f1bef140