### PR TITLE
Invalidate cache when frontend binary changes

### DIFF
--- a/Tests/run_clike_tests.sh
+++ b/Tests/run_clike_tests.sh
@@ -161,4 +161,37 @@ fi
 rm -rf "$tmp_home" "$src_dir"
 echo
 
+# Cache invalidation test when the CLike binary is newer than the cache
+echo "---- CacheBinaryStalenessTest ----"
+tmp_home=$(mktemp -d)
+src_dir=$(mktemp -d)
+cat > "$src_dir/BinaryTest.cl" <<'EOF'
+int main() {
+    printf("first\n");
+    return 0;
+}
+EOF
+sleep 1
+set +e
+(cd "$src_dir" && HOME="$tmp_home" "$CLIKE_BIN" BinaryTest.cl > "$tmp_home/out1" 2> "$tmp_home/err1")
+status1=$?
+set -e
+if [ $status1 -eq 0 ] && grep -q 'first' "$tmp_home/out1"; then
+  sleep 2
+  touch "$CLIKE_BIN"
+  set +e
+  (cd "$src_dir" && HOME="$tmp_home" "$CLIKE_BIN" BinaryTest.cl > "$tmp_home/out2" 2> "$tmp_home/err2")
+  status2=$?
+  set -e
+  if [ $status2 -ne 0 ] || grep -q 'Loaded cached byte code' "$tmp_home/err2"; then
+    echo "Cache binary staleness test failed: expected cache invalidation" >&2
+    EXIT_CODE=1
+  fi
+else
+  echo "Cache binary staleness test failed to run" >&2
+  EXIT_CODE=1
+fi
+rm -rf "$tmp_home" "$src_dir"
+echo
+
 exit $EXIT_CODE

--- a/Tests/run_rea_tests.sh
+++ b/Tests/run_rea_tests.sh
@@ -139,4 +139,34 @@ fi
 rm -rf "$tmp_home" "$src_dir"
 echo
 
+# Cache invalidation test when the Rea binary is newer than the cache
+echo "---- CacheBinaryStalenessTest ----"
+tmp_home=$(mktemp -d)
+src_dir=$(mktemp -d)
+cat > "$src_dir/BinaryTest.rea" <<'EOF'
+writeln("first");
+EOF
+sleep 1
+set +e
+(cd "$src_dir" && HOME="$tmp_home" "$REA_BIN" BinaryTest.rea > "$tmp_home/out1" 2> "$tmp_home/err1")
+status1=$?
+set -e
+if [ $status1 -eq 0 ] && grep -q 'first' "$tmp_home/out1"; then
+  sleep 2
+  touch "$REA_BIN"
+  set +e
+  (cd "$src_dir" && HOME="$tmp_home" "$REA_BIN" BinaryTest.rea > "$tmp_home/out2" 2> "$tmp_home/err2")
+  status2=$?
+  set -e
+  if [ $status2 -ne 0 ] || grep -q 'Loaded cached byte code' "$tmp_home/err2"; then
+    echo "Cache binary staleness test failed: expected cache invalidation" >&2
+    EXIT_CODE=1
+  fi
+else
+  echo "Cache binary staleness test failed to run" >&2
+  EXIT_CODE=1
+fi
+rm -rf "$tmp_home" "$src_dir"
+echo
+
 exit $EXIT_CODE

--- a/src/Pascal/main.c
+++ b/src/Pascal/main.c
@@ -70,7 +70,7 @@ void initSymbolSystem(void) {
 #endif
 }
 
-int runProgram(const char *source, const char *programName, int dump_ast_json_flag, int dump_bytecode_flag, int dump_bytecode_only_flag) {
+int runProgram(const char *source, const char *programName, const char *frontend_path, int dump_ast_json_flag, int dump_bytecode_flag, int dump_bytecode_only_flag) {
     if (globalSymbols == NULL) {
         fprintf(stderr, "Internal error: globalSymbols hash table is NULL at the start of runProgram.\n");
         EXIT_FAILURE_HANDLER();
@@ -111,7 +111,7 @@ int runProgram(const char *source, const char *programName, int dump_ast_json_fl
             overall_success_status = true;
         } else {
             GlobalAST = optimizePascalAST(GlobalAST);
-            used_cache = loadBytecodeFromCache(programName, NULL, 0, &chunk);
+            used_cache = loadBytecodeFromCache(programName, frontend_path, NULL, 0, &chunk);
             bool compilation_ok_for_vm = true;
             if (!used_cache) {
                 if (dump_bytecode_flag) {
@@ -310,7 +310,7 @@ int main(int argc, char *argv[]) {
     }
 
     // Call runProgram
-    int result = runProgram(source_buffer, programName, dump_ast_json_flag, dump_bytecode_flag, dump_bytecode_only_flag);
+    int result = runProgram(source_buffer, programName, argv[0], dump_ast_json_flag, dump_bytecode_flag, dump_bytecode_only_flag);
     free(source_buffer); // Free the source code buffer
     return vmExitWithCleanup(result);
 }

--- a/src/clike/main.c
+++ b/src/clike/main.c
@@ -199,7 +199,7 @@ int main(int argc, char **argv) {
     }
     BytecodeChunk chunk;
     initBytecodeChunk(&chunk);
-    bool used_cache = loadBytecodeFromCache(path, (const char**)dep_paths, clike_import_count, &chunk);
+    bool used_cache = loadBytecodeFromCache(path, argv[0], (const char**)dep_paths, clike_import_count, &chunk);
     if (dep_paths) {
         for (int i = 0; i < clike_import_count; ++i) free(dep_paths[i]);
         free(dep_paths);

--- a/src/core/cache.c
+++ b/src/core/cache.c
@@ -389,6 +389,7 @@ static bool readValue(FILE* f, Value* out) {
 }
 
 bool loadBytecodeFromCache(const char* source_path,
+                           const char* frontend_path,
                            const char** dependencies,
                            int dep_count,
                            BytecodeChunk* chunk) {
@@ -402,12 +403,15 @@ bool loadBytecodeFromCache(const char* source_path,
     int const_count = 0;
     int read_consts = 0;
 
-    if (!isCacheFresh(cache_path, source_path)) {
+    if (!isCacheFresh(cache_path, source_path) ||
+        (frontend_path && !isCacheFresh(cache_path, frontend_path))) {
+        unlink(cache_path);
         free(cache_path);
         return false;
     }
     for (int i = 0; dependencies && i < dep_count; ++i) {
         if (!isCacheFresh(cache_path, dependencies[i])) {
+            unlink(cache_path);
             free(cache_path);
             return false;
         }

--- a/src/core/cache.h
+++ b/src/core/cache.h
@@ -5,6 +5,7 @@
 #include "compiler/bytecode.h"
 
 bool loadBytecodeFromCache(const char* source_path,
+                           const char* frontend_path,
                            const char** dependencies,
                            int dep_count,
                            BytecodeChunk* chunk);

--- a/src/rea/main.c
+++ b/src/rea/main.c
@@ -299,7 +299,7 @@ int main(int argc, char **argv) {
 
     BytecodeChunk chunk;
     initBytecodeChunk(&chunk);
-    bool used_cache = loadBytecodeFromCache(path, dep_array, dep_count, &chunk);
+    bool used_cache = loadBytecodeFromCache(path, argv[0], dep_array, dep_count, &chunk);
     if (dep_array) free(dep_array);
     if (used_cache) {
 #if defined(__APPLE__)


### PR DESCRIPTION
## Summary
- Invalidate bytecode cache when the frontend executable is newer than cached bytecode
- Pass frontend path into cache loader for Pascal, CLike, and Rea drivers
- Add regression tests to ensure caches rebuild after frontend updates

## Testing
- `cmake -S . -B build`
- `cmake --build build -j 4`
- `Tests/run_pascal_tests.sh`
- `Tests/run_clike_tests.sh`
- `Tests/run_rea_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c44a4a8e9c832a8303d64f8823a829