### PR TITLE
rea: recognize 'string' type keyword

### DIFF
--- a/src/rea/LANGUAGE_SPEC.md
+++ b/src/rea/LANGUAGE_SPEC.md
@@ -50,7 +50,7 @@ floating-point types as the default for new development.
 | `float` | `TYPE_DOUBLE` | 64-bit floating-point number. |
 | `float32` | `TYPE_FLOAT` | 32-bit floating-point number. |
 | `long double` | `TYPE_LONG_DOUBLE` | Extended precision floating-point number. |
-| `str` | `TYPE_STRING` | Dynamic-length string. |
+| `str` or `string` | `TYPE_STRING` | Dynamic-length string. |
 | `bool` | `TYPE_BOOLEAN` | Boolean values (`true` and `false`). |
 | `void` | `TYPE_VOID` | Absence of value (for procedures). |
 

--- a/src/rea/lexer.c
+++ b/src/rea/lexer.c
@@ -135,6 +135,7 @@ static ReaTokenType keywordType(const char *start, size_t length) {
             if (strncmp(start, "switch", 6) == 0) return REA_TOKEN_SWITCH;
             if (strncmp(start, "double", 6) == 0) return REA_TOKEN_FLOAT;
             if (strncmp(start, "myself", 6) == 0) return REA_TOKEN_MYSELF;
+            if (strncmp(start, "string", 6) == 0) return REA_TOKEN_STR;
             break;
         case 7:
             if (strncmp(start, "extends", 7) == 0) return REA_TOKEN_EXTENDS;


### PR DESCRIPTION
## Summary
- allow `string` as alias for `str` in Rea lexer
- document `string` synonym in language spec

## Testing
- `ctest -R rea_tests`

------
https://chatgpt.com/codex/tasks/task_e_68c6c45a7604832aa9bd5c6edf05dcce