### PR TITLE
Handle unmangled class methods in Rea semantic analysis

### DIFF
--- a/src/rea/semantic.c
+++ b/src/rea/semantic.c
@@ -232,60 +232,54 @@ static void collectMethods(AST *node) {
                 free(cls);
             }
         } else if (node->parent && node->parent->type == AST_COMPOUND) {
-            /* Handle un-mangled methods; parameter info may be in a preceding sibling */
-            AST *param = NULL;
-            for (int i = 0; i < node->parent->child_count; i++) {
-                if (node->parent->children[i] == node) {
-                    if (i > 0) param = node->parent->children[i - 1];
-                    break;
+            /* Handle un-mangled methods; examine first parameter for class type */
+            AST *param = (node->child_count > 0) ? node->children[0] : NULL;
+            if (param && param->type == AST_VAR_DECL) {
+                AST *ptype = param->right;
+                while (ptype && (ptype->type == AST_POINTER_TYPE || ptype->type == AST_ARRAY_TYPE)) {
+                    ptype = ptype->right;
                 }
-            }
-            if (param && param->child_count > 0) param = param->children[0];
-            if (param && param->type != AST_VAR_DECL) param = NULL;
-            AST *ptype = param ? param->right : NULL;
-            while (ptype && (ptype->type == AST_POINTER_TYPE || ptype->type == AST_ARRAY_TYPE)) {
-                ptype = ptype->right;
-            }
-            if (ptype && ptype->type == AST_TYPE_REFERENCE && ptype->token && ptype->token->value) {
-                const char *cls = ptype->token->value;
-                ClassInfo *ci = lookupClass(cls);
-                if (ci) {
-                    size_t ln = strlen(cls) + 1 + strlen(fullname) + 1;
-                    char *mangled = (char *)malloc(ln);
-                    if (mangled) {
-                        snprintf(mangled, ln, "%s_%s", cls, fullname);
-                        free(node->token->value);
-                        node->token->value = mangled;
-                        node->token->length = strlen(mangled);
-                        fullname = node->token->value;
-                    }
-                    char *lname = lowerDup(fullname + strlen(cls) + 1);
-                    if (lname) {
-                        if (hashTableLookup(ci->methods, lname)) {
-                            fprintf(stderr, "Duplicate method '%s' in class '%s'\n", fullname + strlen(cls) + 1, cls);
-                            pascal_semantic_error_count++;
-                            free(lname);
-                        } else {
-                            Symbol *sym = (Symbol *)calloc(1, sizeof(Symbol));
-                            Value *v = (Value *)calloc(1, sizeof(Value));
-                            if (sym && v) {
-                                sym->name = lname;
-                                v->ptr_val = (Value *)node;
-                                sym->value = v;
-                                sym->type_def = node;
-                                hashTableInsert(ci->methods, sym);
-                                char lowerName[MAX_SYMBOL_LENGTH];
-                                lowerCopy(fullname, lowerName);
-                                if (!lookupProcedure(lowerName)) {
-                                    Symbol *ps = (Symbol *)calloc(1, sizeof(Symbol));
-                                    if (ps) {
-                                        ps->name = strdup(lowerName);
-                                        ps->type_def = node;
-                                        hashTableInsert(procedure_table, ps);
-                                    }
-                                }
+                if (ptype && ptype->type == AST_TYPE_REFERENCE && ptype->token && ptype->token->value) {
+                    const char *cls = ptype->token->value;
+                    ClassInfo *ci = lookupClass(cls);
+                    if (ci) {
+                        size_t ln = strlen(cls) + 1 + strlen(fullname) + 1;
+                        char *mangled = (char *)malloc(ln);
+                        if (mangled) {
+                            snprintf(mangled, ln, "%s_%s", cls, fullname);
+                            free(node->token->value);
+                            node->token->value = mangled;
+                            node->token->length = strlen(mangled);
+                            fullname = node->token->value;
+                        }
+                        char *lname = lowerDup(fullname + strlen(cls) + 1);
+                        if (lname) {
+                            if (hashTableLookup(ci->methods, lname)) {
+                                fprintf(stderr, "Duplicate method '%s' in class '%s'\n", fullname + strlen(cls) + 1, cls);
+                                pascal_semantic_error_count++;
+                                free(lname);
                             } else {
-                                free(sym); free(v); free(lname);
+                                Symbol *sym = (Symbol *)calloc(1, sizeof(Symbol));
+                                Value *v = (Value *)calloc(1, sizeof(Value));
+                                if (sym && v) {
+                                    sym->name = lname;
+                                    v->ptr_val = (Value *)node;
+                                    sym->value = v;
+                                    sym->type_def = node;
+                                    hashTableInsert(ci->methods, sym);
+                                    char lowerName[MAX_SYMBOL_LENGTH];
+                                    lowerCopy(fullname, lowerName);
+                                    if (!lookupProcedure(lowerName)) {
+                                        Symbol *ps = (Symbol *)calloc(1, sizeof(Symbol));
+                                        if (ps) {
+                                            ps->name = strdup(lowerName);
+                                            ps->type_def = node;
+                                            hashTableInsert(procedure_table, ps);
+                                        }
+                                    }
+                                } else {
+                                    free(sym); free(v); free(lname);
+                                }
                             }
                         }
                     }

--- a/src/rea/semantic.c
+++ b/src/rea/semantic.c
@@ -599,25 +599,23 @@ static void validateNodeInternal(AST *node, ClassInfo *currentClass) {
                     already = true;
                 }
                 ClassInfo *ci = lookupClass(cls);
-                if (ci && lookupMethod(ci, method)) {
-                    if (!already) {
-                        size_t ln = strlen(cls) + 1 + strlen(name) + 1;
-                        char *m = (char*)malloc(ln);
-                        if (m) {
-                            snprintf(m, ln, "%s_%s", cls, name);
-                            free(node->token->value);
-                            node->token->value = m;
-                            node->token->length = strlen(m);
+                if (ci) {
+                    Symbol *ms = lookupMethod(ci, method);
+                    if (ms) {
+                        if (!already) {
+                            size_t ln = strlen(cls) + 1 + strlen(name) + 1;
+                            char *m = (char*)malloc(ln);
+                            if (m) {
+                                snprintf(m, ln, "%s_%s", cls, name);
+                                free(node->token->value);
+                                node->token->value = m;
+                                node->token->length = strlen(m);
+                            }
                         }
-                    }
-                } else if (ci) {
-                    size_t ln = strlen(cls) + 1 + strlen(name) + 1;
-                    char *m = (char*)malloc(ln);
-                    if (m) {
-                        snprintf(m, ln, "%s_%s", cls, name);
-                        free(node->token->value);
-                        node->token->value = m;
-                        node->token->length = strlen(m);
+                    } else {
+                        fprintf(stderr, "Unknown method '%s' on class '%s'\n",
+                                method ? method : "(null)", cls);
+                        pascal_semantic_error_count++;
                     }
                 }
                 if (node->child_count > 0 && node->children[0] &&

--- a/src/rea/semantic.c
+++ b/src/rea/semantic.c
@@ -231,6 +231,66 @@ static void collectMethods(AST *node) {
                 }
                 free(cls);
             }
+        } else if (node->parent && node->parent->type == AST_COMPOUND) {
+            /* Handle un-mangled methods; parameter info may be in a preceding sibling */
+            AST *param = NULL;
+            for (int i = 0; i < node->parent->child_count; i++) {
+                if (node->parent->children[i] == node) {
+                    if (i > 0) param = node->parent->children[i - 1];
+                    break;
+                }
+            }
+            if (param && param->child_count > 0) param = param->children[0];
+            if (param && param->type != AST_VAR_DECL) param = NULL;
+            AST *ptype = param ? param->right : NULL;
+            while (ptype && (ptype->type == AST_POINTER_TYPE || ptype->type == AST_ARRAY_TYPE)) {
+                ptype = ptype->right;
+            }
+            if (ptype && ptype->type == AST_TYPE_REFERENCE && ptype->token && ptype->token->value) {
+                const char *cls = ptype->token->value;
+                ClassInfo *ci = lookupClass(cls);
+                if (ci) {
+                    size_t ln = strlen(cls) + 1 + strlen(fullname) + 1;
+                    char *mangled = (char *)malloc(ln);
+                    if (mangled) {
+                        snprintf(mangled, ln, "%s_%s", cls, fullname);
+                        free(node->token->value);
+                        node->token->value = mangled;
+                        node->token->length = strlen(mangled);
+                        fullname = node->token->value;
+                    }
+                    char *lname = lowerDup(fullname + strlen(cls) + 1);
+                    if (lname) {
+                        if (hashTableLookup(ci->methods, lname)) {
+                            fprintf(stderr, "Duplicate method '%s' in class '%s'\n", fullname + strlen(cls) + 1, cls);
+                            pascal_semantic_error_count++;
+                            free(lname);
+                        } else {
+                            Symbol *sym = (Symbol *)calloc(1, sizeof(Symbol));
+                            Value *v = (Value *)calloc(1, sizeof(Value));
+                            if (sym && v) {
+                                sym->name = lname;
+                                v->ptr_val = (Value *)node;
+                                sym->value = v;
+                                sym->type_def = node;
+                                hashTableInsert(ci->methods, sym);
+                                char lowerName[MAX_SYMBOL_LENGTH];
+                                lowerCopy(fullname, lowerName);
+                                if (!lookupProcedure(lowerName)) {
+                                    Symbol *ps = (Symbol *)calloc(1, sizeof(Symbol));
+                                    if (ps) {
+                                        ps->name = strdup(lowerName);
+                                        ps->type_def = node;
+                                        hashTableInsert(procedure_table, ps);
+                                    }
+                                }
+                            } else {
+                                free(sym); free(v); free(lname);
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 recurse:
@@ -550,9 +610,26 @@ static void validateNodeInternal(AST *node, ClassInfo *currentClass) {
                             node->token->length = strlen(m);
                         }
                     }
-                } else if (ci && !lookupMethod(ci, method)) {
-                    fprintf(stderr, "Unknown method '%s' for class '%s'\n", method, cls);
-                    pascal_semantic_error_count++;
+                } else if (ci) {
+                    size_t ln = strlen(cls) + 1 + strlen(name) + 1;
+                    char *m = (char*)malloc(ln);
+                    if (m) {
+                        snprintf(m, ln, "%s_%s", cls, name);
+                        free(node->token->value);
+                        node->token->value = m;
+                        node->token->length = strlen(m);
+                    }
+                }
+                if (node->child_count > 0 && node->children[0] &&
+                    node->children[0]->type == AST_VARIABLE &&
+                    node->children[0]->token && node->children[0]->token->value &&
+                    (strcasecmp(node->children[0]->token->value, "myself") == 0 ||
+                     strcasecmp(node->children[0]->token->value, "my") == 0)) {
+                    freeAST(node->children[0]);
+                    for (int i = 1; i < node->child_count; i++) {
+                        node->children[i-1] = node->children[i];
+                    }
+                    node->child_count--;
                 }
             }
         } else if (currentClass && node->token) {


### PR DESCRIPTION
## Summary
- Mangle class methods even when parser doesn't prefix them
- Register mangled methods and procedure symbols for compiler lookup
- Normalize procedure calls by removing duplicate implicit `myself` argument

## Testing
- `make -j4`
- `./run_all_tests` *(fails: no output, manual interruption)*

------
https://chatgpt.com/codex/tasks/task_e_68c7667d207c832abbaa8bac96f6f5ec