### PR TITLE
Fix thread join and frame pacing in SDL solar system example

### DIFF
--- a/Examples/rea/sdl_planets
+++ b/Examples/rea/sdl_planets
@@ -54,7 +54,10 @@ class Planet {
       myself.tid = spawn Planet_updateWorker(myself);
     }
 
-    void join() {
+    // Wait for the worker thread to finish. "join" is a reserved keyword in
+    // Rea, so give the method a more explicit name to avoid confusion with the
+    // built-in thread operation.
+    void joinThread() {
       join myself.tid;
     }
 
@@ -116,7 +119,7 @@ class SolarSystemApp {
   void joinThreads() {
     int i = 1;
     while (i <= NumPlanets) {
-      Planet_join(myself.planets[i]);
+      Planet_joinThread(myself.planets[i]);
       i = i + 1;
     }
   }
@@ -136,7 +139,9 @@ class SolarSystemApp {
         if (toupper(c) == 'Q') quit = true;
       }
       SolarSystemApp_draw(myself);
-      graphloop(my.FrameDelay);
+      // Use the object's frame delay to pace the main loop and yield time to
+      // planet worker threads, ensuring smooth motion.
+      graphloop(myself.FrameDelay);
     }
     SolarSystemApp_joinThreads(myself);
     closegraph();


### PR DESCRIPTION
## Summary
- Rename `Planet.join` to `Planet.joinThread` to avoid reserved keyword and update usage in `SolarSystemApp`
- Pace the main loop with `FrameDelay` so planet threads update smoothly

## Testing
- `./run_all_tests` *(fails: No such file or directory)*
- `build/bin/rea Examples/rea/sdl_planets` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c702067af8832a8e2926c5a6bdcff3