### PR TITLE
Support object method thread spawns

### DIFF
--- a/src/rea/parser.c
+++ b/src/rea/parser.c
@@ -1192,7 +1192,8 @@ static AST *parseVarDecl(ReaParser *p) {
 
     AST *baseType = copyAST(typeNode); // copy uses original token pointers; keep until end
     AST *compound = newASTNode(AST_COMPOUND, NULL);
-    compound->is_global_scope = true;
+    // Mark as global scope only when parsing at the top level
+    compound->is_global_scope = (p->currentFunctionType == TYPE_VOID && p->currentClassName == NULL);
 
     bool first = true;
     while (1) {


### PR DESCRIPTION
## Summary
- restore the Rea Mandelbrot demo to use instance-method thread spawns
- allow `spawn` to pass the receiver via `CreateThread` when a method is targeted
- only mark multi-var declarations as global when parsing at file scope

## Testing
- `cmake -B build`
- `cmake --build build`
- `Tests/run_rea_tests.sh` *(fails: produced partial output)*

------
https://chatgpt.com/codex/tasks/task_e_68c454fa09cc832aab37297dd559188d