### PR TITLE
Ensure locals in Rea methods aren't emitted as globals

### DIFF
--- a/Tests/rea/myself_keyword.err
+++ b/Tests/rea/myself_keyword.err
@@ -1,0 +1,53 @@
+--- Compiling Main Program AST to Bytecode ---
+== Disassembly: Tests/rea/myself_keyword.rea ==
+Offset Line Opcode           Operand  Value / Target (Args)
+------ ---- ---------------- -------- --------------------------
+0000    8 DEFINE_GLOBAL    NameIdx:0   'd' Type:POINTER ('Dummy')
+0005    | ALLOC_OBJECT        3 (fields)
+0007    | SET_GLOBAL          0 'd'
+0009    3 JUMP               24 (to 0036)
+
+--- Procedure dummy_test (at 0012) ---
+0012    4 GET_LOCAL           0 (slot)
+0014    | GET_FIELD_OFFSET    2 (index)
+0016    | GET_INDIRECT
+0017    | CONSTANT            2 '0'
+0019    | EQUAL
+0020    | SET_LOCAL           1 (slot)
+0022    5 GET_LOCAL           1 (slot)
+0024    | JUMP_IF_FALSE       8 (to 0035)
+0027    | CONSTANT            3 '1'
+0029    | GET_LOCAL           0 (slot)
+0031    | GET_FIELD_OFFSET    2 (index)
+0033    | SWAP
+0034    | SET_INDIRECT
+0035    3 RETURN
+0036    0 CONSTANT            4 'Value type ARRAY'
+0038    | DEFINE_GLOBAL    NameIdx:5   'dummy_vtable' Type:ARRAY Dims:1 [0..0] of INTEGER ('integer')
+0048    | SET_GLOBAL          5 'dummy_vtable'
+0050    | GET_GLOBAL          0 'd'
+0052    | DUP
+0053    | GET_FIELD_OFFSET    0 (index)
+0055    | GET_GLOBAL_ADDRESS    5 'dummy_vtable'
+0057    | SET_INDIRECT
+0058    | POP
+0059    9 GET_GLOBAL          0 'd'
+0061    | DUP
+0062    | GET_FIELD_OFFSET    0 (index)
+0064    | GET_INDIRECT
+0065    | CONSTANT            2 '0'
+0067    | SWAP
+0068    | GET_ELEMENT_ADDRESS    1 (dims)
+0070    | GET_INDIRECT
+0071    | PROC_CALL_INDIRECT (args=1)
+0073    0 HALT
+== End Disassembly: Tests/rea/myself_keyword.rea ==
+
+Constants (7):\n  0000: STR   "d"
+  0001: STR   "Dummy"
+  0002: INT   0
+  0003: INT   1
+  0004: Value type ARRAY
+  0005: STR   "dummy_vtable"
+  0006: STR   "integer"
+

--- a/Tests/rea/myself_keyword.rea
+++ b/Tests/rea/myself_keyword.rea
@@ -1,0 +1,9 @@
+class Dummy {
+  int x;
+  void test() {
+    bool allDone = (myself.x == 0);
+    if (allDone) { myself.x = 1; }
+  }
+}
+Dummy d = new Dummy();
+d.test();


### PR DESCRIPTION
## Summary
- prevent local declarations from being misidentified as globals when compiling Rea code
- add regression test for local variable using `myself`

## Testing
- `Tests/run_rea_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c4d4532fb0832a87aff38d2e703ab6