### PR TITLE
Handle TYPE_NIL in makeValueForType

### DIFF
--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -896,6 +896,8 @@ Value makeValueForType(VarType type, AST *type_def_param, Symbol* context_symbol
         case TYPE_POINTER:
             v.ptr_val = NULL;
             break;
+        case TYPE_NIL:
+            return makeNil();
         case TYPE_VOID:
             break;
         default:


### PR DESCRIPTION
## Summary
- add explicit TYPE_NIL handling in makeValueForType so nil literals initialize cleanly
- prevent the unhandled type warning triggered when nil values are constructed

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c96f99a4a0832ab13eed2cd4d447c7