### PR TITLE
Fix C-like function body placement in AST loader

### DIFF
--- a/src/tools/ast_json_loader.c
+++ b/src/tools/ast_json_loader.c
@@ -300,6 +300,17 @@ static AST* parse_ast_object(J* j) {
         (void)expect(j, ',');
     }
 
+    // Some front ends (e.g. the C-like one) serialize function declarations
+    // with the function body stored in the "right" field rather than "extra"
+    // (which is what the Pascal compiler expects).  This leads to missing
+    // bodies during bytecode compilation and, in older builds, crashes.  Detect
+    // this layout and normalize it by moving the body to `extra` if needed.
+    if (node_type == AST_FUNCTION_DECL && extra == NULL && right &&
+        right->type == AST_COMPOUND) {
+        extra = right;
+        right = NULL;
+    }
+
     AST* node = newASTNode(node_type, tok);
     if (tok) { freeToken(tok); tok = NULL; }
     if (vtype != TYPE_UNKNOWN) setTypeAST(node, vtype);


### PR DESCRIPTION
## Summary
- Normalize AST JSON from C-like front end so function bodies are loaded into `extra`
- Prevent missing bytecode and crashes during json2bc compilation

## Testing
- `cmake --build build`
- `build/bin/clike --dump-ast-json /tmp/example | build/bin/pscaljson2bc -o out.bc`
- `build/bin/pscald out.bc`
- `ctest` *(hangs: `Start 1: pascal_tests`)*


------
https://chatgpt.com/codex/tasks/task_e_68c623ff2c7c832a834f7a028fd785c3