### PR TITLE
Handle 'my' alias for current object in Rea

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -530,7 +530,8 @@ static void emitArrayFieldInitializers(AST* recordType, BytecodeChunk* chunk, in
 static AST* getRecordTypeFromExpr(AST* expr) {
     if (!expr) return NULL;
     if (expr->type == AST_VARIABLE && expr->token && expr->token->value &&
-        strcasecmp(expr->token->value, "myself") == 0 &&
+        (strcasecmp(expr->token->value, "myself") == 0 ||
+         strcasecmp(expr->token->value, "my") == 0) &&
         current_class_record_type && current_class_record_type->type == AST_RECORD_TYPE) {
         return current_class_record_type;
     }
@@ -1574,7 +1575,8 @@ static void compileLValue(AST* node, BytecodeChunk* chunk, int current_line_appr
             if ((!recType || recType->type != AST_RECORD_TYPE) &&
                 node->left && node->left->type == AST_VARIABLE &&
                 node->left->token && node->left->token->value &&
-                strcasecmp(node->left->token->value, "myself") == 0) {
+                (strcasecmp(node->left->token->value, "myself") == 0 ||
+                 strcasecmp(node->left->token->value, "my") == 0)) {
                 if (!recType && current_class_record_type && current_class_record_type->type == AST_RECORD_TYPE) {
                     recType = current_class_record_type;
                 }
@@ -1604,7 +1606,8 @@ static void compileLValue(AST* node, BytecodeChunk* chunk, int current_line_appr
             int fieldOffset = getRecordFieldOffset(recType, node->token ? node->token->value : NULL);
             if (fieldOffset < 0 && recType && node->left && node->left->type == AST_VARIABLE &&
                 node->left->token && node->left->token->value &&
-                strcasecmp(node->left->token->value, "myself") == 0) {
+                (strcasecmp(node->left->token->value, "myself") == 0 ||
+                 strcasecmp(node->left->token->value, "my") == 0)) {
                 // Fallback: case-insensitive search through class fields
                 int offset = 0;
                 if (recType->extra && recType->extra->token && recType->extra->token->value) {
@@ -3218,7 +3221,10 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
                     // Prefer explicit type identifier token value
                     if (tdef->type == AST_TYPE_IDENTIFIER || tdef->type == AST_VARIABLE) {
                         cls_name = tdef->token->value;
-                    } else if (recv->token && recv->token->value && strcasecmp(recv->token->value, "myself") == 0 && current_function_compiler && current_function_compiler->function_symbol) {
+                    } else if (recv->token && recv->token->value &&
+                               (strcasecmp(recv->token->value, "myself") == 0 ||
+                                strcasecmp(recv->token->value, "my") == 0) &&
+                               current_function_compiler && current_function_compiler->function_symbol) {
                         // Derive from current function name 'Class_method' if available
                         const char* fname = current_function_compiler->function_symbol->name;
                         const char* us = fname ? strchr(fname, '_') : NULL;

--- a/src/rea/parser.c
+++ b/src/rea/parser.c
@@ -35,7 +35,9 @@ void reaSetStrictMode(int enable) { g_rea_strict_mode = enable ? 1 : 0; }
 // Strict scan for forbidden top-level constructs
 static bool strictScanTop(AST* n) {
     if (!n) return false;
-    if ((n->type == AST_VARIABLE && n->token && n->token->value && strcasecmp(n->token->value, "myself") == 0) ||
+    if ((n->type == AST_VARIABLE && n->token && n->token->value &&
+         (strcasecmp(n->token->value, "myself") == 0 ||
+          strcasecmp(n->token->value, "my") == 0)) ||
         n->type == AST_RETURN) {
         return true;
     }
@@ -819,9 +821,11 @@ static AST *parseFactor(ReaParser *p) {
                     }
                     if (p->current.type == REA_TOKEN_RIGHT_PAREN) reaAdvance(p);
                     // Build call node and prepend receiver as first arg
-                    // Potentially mangle if receiver is 'myself' or freshly constructed 'new Class'
+                    // Potentially mangle if receiver is 'myself'/`my` or freshly constructed 'new Class'
                     const char* cls = NULL;
-                    if (node->type == AST_VARIABLE && node->token && node->token->value && strcasecmp(node->token->value, "myself") == 0) {
+                    if (node->type == AST_VARIABLE && node->token && node->token->value &&
+                        (strcasecmp(node->token->value, "myself") == 0 ||
+                         strcasecmp(node->token->value, "my") == 0)) {
                         cls = p->currentClassName;
                     } else if (node->type == AST_NEW && node->token && node->token->value) {
                         cls = node->token->value;

--- a/src/rea/semantic.c
+++ b/src/rea/semantic.c
@@ -357,7 +357,9 @@ static const char *resolveExprClass(AST *expr, ClassInfo *currentClass) {
          * the class currently being validated so that expressions like
          * `my.field` or `my.method()` resolve correctly.
          */
-        if (currentClass && strcasecmp(expr->token->value, "myself") == 0) {
+        if (currentClass && expr->token && expr->token->value &&
+            (strcasecmp(expr->token->value, "myself") == 0 ||
+             strcasecmp(expr->token->value, "my") == 0)) {
             return currentClass->name;
         }
         AST *decl = findStaticDeclarationInAST(expr->token->value, expr, gProgramRoot);
@@ -570,7 +572,8 @@ static void validateNodeInternal(AST *node, ClassInfo *currentClass) {
                 if (node->child_count > 0 && node->children[0] &&
                     node->children[0]->type == AST_VARIABLE &&
                     node->children[0]->token && node->children[0]->token->value &&
-                    strcasecmp(node->children[0]->token->value, "myself") == 0) {
+                    (strcasecmp(node->children[0]->token->value, "myself") == 0 ||
+                     strcasecmp(node->children[0]->token->value, "my") == 0)) {
                     firstIsMyself = true;
                 }
 


### PR DESCRIPTION
## Summary
- recognize `my` as an alias for `myself` during parsing, semantic analysis, and compilation
- resolve receiver-based method calls and records when using `my`

## Testing
- `ctest --test-dir build -R rea_tests`

------
https://chatgpt.com/codex/tasks/task_e_68c6f461b6dc832aa25534f7c5960649