### PR TITLE
Fix missing method handling in Rea compiler

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -3206,6 +3206,12 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
                 proc_symbol = proc_symbol->real_symbol;
             }
 
+            // Ensure the target procedure is compiled so its address is available
+            if (proc_symbol && !proc_symbol->is_defined && proc_symbol->type_def) {
+                compileDefinedFunction(proc_symbol->type_def, chunk,
+                                      getLine(proc_symbol->type_def));
+            }
+
             bool isVirtualMethod = (node->child_count > 0 && node->i_val == 0 && proc_symbol && proc_symbol->type_def && proc_symbol->type_def->is_virtual);
 
 #ifdef FRONTEND_REA


### PR DESCRIPTION
## Summary
- handle implicitly declared class methods and assign vtable index
- compile target procedures on demand to guarantee callable addresses

## Testing
- `cmake --build build`
- `build/bin/rea --dump-bytecode-only --no-cache Examples/rea/sdl_planets_sun`


------
https://chatgpt.com/codex/tasks/task_e_68c817e677a4832a92dd5cc8136e6c65