### PR TITLE
Fix Rea SDL examples font init

### DIFF
--- a/Docs/pascal_language_reference.md
+++ b/Docs/pascal_language_reference.md
@@ -220,7 +220,7 @@ The Pascal front end exposes the PSCAL VM's built-ins, including:
 - Memory: `New`, `Dispose`.
 - Console/text: `GotoXY`, `TextColor`, `TextBackground`, `ClrScr`, `WhereX`, `WhereY`.
 - Concurrency (see below): `spawn`, `join`, `mutex`, `rcmutex`, `lock`, `unlock`, `destroy`.
-- SDL-based graphics/sound (when built with `-DSDL=ON`): e.g., `InitGraph`, `CloseGraph`, `UpdateScreen`, `SetRGBColor`, `DrawLine`, `FillRect`, `FillCircle`, `CreateTexture`, `UpdateTexture`, `DestroyTexture`, text helpers like `InitTextSystem`, `OutTextXY`, and audio: `InitSoundSystem`, `LoadSound`, `PlaySound`, `IsSoundPlaying`, `FreeSound`, `QuitSoundSystem`.
+- SDL-based graphics/sound (when built with `-DSDL=ON`): e.g., `InitGraph`, `CloseGraph`, `UpdateScreen`, `SetRGBColor`, `DrawLine`, `FillRect`, `FillCircle`, `CreateTexture`, `UpdateTexture`, `DestroyTexture`, text helpers like `InitTextSystem(FontFileName, FontSize)`, `OutTextXY`, and audio: `InitSoundSystem`, `LoadSound`, `PlaySound`, `IsSoundPlaying`, `FreeSound`, `QuitSoundSystem`.
 
 Note: SDL built-ins are available only in SDL-enabled builds. Headless CI typically skips these routines.
 

--- a/Docs/pscal_vm_builtins.md
+++ b/Docs/pscal_vm_builtins.md
@@ -241,7 +241,7 @@ These built-ins are available when Pscal is built with SDL support.
 | freesound | (sound: Sound) | void | Free a loaded sound. |
 | playsound | (sound: Sound) | void | Play sound. |
 | issoundplaying | (sound: Sound) | Boolean | Query if sound playing. |
-| inittextsystem | () | void | Initialize text subsystem. |
+| inittextsystem | (fontPath: String, fontSize: Integer) | void | Initialize text subsystem with a TTF font. |
 | quittextsystem | () | void | Shut down text subsystem. |
 | getmousestate | (var x: Integer, var y: Integer, var buttons: Integer) | void | Query mouse position and buttons. |
 | getticks | () | Integer | Milliseconds since start. |

--- a/Examples/rea/sdl_demo
+++ b/Examples/rea/sdl_demo
@@ -2,9 +2,20 @@
 // Rea SDL demo (requires building with -DSDL=ON)
 
 writeln("Starting Rea SDL demo (initializing text system)...");
-InitTextSystem();
+InitGraph(1, 1, "Rea SDL demo");
+string systemFontPath = "/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf";
+string repoFontPath1 = "fonts/Roboto/static/Roboto-Regular.ttf";
+string repoFontPath2 = "../../fonts/Roboto/static/Roboto-Regular.ttf";
+if (fileexists(systemFontPath)) {
+  InitTextSystem(systemFontPath, 18);
+} else if (fileexists(repoFontPath1)) {
+  InitTextSystem(repoFontPath1, 18);
+} else {
+  InitTextSystem(repoFontPath2, 18);
+}
 SetColor(255, 255, 255, 255);
-writeln("Text system initialized. (No window shown in this demo.)");
+writeln("Text system initialized.");
 QuitTextSystem();
+CloseGraph();
 writeln("Rea SDL demo finished.");
 

--- a/Examples/rea/sdl_mandelbrot_interactive
+++ b/Examples/rea/sdl_mandelbrot_interactive
@@ -48,7 +48,16 @@ class MandelbrotApp {
     myself.minIm = -1.2;
     myself.maxIm = myself.minIm + (myself.maxRe - myself.minRe) * myself.Height / myself.Width;
     initgraph(myself.Width, myself.Height, "Rea Mandelbrot");
-    inittextsystem();
+    string systemFontPath = "/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf";
+    string repoFontPath1 = "fonts/Roboto/static/Roboto-Regular.ttf";
+    string repoFontPath2 = "../../fonts/Roboto/static/Roboto-Regular.ttf";
+    if (fileexists(systemFontPath)) {
+      inittextsystem(systemFontPath, 18);
+    } else if (fileexists(repoFontPath1)) {
+      inittextsystem(repoFontPath1, 18);
+    } else {
+      inittextsystem(repoFontPath2, 18);
+    }
     printf("[int] init: initgraph done (%dx%d)\n", myself.Width, myself.Height);
     myself.textureID = createtexture(myself.Width, myself.Height);
     if (myself.textureID < 0) {

--- a/Examples/rea/sdl_mandelbrot_interactive_ext
+++ b/Examples/rea/sdl_mandelbrot_interactive_ext
@@ -46,7 +46,16 @@ class MandelbrotApp {
     myself.minIm = -1.2;
     myself.maxIm = myself.minIm + (myself.maxRe - myself.minRe) * myself.Height / myself.Width;
     initgraph(myself.Width, myself.Height, "Rea Mandelbrot (ext)");
-    inittextsystem();
+    string systemFontPath = "/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf";
+    string repoFontPath1 = "fonts/Roboto/static/Roboto-Regular.ttf";
+    string repoFontPath2 = "../../fonts/Roboto/static/Roboto-Regular.ttf";
+    if (fileexists(systemFontPath)) {
+      inittextsystem(systemFontPath, 18);
+    } else if (fileexists(repoFontPath1)) {
+      inittextsystem(repoFontPath1, 18);
+    } else {
+      inittextsystem(repoFontPath2, 18);
+    }
     myself.textureID = createtexture(myself.Width, myself.Height);
     if (myself.textureID < 0) { printf("Error: unable to create texture.\n"); halt(); }
     myself.quit = false;


### PR DESCRIPTION
## Summary
- initialize SDL text subsystem in Rea examples with a proper TTF font path and size
- document new inittextsystem signature

## Testing
- `cd Tests; ./run_all_tests` *(fails: pascal, clike, rea, and pscalvm binaries not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6bda8d8fc832a9e4aaeb0fd16ff2c