### PR TITLE
Fix missing Planet_draw function in SDL planets example

### DIFF
--- a/Examples/rea/sdl_planets
+++ b/Examples/rea/sdl_planets
@@ -58,10 +58,11 @@ class Planet {
       join myself.tid;
     }
 
-    void draw() {
-      setrgbcolor(myself.r, myself.g, myself.b);
-      fillcircle(trunc(myself.posX), trunc(myself.posY), myself.size);
-    }
+  }
+
+void Planet_draw(Planet p) {
+  setrgbcolor(p.r, p.g, p.b);
+  fillcircle(trunc(p.posX), trunc(p.posY), p.size);
 }
 
 class SolarSystemApp {


### PR DESCRIPTION
## Summary
- add explicit `Planet_draw` helper function
- call the new helper during solar system rendering

## Testing
- `cmake ..`
- `make -j4`
- `build/bin/rea Examples/rea/sdl_planets` *(fails: Undefined global variable 'initgraph')*

------
https://chatgpt.com/codex/tasks/task_e_68c70084f490832a8e38131fcced984d