### PR TITLE
Use instance method syntax in Rea examples and docs

### DIFF
--- a/Docs/rea_tutorial.md
+++ b/Docs/rea_tutorial.md
@@ -292,11 +292,11 @@ and draws the scene each frame, and exits when the `Q` key is pressed.
 ### Program entry point
 ```rea
 BallsApp app = new BallsApp();
-BallsApp_run(app);
+app.run();
 ```
 Creates the `BallsApp` instance and invokes its `run` method.
 
-**Syntax notes:** Top‑level code allocates a class with `new` and calls its method using the generated `ClassName_method(instance)` form.
+**Syntax notes:** Top-level code allocates a class with `new` and invokes methods using `object.method()` syntax.
 
 ## Next steps
 

--- a/Examples/rea/sdl_mandelbrot_interactive
+++ b/Examples/rea/sdl_mandelbrot_interactive
@@ -160,7 +160,7 @@ class MandelbrotApp {
     }
 
     for (i = 0; i < myself.ThreadCount; i = i + 1) {
-      myself.tids[i] = spawn MandelbrotApp_computeRowsWorker(myself, i);
+      myself.tids[i] = spawn myself.computeRowsWorker(i);
     }
     myself.computing = true;
   }
@@ -201,7 +201,7 @@ class MandelbrotApp {
         cleardevice(); rendercopy(myself.textureID); outtextxy(8, 8, "Rendering..."); updatescreen();
         myself.lastUpdatedRows = doneCount;
       }
-      MandelbrotApp_joinAndResetThreads(myself);
+      myself.joinAndResetThreads();
       myself.computing = false;
       myself.lastUpdatedRows = 0;
     }
@@ -235,7 +235,7 @@ class MandelbrotApp {
     bool changed = false;
     int key = pollkey();
     if (key != 0) {
-      if (key == 'q' || key == 'Q') { MandelbrotApp_setQuit(myself, true); return false; }
+      if (key == 'q' || key == 'Q') { myself.setQuit(true); return false; }
       double widthRe = (myself.maxRe - myself.minRe);
       double heightIm = (myself.maxIm - myself.minIm);
       double dx = widthRe * 0.5;
@@ -258,10 +258,10 @@ class MandelbrotApp {
       if (winH != myself.Height) { y = (y * myself.Height) / winH; if (y >= myself.Height) y = myself.Height - 1; }
     }
     if ((b & myself.ButtonLeft) != 0 && (myself.prevButtons & myself.ButtonLeft) == 0) {
-      MandelbrotApp_zoom(myself, x, y, 1.0 / myself.ZoomFactor);
+      myself.zoom(x, y, 1.0 / myself.ZoomFactor);
       changed = true;
     } else if ((b & myself.ButtonRight) != 0 && (myself.prevButtons & myself.ButtonRight) == 0) {
-      MandelbrotApp_zoom(myself, x, y, myself.ZoomFactor);
+      myself.zoom(x, y, myself.ZoomFactor);
       changed = true;
     }
     myself.prevButtons = b;
@@ -269,27 +269,27 @@ class MandelbrotApp {
   }
 
   void run() {
-    MandelbrotApp_init(myself);
+    myself.init();
     bool needRender = true;
     while (!myself.getQuit()) {
       if (needRender && !myself.computing) {
-        MandelbrotApp_startCompute(myself);
+        myself.startCompute();
         needRender = false;
       }
       // Poll ongoing compute to keep UI responsive
-      MandelbrotApp_pollCompute(myself);
+      myself.pollCompute();
       // Small yield to avoid a tight loop hogging CPU and to give SDL a chance to paint
       delay(1);
       // Handle input and restart compute on changes
-      if (MandelbrotApp_handleInput(myself)) {
+      if (myself.handleInput()) {
         // Cancel any ongoing compute and restart
-        MandelbrotApp_setCancel(myself, true);
+        myself.setCancel(true);
         if (myself.computing) {
           int i;
           for (i = 0; i < myself.ThreadCount; i = i + 1) { if (myself.tids[i] >= 0) { join myself.tids[i]; myself.tids[i] = -1; } }
           myself.computing = false;
         }
-        MandelbrotApp_setCancel(myself, false);
+        myself.setCancel(false);
         needRender = true;
         // Immediate visual feedback
         updatetexture(myself.textureID, myself.pixels);
@@ -308,4 +308,4 @@ class MandelbrotApp {
 }
 
 MandelbrotApp app = new MandelbrotApp();
-MandelbrotApp_run(app);
+app.run();

--- a/Examples/rea/sdl_mandelbrot_interactive_ext
+++ b/Examples/rea/sdl_mandelbrot_interactive_ext
@@ -140,7 +140,7 @@ class MandelbrotApp {
     }
 
     for (i = 0; i < myself.ThreadCount; i = i + 1) {
-      myself.tids[i] = spawn MandelbrotApp_computeRowsWorker(myself, i);
+      myself.tids[i] = spawn myself.computeRowsWorker(i);
     }
     myself.computing = true;
   }
@@ -183,7 +183,7 @@ class MandelbrotApp {
         cleardevice(); rendercopy(myself.textureID); outtextxy(8, 8, "Rendering..."); updatescreen();
         myself.lastUpdatedRows = doneCount;
       }
-      MandelbrotApp_finishThreads(myself);
+      myself.finishThreads();
       myself.computing = false;
       myself.lastUpdatedRows = 0;
     }
@@ -230,10 +230,10 @@ class MandelbrotApp {
       if (winH != myself.Height) { y = (y * myself.Height) / winH; if (y >= myself.Height) y = myself.Height - 1; }
     }
     if ((b & myself.ButtonLeft) != 0 && (myself.prevButtons & myself.ButtonLeft) == 0) {
-      MandelbrotApp_zoom(myself, x, y, 1.0 / myself.ZoomFactor);
+      myself.zoom(x, y, 1.0 / myself.ZoomFactor);
       changed = true;
     } else if ((b & myself.ButtonRight) != 0 && (myself.prevButtons & myself.ButtonRight) == 0) {
-      MandelbrotApp_zoom(myself, x, y, myself.ZoomFactor);
+      myself.zoom(x, y, myself.ZoomFactor);
       changed = true;
     }
     myself.prevButtons = b;
@@ -241,23 +241,23 @@ class MandelbrotApp {
   }
 
   void run() {
-    MandelbrotApp_init(myself);
+    myself.init();
     bool needRender = true;
     while (!myself.getQuit()) {
       if (needRender && !myself.computing) {
-        MandelbrotApp_startCompute(myself);
+        myself.startCompute();
         needRender = false;
       }
-      MandelbrotApp_pollCompute(myself);
+      myself.pollCompute();
       delay(1);
-      if (MandelbrotApp_handleInput(myself)) {
-        MandelbrotApp_setCancel(myself, true);
+      if (myself.handleInput()) {
+        myself.setCancel(true);
         if (myself.computing) {
           int i;
           for (i = 0; i < myself.ThreadCount; i = i + 1) { if (myself.tids[i] >= 0) { join myself.tids[i]; myself.tids[i] = -1; } }
           myself.computing = false;
         }
-        MandelbrotApp_setCancel(myself, false);
+        myself.setCancel(false);
         needRender = true;
         updatetexture(myself.textureID, myself.pixels);
         cleardevice(); rendercopy(myself.textureID); updatescreen();
@@ -274,4 +274,4 @@ class MandelbrotApp {
 }
 
 MandelbrotApp app = new MandelbrotApp();
-MandelbrotApp_run(app);
+app.run();

--- a/Examples/rea/sdl_multibouncingballs
+++ b/Examples/rea/sdl_multibouncingballs
@@ -198,5 +198,5 @@ class BallsApp {
 }
 
 BallsApp app = new BallsApp();
-BallsApp_run(app);
+app.run();
 

--- a/Examples/rea/sdl_planets
+++ b/Examples/rea/sdl_planets
@@ -62,7 +62,7 @@ class Planet {
     }
 
     void start() {
-      myself.tid = spawn Planet_updateWorker(myself);
+      myself.tid = spawn myself.updateWorker();
     }
 
     // Wait for the worker thread to finish. "join" is a reserved keyword in
@@ -74,7 +74,7 @@ class Planet {
 
   }
 
-void Planet_draw(Planet p) {
+void Planet p.draw() {
   setrgbcolor(p.r, p.g, p.b);
   fillcircle(trunc(p.posX), trunc(p.posY), p.size);
 }
@@ -104,36 +104,36 @@ class SolarSystemApp {
     int extra = 0;
     // Mercury - 0.39 AU
     orbit = trunc(AUOffset + AUScale * 0.39 + extra);
-    myself.planets[1] = new Planet(); Planet_init(myself.planets[1], orbit, 1, 4.7, 169, 169, 169, myself.centerX, myself.centerY);
+    myself.planets[1] = new Planet(); myself.planets[1].init(orbit, 1, 4.7, 169, 169, 169, myself.centerX, myself.centerY);
     extra = extra + OrbitSpacing;
     // Venus - 0.72 AU
     orbit = trunc(AUOffset + AUScale * 0.72 + extra);
-    myself.planets[2] = new Planet(); Planet_init(myself.planets[2], orbit, 2, 3.5, 218, 165,  32, myself.centerX, myself.centerY);
+    myself.planets[2] = new Planet(); myself.planets[2].init(orbit, 2, 3.5, 218, 165,  32, myself.centerX, myself.centerY);
     extra = extra + OrbitSpacing;
     // Earth - 1.00 AU
     orbit = trunc(AUOffset + AUScale * 1.00 + extra);
-    myself.planets[3] = new Planet(); Planet_init(myself.planets[3], orbit, 3, 3.0,   0, 102, 255, myself.centerX, myself.centerY);
+    myself.planets[3] = new Planet(); myself.planets[3].init(orbit, 3, 3.0,   0, 102, 255, myself.centerX, myself.centerY);
     myself.planets[3].isEarth = 1;
     extra = extra + OrbitSpacing;
     // Mars - 1.52 AU
     orbit = trunc(AUOffset + AUScale * 1.52 + extra);
-    myself.planets[4] = new Planet(); Planet_init(myself.planets[4], orbit, 2, 2.4, 188,  39,  50, myself.centerX, myself.centerY);
+    myself.planets[4] = new Planet(); myself.planets[4].init(orbit, 2, 2.4, 188,  39,  50, myself.centerX, myself.centerY);
     extra = extra + OrbitSpacing;
     // Jupiter - 5.20 AU
     orbit = trunc(AUOffset + AUScale * 5.20 + extra);
-    myself.planets[5] = new Planet(); Planet_init(myself.planets[5], orbit,18, 1.3, 205, 133,  63, myself.centerX, myself.centerY);
+    myself.planets[5] = new Planet(); myself.planets[5].init(orbit,18, 1.3, 205, 133,  63, myself.centerX, myself.centerY);
     extra = extra + OrbitSpacing;
     // Saturn - 9.58 AU
     orbit = trunc(AUOffset + AUScale * 9.58 + extra);
-    myself.planets[6] = new Planet(); Planet_init(myself.planets[6], orbit,16, 0.9, 210, 180, 140, myself.centerX, myself.centerY);
+    myself.planets[6] = new Planet(); myself.planets[6].init(orbit,16, 0.9, 210, 180, 140, myself.centerX, myself.centerY);
     extra = extra + OrbitSpacing;
     // Uranus - 19.20 AU
     orbit = trunc(AUOffset + AUScale * 19.20 + extra);
-    myself.planets[7] = new Planet(); Planet_init(myself.planets[7], orbit,12, 0.7, 173, 216, 230, myself.centerX, myself.centerY);
+    myself.planets[7] = new Planet(); myself.planets[7].init(orbit,12, 0.7, 173, 216, 230, myself.centerX, myself.centerY);
     extra = extra + OrbitSpacing;
     // Neptune - 30.05 AU
     orbit = trunc(AUOffset + AUScale * 30.05 + extra);
-    myself.planets[8] = new Planet(); Planet_init(myself.planets[8], orbit,12, 0.5,  65, 105, 225, myself.centerX, myself.centerY);
+    myself.planets[8] = new Planet(); myself.planets[8].init(orbit,12, 0.5,  65, 105, 225, myself.centerX, myself.centerY);
   }
 
   void initAsteroids() {
@@ -154,7 +154,7 @@ class SolarSystemApp {
   void startThreads() {
     int i = 1;
     while (i <= NumPlanets) {
-      Planet_start(myself.planets[i]);
+      myself.planets[i].start();
       i = i + 1;
     }
   }
@@ -178,7 +178,7 @@ class SolarSystemApp {
     }
     int i = 1;
     while (i <= NumPlanets) {
-      Planet_draw(myself.planets[i]);
+      myself.planets[i].draw();
       i = i + 1;
     }
     str monthStr = "Earth months elapsed: " + inttostr(trunc(earthMonths));
@@ -190,7 +190,7 @@ class SolarSystemApp {
   void joinThreads() {
     int i = 1;
     while (i <= NumPlanets) {
-      Planet_joinThread(myself.planets[i]);
+      myself.planets[i].joinThread();
       i = i + 1;
     }
   }
@@ -226,4 +226,4 @@ class SolarSystemApp {
 }
 
 SolarSystemApp app = new SolarSystemApp();
-SolarSystemApp_run(app);
+app.run();

--- a/Examples/rea/sdl_planets_inner
+++ b/Examples/rea/sdl_planets_inner
@@ -63,7 +63,7 @@ class Planet {
     }
 
     void start() {
-      myself.tid = spawn Planet_updateWorker(myself);
+      myself.tid = spawn myself.updateWorker();
     }
 
     // Wait for the worker thread to finish. "join" is a reserved keyword in
@@ -75,7 +75,7 @@ class Planet {
 
   }
 
-void Planet_draw(Planet p) {
+void Planet p.draw() {
   setrgbcolor(p.r, p.g, p.b);
   fillcircle(trunc(p.posX), trunc(p.posY), p.size);
 }
@@ -119,32 +119,32 @@ class SolarSystemApp {
     orbit = trunc(myself.AUOffset + myself.AUScale * 0.39 + extra);
     size = trunc(myself.sunRadius * MercuryRadiusAU / SunRadiusAU);
     if (size < 1) size = 1;
-    myself.planets[1] = new Planet(); Planet_init(myself.planets[1], orbit, size, 4.7, 169, 169, 169, myself.centerX, myself.centerY);
+    myself.planets[1] = new Planet(); myself.planets[1].init(orbit, size, 4.7, 169, 169, 169, myself.centerX, myself.centerY);
     extra = extra + OrbitSpacing;
     // Venus - 0.72 AU
     orbit = trunc(myself.AUOffset + myself.AUScale * 0.72 + extra);
     size = trunc(myself.sunRadius * VenusRadiusAU / SunRadiusAU);
     if (size < 1) size = 1;
-    myself.planets[2] = new Planet(); Planet_init(myself.planets[2], orbit, size, 3.5, 218, 165,  32, myself.centerX, myself.centerY);
+    myself.planets[2] = new Planet(); myself.planets[2].init(orbit, size, 3.5, 218, 165,  32, myself.centerX, myself.centerY);
     extra = extra + OrbitSpacing;
     // Earth - 1.00 AU
     orbit = trunc(myself.AUOffset + myself.AUScale * 1.00 + extra);
     size = trunc(myself.sunRadius * EarthRadiusAU / SunRadiusAU);
     if (size < 1) size = 1;
-    myself.planets[3] = new Planet(); Planet_init(myself.planets[3], orbit, size, 3.0,   0, 102, 255, myself.centerX, myself.centerY);
+    myself.planets[3] = new Planet(); myself.planets[3].init(orbit, size, 3.0,   0, 102, 255, myself.centerX, myself.centerY);
     myself.planets[3].isEarth = 1;
     extra = extra + OrbitSpacing;
     // Mars - 1.52 AU
     orbit = trunc(myself.AUOffset + myself.AUScale * 1.52 + extra);
     size = trunc(myself.sunRadius * MarsRadiusAU / SunRadiusAU);
     if (size < 1) size = 1;
-    myself.planets[4] = new Planet(); Planet_init(myself.planets[4], orbit, size, 2.4, 188,  39,  50, myself.centerX, myself.centerY);
+    myself.planets[4] = new Planet(); myself.planets[4].init(orbit, size, 2.4, 188,  39,  50, myself.centerX, myself.centerY);
     extra = extra + OrbitSpacing;
     // Jupiter - 5.20 AU
     orbit = trunc(myself.AUOffset + myself.AUScale * 5.20 + extra);
     size = trunc(myself.sunRadius * JupiterRadiusAU / SunRadiusAU);
     if (size < 1) size = 1;
-    myself.planets[5] = new Planet(); Planet_init(myself.planets[5], orbit, size, 1.3, 205, 133,  63, myself.centerX, myself.centerY);
+    myself.planets[5] = new Planet(); myself.planets[5].init(orbit, size, 1.3, 205, 133,  63, myself.centerX, myself.centerY);
   }
 
   void initAsteroids() {
@@ -165,7 +165,7 @@ class SolarSystemApp {
   void startThreads() {
     int i = 1;
     while (i <= NumPlanets) {
-      Planet_start(myself.planets[i]);
+      myself.planets[i].start();
       i = i + 1;
     }
   }
@@ -189,7 +189,7 @@ class SolarSystemApp {
     }
     int i = 1;
     while (i <= NumPlanets) {
-      Planet_draw(myself.planets[i]);
+      myself.planets[i].draw();
       i = i + 1;
     }
     str monthStr = "Earth months elapsed: " + inttostr(trunc(earthMonths));
@@ -201,7 +201,7 @@ class SolarSystemApp {
   void joinThreads() {
     int i = 1;
     while (i <= NumPlanets) {
-      Planet_joinThread(myself.planets[i]);
+      myself.planets[i].joinThread();
       i = i + 1;
     }
   }
@@ -242,4 +242,4 @@ class SolarSystemApp {
 }
 
 SolarSystemApp app = new SolarSystemApp();
-SolarSystemApp_run(app);
+app.run();

--- a/Examples/rea/sdl_planets_sun
+++ b/Examples/rea/sdl_planets_sun
@@ -65,7 +65,7 @@ class Planet {
     }
 
     void start() {
-      myself.tid = spawn Planet_updateWorker(myself);
+      myself.tid = spawn myself.updateWorker();
     }
 
     // Wait for the worker thread to finish. "join" is a reserved keyword in
@@ -77,7 +77,7 @@ class Planet {
 
   }
 
-void Planet_draw(Planet p) {
+void Planet p.draw() {
   setrgbcolor(p.r, p.g, p.b);
 
   // Round the scaled radius so small planets like Mars don't disappear
@@ -124,15 +124,15 @@ class SolarSystemApp {
     // Mercury - 0.39 AU orbit, true radius
     orbit = trunc(myself.AUScale * 0.39);
     radius = myself.AUScale * MercuryRadiusAU * myself.SizeScale;
-    myself.planets[1] = new Planet(); Planet_init(myself.planets[1], orbit, radius, 4.7, 169, 169, 169, myself.centerX, myself.centerY);
+    myself.planets[1] = new Planet(); myself.planets[1].init(orbit, radius, 4.7, 169, 169, 169, myself.centerX, myself.centerY);
     // Venus - 0.72 AU orbit, true radius
     orbit = trunc(myself.AUScale * 0.72);
     radius = myself.AUScale * VenusRadiusAU * myself.SizeScale;
-    myself.planets[2] = new Planet(); Planet_init(myself.planets[2], orbit, radius, 3.5, 218, 165, 32, myself.centerX, myself.centerY);
+    myself.planets[2] = new Planet(); myself.planets[2].init(orbit, radius, 3.5, 218, 165, 32, myself.centerX, myself.centerY);
     // Earth - 1.00 AU orbit, true radius
     orbit = trunc(myself.AUScale * 1.00);
     radius = myself.AUScale * EarthRadiusAU * myself.SizeScale;
-    myself.planets[3] = new Planet(); Planet_init(myself.planets[3], orbit, radius, 3.0,   0, 102, 255, myself.centerX, myself.centerY);
+    myself.planets[3] = new Planet(); myself.planets[3].init(orbit, radius, 3.0,   0, 102, 255, myself.centerX, myself.centerY);
     myself.planets[3].isEarth = 1;
 
     // Moon - orbits Earth at 0.00257 AU with true radius
@@ -144,13 +144,13 @@ class SolarSystemApp {
     // Mars - 1.52 AU orbit, true radius
     orbit = trunc(myself.AUScale * 1.52);
     radius = myself.AUScale * MarsRadiusAU * myself.SizeScale;
-    myself.planets[4] = new Planet(); Planet_init(myself.planets[4], orbit, radius, 2.4, 188, 39, 50, myself.centerX, myself.centerY);
+    myself.planets[4] = new Planet(); myself.planets[4].init(orbit, radius, 2.4, 188, 39, 50, myself.centerX, myself.centerY);
   }
 
   void startThreads() {
     int i = 1;
     while (i <= NumPlanets) {
-      Planet_start(myself.planets[i]);
+      myself.planets[i].start();
       i = i + 1;
     }
   }
@@ -162,7 +162,7 @@ class SolarSystemApp {
     fillcircle(myself.centerX, myself.centerY, myself.sunRadius);
     int i = 1;
     while (i <= NumPlanets) {
-      Planet_draw(myself.planets[i]);
+      myself.planets[i].draw();
       i = i + 1;
     }
     // Update and draw Earth's Moon
@@ -183,7 +183,7 @@ class SolarSystemApp {
   void joinThreads() {
     int i = 1;
     while (i <= NumPlanets) {
-      Planet_joinThread(myself.planets[i]);
+      myself.planets[i].joinThread();
       i = i + 1;
     }
   }
@@ -229,4 +229,4 @@ class SolarSystemApp {
   }
 }
 SolarSystemApp app = new SolarSystemApp();
-SolarSystemApp_run(app);
+app.run();

--- a/rea-method-dispatch-runtime.md
+++ b/rea-method-dispatch-runtime.md
@@ -1,7 +1,7 @@
 # Rea method dispatch runtime investigation
 
 Summary:
-- Qualified calls now compile to direct calls (Class_method(this, ...)) and work in disassembly.
+- Qualified calls now compile to direct calls; method invocations like `obj.method(args)` translate to the internal `Class_method(obj, args)` form and work in disassembly.
 - A runtime stack underflow occurs at program start when executing method_calls.
 
 Next steps:


### PR DESCRIPTION
## Summary
- Replace legacy `ClassName_method(instance)` calls in SDL examples with idiomatic instance method syntax.
- Document new `object.method()` usage and update runtime investigation notes.

## Testing
- `cmake -S . -B build`
- `cmake --build build --target rea`
- `./Tests/run_rea_tests.sh` *(fails: stdout mismatch in array_decl)*

------
https://chatgpt.com/codex/tasks/task_e_68c825fb9108832aa96ad815f775aede