### PR TITLE
Register thread builtins for Rea

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -3891,6 +3891,8 @@ void registerAllBuiltins(void) {
     registerBuiltinFunction("WhereY", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("BIWhereY", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("printf", AST_FUNCTION_DECL, NULL); // special-case handled by compiler
+    registerBuiltinFunction("CreateThread", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("WaitForThread", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("mutex", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("rcmutex", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("lock", AST_PROCEDURE_DECL, NULL);


### PR DESCRIPTION
## Summary
- Ensure core VM thread helpers are visible to the Rea front end
- Register `CreateThread` and `WaitForThread` as built-in functions

## Testing
- `cmake --build build`
- `Tests/run_rea_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c4243fb2a8832aa1ac7a99f9c954cd