### PR TITLE
Define global doneCount for Mandelbrot examples

### DIFF
--- a/Examples/rea/sdl_mandelbrot_interactive
+++ b/Examples/rea/sdl_mandelbrot_interactive
@@ -3,6 +3,8 @@
 // Left click to zoom in, right click to zoom out, Q to quit.
 // Requires SDL support in the Pscal build.
 
+int doneCount;
+
 class MandelbrotApp {
   const int Width = 640;
   const int Height = 480;
@@ -153,9 +155,9 @@ class MandelbrotApp {
   }
 
   void pollCompute() {
-    if (!myself.computing) return;
     int y;
-    int doneCount = 0;
+    if (!myself.computing) return;
+    doneCount = 0;
     for (y = 0; y < myself.Height; y = y + 1) {
       bool done;
       lock(myself.rowMutex);

--- a/Examples/rea/sdl_mandelbrot_interactive_ext
+++ b/Examples/rea/sdl_mandelbrot_interactive_ext
@@ -3,6 +3,8 @@
 // Left click to zoom in, right click to zoom out, Q to quit.
 // Uses the extended builtin MandelbrotRow. Requires SDL support.
 
+int doneCount;
+
 class MandelbrotApp {
   const int Width = 1024;
   const int Height = 768;
@@ -120,9 +122,9 @@ class MandelbrotApp {
   }
 
   void pollCompute() {
-    if (!myself.computing) return;
     int y;
-    int doneCount = 0;
+    if (!myself.computing) return;
+    doneCount = 0;
     for (y = 0; y < myself.Height; y = y + 1) {
       bool done;
       lock(myself.rowMutex);


### PR DESCRIPTION
## Summary
- prevent runtime failure in Mandelbrot demos by defining shared `doneCount`
- initialize and reuse global counter in `pollCompute`

## Testing
- `Tests/run_rea_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c4c7301e2c832a811745692686dc30