### PR TITLE
Fix case-sensitive path handling in Rea test runner

### DIFF
--- a/Tests/run_rea_tests.sh
+++ b/Tests/run_rea_tests.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+# Resolve the script directory and repository root using realpath to ensure
+# the canonical filesystem casing is preserved even when the script is invoked
+# via a differently-cased path (e.g. "tests" vs "Tests").  macOS filesystems
+# are typically case-insensitive, which previously led to lowercase paths being
+# passed to the compiler and causing test diffs.
+SCRIPT_DIR="$(python3 -c 'import os,sys; print(os.path.realpath(os.path.dirname(sys.argv[1])))' "${BASH_SOURCE[0]}")"
+ROOT_DIR="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$SCRIPT_DIR/..")"
 REA_BIN="$ROOT_DIR/build/bin/rea"
 RUNNER_PY="$ROOT_DIR/Tests/tools/run_with_timeout.py"
 TEST_TIMEOUT="${TEST_TIMEOUT:-25}"


### PR DESCRIPTION
## Summary
- Resolve Rea test runner script directory using `realpath` to preserve filesystem casing
- Prevents lowercase paths from being passed to the compiler on case-insensitive filesystems

## Testing
- `cmake --build . --target rea`
- `Tests/run_rea_tests.sh`
- `build/bin/rea --dump-bytecode-only Tests/rea/assign_expr.rea`


------
https://chatgpt.com/codex/tasks/task_e_68c6463aeffc832ab60953ae56849372