### PR TITLE
Fix json2bc output to produce loadable bytecode

### DIFF
--- a/src/core/cache.h
+++ b/src/core/cache.h
@@ -10,6 +10,7 @@ bool loadBytecodeFromCache(const char* source_path,
                            int dep_count,
                            BytecodeChunk* chunk);
 void saveBytecodeToCache(const char* source_path, const BytecodeChunk* chunk);
+bool saveBytecodeToFile(const char* file_path, const char* source_path, const BytecodeChunk* chunk);
 bool loadBytecodeFromFile(const char* file_path, BytecodeChunk* chunk);
 
 // Build the canonical path for the cache file corresponding to a source path.


### PR DESCRIPTION
## Summary
- serialize bytecode chunks with headers and metadata in a new helper
- expose `saveBytecodeToFile` for writing bytecode in VM-friendly format
- update `pscaljson2bc` to use the new helper so generated files load in `pscalvm`

## Testing
- `build/bin/pascal --dump-ast-json Tests/Pascal/BoolTest | build/bin/pscaljson2bc -o out.bc`
- `build/bin/pscalvm out.bc`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68c6147680ec832aa5f04dbeea3356be