### PR TITLE
Add Byte() cast builtin across frontends

### DIFF
--- a/Tests/Pascal/TypeTestSuite
+++ b/Tests/Pascal/TypeTestSuite
@@ -395,6 +395,7 @@ begin
   testByte := 128;
   tempInt := testByte;
   AssertEqualInt(128, tempInt, 'Assign Integer to Byte');
+  AssertEqualInt(255, byte(511), 'Byte(511)');
 end;
 
 procedure TestWordType;

--- a/Tests/Pascal/TypeTestSuite.out
+++ b/Tests/Pascal/TypeTestSuite.out
@@ -103,6 +103,7 @@ START: High(byte): PASS
 START: Inc(Byte): PASS
 START: Dec(Byte, 5): PASS
 START: Assign Integer to Byte: PASS
+START: Byte(511): PASS
 
 --- Testing WORD ---
 START: Word Assign 0: PASS

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -127,6 +127,28 @@ static Value vmBuiltinToChar(VM* vm, int arg_count, Value* args) {
     return makeChar((int)c);
 }
 
+static Value vmBuiltinToByte(VM* vm, int arg_count, Value* args) {
+    if (arg_count != 1) {
+        runtimeError(vm, "byte(x) expects 1 argument.");
+        return makeByte(0);
+    }
+    Value v = args[0];
+    unsigned char b = 0;
+    if (isRealType(v.type)) {
+        long double d = AS_REAL(v);
+        b = (unsigned char)((long long)d);
+    } else if (IS_INTLIKE(v)) {
+        b = (unsigned char)AS_INTEGER(v);
+    } else if (v.type == TYPE_BOOLEAN) {
+        b = v.i_val ? 1 : 0;
+    } else if (v.type == TYPE_CHAR) {
+        b = (unsigned char)v.c_val;
+    } else {
+        b = 0;
+    }
+    return makeByte(b);
+}
+
 static Value vmBuiltinToBool(VM* vm, int arg_count, Value* args) {
     if (arg_count != 1) {
         runtimeError(vm, "bool(x) expects 1 argument.");
@@ -191,6 +213,7 @@ static const VmBuiltinMapping vmBuiltinDispatchTable[] = {
     {"blinktext", vmBuiltinBlinktext},
     {"boldtext", vmBuiltinBoldtext},
     {"bool", vmBuiltinToBool},
+    {"byte", vmBuiltinToByte},
     {"bytecodeversion", vmBuiltinBytecodeVersion},
     {"ceil", vmBuiltinCeil},
     {"char", vmBuiltinToChar},
@@ -3768,6 +3791,7 @@ void registerAllBuiltins(void) {
     registerBuiltinFunction("ArcTan", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("Assign", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("Beep", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("Byte", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("Ceil", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("Chr", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("Close", AST_PROCEDURE_DECL, NULL);
@@ -3918,5 +3942,6 @@ void registerAllBuiltins(void) {
     registerVmBuiltin("tofloat",  vmBuiltinToFloat);
     registerVmBuiltin("tochar",   vmBuiltinToChar);
     registerVmBuiltin("tobool",   vmBuiltinToBool);
+    registerVmBuiltin("tobyte",   vmBuiltinToByte);
     pthread_mutex_unlock(&builtin_registry_mutex);
 }

--- a/src/clike/builtins.c
+++ b/src/clike/builtins.c
@@ -72,10 +72,12 @@ void clikeRegisterBuiltins(void) {
     registerBuiltinFunction("float", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("char", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("bool", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("byte", AST_FUNCTION_DECL, NULL);
     /* synonyms to avoid parser conflicts with type tokens */
     registerBuiltinFunction("toint", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("todouble", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("tofloat", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("tochar", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("tobool", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("tobyte", AST_FUNCTION_DECL, NULL);
 }

--- a/src/clike/semantics.c
+++ b/src/clike/semantics.c
@@ -13,6 +13,7 @@ static VarType builtinReturnType(const char* name) {
 
     if (strcasecmp(name, "chr")  == 0) return TYPE_CHAR;
     if (strcasecmp(name, "ord")  == 0) return TYPE_INT32;
+    if (strcasecmp(name, "byte") == 0 || strcasecmp(name, "tobyte") == 0) return TYPE_BYTE;
 
     if (strcasecmp(name, "sqrt") == 0) return TYPE_LONG_DOUBLE;
 

--- a/src/rea/main.c
+++ b/src/rea/main.c
@@ -275,12 +275,14 @@ int main(int argc, char **argv) {
     registerBuiltinFunction("float", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("char", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("bool", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("byte", AST_FUNCTION_DECL, NULL);
     /* synonyms to avoid keyword collisions */
     registerBuiltinFunction("toint", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("todouble", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("tofloat", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("tochar", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("tobool", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("tobyte", AST_FUNCTION_DECL, NULL);
 
     if (strict_mode) reaSetStrictMode(1);
     AST *program = parseRea(src);


### PR DESCRIPTION
## Summary
- add `Byte()` cast routine to VM and register it as a builtin
- expose `Byte()` helper in Pascal, C-like, and Rea front-ends
- expand type tests to cover `Byte()` conversion

## Testing
- `cmake -S . -B build`
- `cmake --build build -j8`
- `make -C Tests`


------
https://chatgpt.com/codex/tasks/task_e_68c631588b24832a8812d9bb67c19dff