### PR TITLE
rea: add inherited method alias support

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -213,13 +213,13 @@ static void emitVTables(BytecodeChunk* chunk) {
         Symbol* sym = procedure_table->buckets[b];
         while (sym) {
             Symbol* base = sym->is_alias ? sym->real_symbol : sym;
-            if (base && base->type_def && base->type_def->is_virtual && base->name) {
-                const char* us = strchr(base->name, '_');
+            if (base && base->type_def && base->type_def->is_virtual && sym->name) {
+                const char* us = strchr(sym->name, '_');
                 if (us) {
-                    size_t cls_len = (size_t)(us - base->name);
+                    size_t cls_len = (size_t)(us - sym->name);
                     char cls[256];
                     if (cls_len < sizeof(cls)) {
-                        memcpy(cls, base->name, cls_len);
+                        memcpy(cls, sym->name, cls_len);
                         cls[cls_len] = '\0';
                         int idx = -1;
                         for (int i = 0; i < table_count; i++) {


### PR DESCRIPTION
## Summary
- ensure subclasses inherit parent methods by inserting alias symbols during semantic analysis
- fix vtable generation to respect alias names for inherited methods

## Testing
- `cmake --build build`
- `Tests/run_clike_tests.sh`
- `Tests/run_pascal_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c7a2ee99f8832abca51710e6d03283