### PR TITLE
Ensure implicit Rea `myself` global encodes pointer metadata

### DIFF
--- a/Tests/Pascal/RealIntOverflowTest.err
+++ b/Tests/Pascal/RealIntOverflowTest.err
@@ -1,2 +1,2 @@
 Warning: Range check error assigning REAL 100000000000000000000.000000 to INTEGER.
-[Error Location] Offset: 51, Line: 15
+[Error Location] Offset: 58, Line: 15

--- a/Tests/rea/assign_expr.err
+++ b/Tests/rea/assign_expr.err
@@ -2,19 +2,24 @@
 == Disassembly: Tests/rea/assign_expr.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
-0000    1 DEFINE_GLOBAL    NameIdx:0   'b' Type:INT64 ('int')
-0005    2 DEFINE_GLOBAL    NameIdx:2   'a' Type:INT64 ('int')
-0010    | CONSTANT            3 '3'
-0012    | DUP
-0013    | GET_GLOBAL_ADDRESS    0 'b'
-0015    | SWAP
-0016    | SET_INDIRECT
-0017    | SET_GLOBAL          2 'a'
-0019    0 HALT
+0000    0 CONSTANT            1 'nil'
+0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
+0007    1 DEFINE_GLOBAL    NameIdx:3   'b' Type:INT64 ('int')
+0012    2 DEFINE_GLOBAL    NameIdx:5   'a' Type:INT64 ('int')
+0017    | CONSTANT            6 '3'
+0019    | DUP
+0020    | GET_GLOBAL_ADDRESS    3 'b'
+0022    | SWAP
+0023    | SET_INDIRECT
+0024    | SET_GLOBAL          5 'a'
+0026    0 HALT
 == End Disassembly: Tests/rea/assign_expr.rea ==
 
-Constants (4):\n  0000: STR   "b"
-  0001: STR   "int"
-  0002: STR   "a"
-  0003: INT   3
+Constants (7):\n  0000: STR   "myself"
+  0001: NIL
+  0002: STR   ""
+  0003: STR   "b"
+  0004: STR   "int"
+  0005: STR   "a"
+  0006: INT   3
 

--- a/Tests/rea/block_decl.err
+++ b/Tests/rea/block_decl.err
@@ -2,26 +2,31 @@
 == Disassembly: Tests/rea/block_decl.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
-0000    1 DEFINE_GLOBAL    NameIdx:0   'x' Type:INT64 ('int')
-0005    | CONSTANT            2 '0'
-0007    | SET_GLOBAL          0 'x'
-0009    2 GET_GLOBAL          0 'x'
-0011    | CONSTANT            2 '0'
-0013    | EQUAL
-0014    | JUMP_IF_FALSE      15 (to 0032)
-0017    3 DEFINE_GLOBAL    NameIdx:3   'y' Type:INT64 ('int')
-0022    | CONSTANT            4 '1'
-0024    | SET_GLOBAL          3 'y'
-0026    4 GET_GLOBAL          3 'y'
-0028    | GET_GLOBAL_ADDRESS    0 'x'
-0030    | SWAP
-0031    | SET_INDIRECT
-0032    0 HALT
+0000    0 CONSTANT            1 'nil'
+0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
+0007    1 DEFINE_GLOBAL    NameIdx:3   'x' Type:INT64 ('int')
+0012    | CONSTANT            5 '0'
+0014    | SET_GLOBAL          3 'x'
+0016    2 GET_GLOBAL          3 'x'
+0018    | CONSTANT            5 '0'
+0020    | EQUAL
+0021    | JUMP_IF_FALSE      15 (to 0039)
+0024    3 DEFINE_GLOBAL    NameIdx:6   'y' Type:INT64 ('int')
+0029    | CONSTANT            7 '1'
+0031    | SET_GLOBAL          6 'y'
+0033    4 GET_GLOBAL          6 'y'
+0035    | GET_GLOBAL_ADDRESS    3 'x'
+0037    | SWAP
+0038    | SET_INDIRECT
+0039    0 HALT
 == End Disassembly: Tests/rea/block_decl.rea ==
 
-Constants (5):\n  0000: STR   "x"
-  0001: STR   "int"
-  0002: INT   0
-  0003: STR   "y"
-  0004: INT   1
+Constants (8):\n  0000: STR   "myself"
+  0001: NIL
+  0002: STR   ""
+  0003: STR   "x"
+  0004: STR   "int"
+  0005: INT   0
+  0006: STR   "y"
+  0007: INT   1
 

--- a/Tests/rea/bytecode_dump.err
+++ b/Tests/rea/bytecode_dump.err
@@ -2,6 +2,12 @@
 == Disassembly: Tests/rea/bytecode_dump.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
-0000    0 HALT
+0000    0 CONSTANT            1 'nil'
+0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
+0007    | HALT
 == End Disassembly: Tests/rea/bytecode_dump.rea ==
+
+Constants (3):\n  0000: STR   "myself"
+  0001: NIL
+  0002: STR   ""
 

--- a/Tests/rea/bytecode_exec.err
+++ b/Tests/rea/bytecode_exec.err
@@ -2,42 +2,47 @@
 == Disassembly: Tests/rea/bytecode_exec.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
-0000    1 DEFINE_GLOBAL    NameIdx:0   'a' Type:INT64 ('int')
-0005    | CONSTANT            2 '1'
-0007    | CONSTANT            3 '2'
-0009    | CONSTANT            4 '3'
-0011    | MULTIPLY
-0012    | ADD
-0013    | SET_GLOBAL          0 'a'
-0015    2 DEFINE_GLOBAL    NameIdx:5   'b' Type:BOOLEAN ('bool')
-0020    | GET_GLOBAL          0 'a'
-0022    | CONSTANT            7 '7'
-0024    | GREATER_EQUAL
-0025    | SET_GLOBAL          5 'b'
-0027    3 DEFINE_GLOBAL    NameIdx:8   'msg' Type:STRING ('str') len=0
-0034    | CONSTANT           11 'hi'
-0036    | SET_GLOBAL          8 'msg'
-0038    4 GET_GLOBAL          0 'a'
-0040    | NEGATE
-0041    | CONSTANT           12 '4'
-0043    | ADD
-0044    | GET_GLOBAL_ADDRESS    0 'a'
-0046    | SWAP
-0047    | SET_INDIRECT
-0048    0 HALT
+0000    0 CONSTANT            1 'nil'
+0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
+0007    1 DEFINE_GLOBAL    NameIdx:3   'a' Type:INT64 ('int')
+0012    | CONSTANT            5 '1'
+0014    | CONSTANT            6 '2'
+0016    | CONSTANT            7 '3'
+0018    | MULTIPLY
+0019    | ADD
+0020    | SET_GLOBAL          3 'a'
+0022    2 DEFINE_GLOBAL    NameIdx:8   'b' Type:BOOLEAN ('bool')
+0027    | GET_GLOBAL          3 'a'
+0029    | CONSTANT           10 '7'
+0031    | GREATER_EQUAL
+0032    | SET_GLOBAL          8 'b'
+0034    3 DEFINE_GLOBAL    NameIdx:11  'msg' Type:STRING ('str') len=0
+0041    | CONSTANT           14 'hi'
+0043    | SET_GLOBAL         11 'msg'
+0045    4 GET_GLOBAL          3 'a'
+0047    | NEGATE
+0048    | CONSTANT           15 '4'
+0050    | ADD
+0051    | GET_GLOBAL_ADDRESS    3 'a'
+0053    | SWAP
+0054    | SET_INDIRECT
+0055    0 HALT
 == End Disassembly: Tests/rea/bytecode_exec.rea ==
 
-Constants (13):\n  0000: STR   "a"
-  0001: STR   "int"
-  0002: INT   1
-  0003: INT   2
-  0004: INT   3
-  0005: STR   "b"
-  0006: STR   "bool"
-  0007: INT   7
-  0008: STR   "msg"
-  0009: STR   "str"
-  0010: INT   0
-  0011: STR   "hi"
-  0012: INT   4
+Constants (16):\n  0000: STR   "myself"
+  0001: NIL
+  0002: STR   ""
+  0003: STR   "a"
+  0004: STR   "int"
+  0005: INT   1
+  0006: INT   2
+  0007: INT   3
+  0008: STR   "b"
+  0009: STR   "bool"
+  0010: INT   7
+  0011: STR   "msg"
+  0012: STR   "str"
+  0013: INT   0
+  0014: STR   "hi"
+  0015: INT   4
 

--- a/Tests/rea/class_decl.err
+++ b/Tests/rea/class_decl.err
@@ -2,6 +2,12 @@
 == Disassembly: Tests/rea/class_decl.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
-0000    0 HALT
+0000    0 CONSTANT            1 'nil'
+0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
+0007    | HALT
 == End Disassembly: Tests/rea/class_decl.rea ==
+
+Constants (3):\n  0000: STR   "myself"
+  0001: NIL
+  0002: STR   ""
 

--- a/Tests/rea/class_instantiation.err
+++ b/Tests/rea/class_instantiation.err
@@ -2,17 +2,22 @@
 == Disassembly: Tests/rea/class_instantiation.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
-0000    2 DEFINE_GLOBAL    NameIdx:0   'd' Type:POINTER ('Dummy')
-0005    | ALLOC_OBJECT        1 (fields)
-0007    | SET_GLOBAL          0 'd'
-0009    3 CONSTANT            2 '1'
-0011    | CONSTANT            2 '1'
-0013    | CALL_BUILTIN         3 'write' (2 args)
-0017    0 HALT
+0000    0 CONSTANT            1 'nil'
+0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
+0007    2 DEFINE_GLOBAL    NameIdx:3   'd' Type:POINTER ('Dummy')
+0012    | ALLOC_OBJECT        1 (fields)
+0014    | SET_GLOBAL          3 'd'
+0016    3 CONSTANT            5 '1'
+0018    | CONSTANT            5 '1'
+0020    | CALL_BUILTIN         6 'write' (2 args)
+0024    0 HALT
 == End Disassembly: Tests/rea/class_instantiation.rea ==
 
-Constants (4):\n  0000: STR   "d"
-  0001: STR   "Dummy"
-  0002: INT   1
-  0003: STR   "write"
+Constants (7):\n  0000: STR   "myself"
+  0001: NIL
+  0002: STR   ""
+  0003: STR   "d"
+  0004: STR   "Dummy"
+  0005: INT   1
+  0006: STR   "write"
 

--- a/Tests/rea/constructor_init.err
+++ b/Tests/rea/constructor_init.err
@@ -2,26 +2,31 @@
 == Disassembly: Tests/rea/constructor_init.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
-0000    2 DEFINE_GLOBAL    NameIdx:0   'p' Type:POINTER ('Point')
-0005    | ALLOC_OBJECT        2 (fields)
-0007    | DUP
-0008    | CONSTANT            2 '5'
-0010    | CALL             0021 (point) (2 args)
-0016    | SET_GLOBAL          0 'p'
-0018    1 JUMP                9 (to 0030)
+0000    0 CONSTANT            1 'nil'
+0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
+0007    2 DEFINE_GLOBAL    NameIdx:3   'p' Type:POINTER ('Point')
+0012    | ALLOC_OBJECT        2 (fields)
+0014    | DUP
+0015    | CONSTANT            5 '5'
+0017    | CALL             0028 (point) (2 args)
+0023    | SET_GLOBAL          3 'p'
+0025    1 JUMP                9 (to 0037)
 
---- Procedure point.point (at 0021) ---
-0021    | GET_LOCAL           1 (slot)
-0023    | GET_LOCAL           0 (slot)
-0025    | GET_FIELD_OFFSET    1 (index)
-0027    | SWAP
-0028    | SET_INDIRECT
-0029    | RETURN
-0030    0 HALT
+--- Procedure point.point (at 0028) ---
+0028    | GET_LOCAL           1 (slot)
+0030    | GET_LOCAL           0 (slot)
+0032    | GET_FIELD_OFFSET    1 (index)
+0034    | SWAP
+0035    | SET_INDIRECT
+0036    | RETURN
+0037    0 HALT
 == End Disassembly: Tests/rea/constructor_init.rea ==
 
-Constants (4):\n  0000: STR   "p"
-  0001: STR   "Point"
-  0002: INT   5
-  0003: STR   "point"
+Constants (7):\n  0000: STR   "myself"
+  0001: NIL
+  0002: STR   ""
+  0003: STR   "p"
+  0004: STR   "Point"
+  0005: INT   5
+  0006: STR   "point"
 

--- a/Tests/rea/field_access_assign.err
+++ b/Tests/rea/field_access_assign.err
@@ -2,16 +2,21 @@
 == Disassembly: Tests/rea/field_access_assign.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
-0000    2 DEFINE_GLOBAL    NameIdx:0   'p' Type:POINTER ('Point')
-0005    4 CONSTANT            2 '1'
-0007    | GET_GLOBAL          0 'p'
-0009    | GET_FIELD_OFFSET    1 (index)
-0011    | SWAP
-0012    | SET_INDIRECT
-0013    0 HALT
+0000    0 CONSTANT            1 'nil'
+0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
+0007    2 DEFINE_GLOBAL    NameIdx:3   'p' Type:POINTER ('Point')
+0012    4 CONSTANT            5 '1'
+0014    | GET_GLOBAL          3 'p'
+0016    | GET_FIELD_OFFSET    1 (index)
+0018    | SWAP
+0019    | SET_INDIRECT
+0020    0 HALT
 == End Disassembly: Tests/rea/field_access_assign.rea ==
 
-Constants (3):\n  0000: STR   "p"
-  0001: STR   "Point"
-  0002: INT   1
+Constants (6):\n  0000: STR   "myself"
+  0001: NIL
+  0002: STR   ""
+  0003: STR   "p"
+  0004: STR   "Point"
+  0005: INT   1
 

--- a/Tests/rea/field_access_read.err
+++ b/Tests/rea/field_access_read.err
@@ -2,17 +2,22 @@
 == Disassembly: Tests/rea/field_access_read.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
-0000    2 DEFINE_GLOBAL    NameIdx:0   'p' Type:POINTER ('Point')
-0005    4 DEFINE_GLOBAL    NameIdx:2   'a' Type:INT64 ('int')
-0010    | GET_GLOBAL          0 'p'
-0012    | GET_FIELD_OFFSET    1 (index)
-0014    | GET_INDIRECT
-0015    | SET_GLOBAL          2 'a'
-0017    0 HALT
+0000    0 CONSTANT            1 'nil'
+0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
+0007    2 DEFINE_GLOBAL    NameIdx:3   'p' Type:POINTER ('Point')
+0012    4 DEFINE_GLOBAL    NameIdx:5   'a' Type:INT64 ('int')
+0017    | GET_GLOBAL          3 'p'
+0019    | GET_FIELD_OFFSET    1 (index)
+0021    | GET_INDIRECT
+0022    | SET_GLOBAL          5 'a'
+0024    0 HALT
 == End Disassembly: Tests/rea/field_access_read.rea ==
 
-Constants (4):\n  0000: STR   "p"
-  0001: STR   "Point"
-  0002: STR   "a"
-  0003: STR   "int"
+Constants (7):\n  0000: STR   "myself"
+  0001: NIL
+  0002: STR   ""
+  0003: STR   "p"
+  0004: STR   "Point"
+  0005: STR   "a"
+  0006: STR   "int"
 

--- a/Tests/rea/method_this_assign.err
+++ b/Tests/rea/method_this_assign.err
@@ -2,24 +2,29 @@
 == Disassembly: Tests/rea/method_this_assign.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
-0000    3 JUMP               11 (to 0014)
+0000    0 CONSTANT            1 'nil'
+0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
+0007    3 JUMP               11 (to 0021)
 
---- Function point.setx (at 0003) ---
-0003    4 GET_LOCAL           1 (slot)
-0005    | GET_LOCAL           0 (slot)
-0007    | GET_FIELD_OFFSET    2 (index)
-0009    | SWAP
-0010    | SET_INDIRECT
-0011    3 GET_LOCAL           2 (slot)
-0013    | RETURN
-0014    0 CONSTANT            0 'Value type ARRAY'
-0016    | DEFINE_GLOBAL    NameIdx:1   'point_vtable' Type:ARRAY Dims:1 [0..0] of INTEGER ('integer')
-0026    | SET_GLOBAL          1 'point_vtable'
-0028    | HALT
+--- Function point.setx (at 0010) ---
+0010    4 GET_LOCAL           1 (slot)
+0012    | GET_LOCAL           0 (slot)
+0014    | GET_FIELD_OFFSET    2 (index)
+0016    | SWAP
+0017    | SET_INDIRECT
+0018    3 GET_LOCAL           2 (slot)
+0020    | RETURN
+0021    0 CONSTANT            3 'Value type ARRAY'
+0023    | DEFINE_GLOBAL    NameIdx:4   'point_vtable' Type:ARRAY Dims:1 [0..0] of INTEGER ('integer')
+0033    | SET_GLOBAL          4 'point_vtable'
+0035    | HALT
 == End Disassembly: Tests/rea/method_this_assign.rea ==
 
-Constants (4):\n  0000: Value type ARRAY
-  0001: STR   "point_vtable"
-  0002: INT   0
-  0003: STR   "integer"
+Constants (7):\n  0000: STR   "myself"
+  0001: NIL
+  0002: STR   ""
+  0003: Value type ARRAY
+  0004: STR   "point_vtable"
+  0005: INT   0
+  0006: STR   "integer"
 

--- a/Tests/rea/myself_keyword.err
+++ b/Tests/rea/myself_keyword.err
@@ -2,52 +2,57 @@
 == Disassembly: Tests/rea/myself_keyword.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
-0000    8 DEFINE_GLOBAL    NameIdx:0   'd' Type:POINTER ('Dummy')
-0005    | ALLOC_OBJECT        3 (fields)
-0007    | SET_GLOBAL          0 'd'
-0009    3 JUMP               24 (to 0036)
+0000    0 CONSTANT            1 'nil'
+0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
+0007    8 DEFINE_GLOBAL    NameIdx:3   'd' Type:POINTER ('Dummy')
+0012    | ALLOC_OBJECT        3 (fields)
+0014    | SET_GLOBAL          3 'd'
+0016    3 JUMP               24 (to 0043)
 
---- Procedure dummy.test (at 0012) ---
-0012    4 GET_LOCAL           0 (slot)
-0014    | GET_FIELD_OFFSET    2 (index)
-0016    | GET_INDIRECT
-0017    | CONSTANT            2 '0'
-0019    | EQUAL
-0020    | SET_LOCAL           1 (slot)
-0022    5 GET_LOCAL           1 (slot)
-0024    | JUMP_IF_FALSE       8 (to 0035)
-0027    | CONSTANT            3 '1'
-0029    | GET_LOCAL           0 (slot)
-0031    | GET_FIELD_OFFSET    2 (index)
-0033    | SWAP
-0034    | SET_INDIRECT
-0035    3 RETURN
-0036    0 CONSTANT            4 'Value type ARRAY'
-0038    | DEFINE_GLOBAL    NameIdx:5   'dummy_vtable' Type:ARRAY Dims:1 [0..0] of INTEGER ('integer')
-0048    | SET_GLOBAL          5 'dummy_vtable'
-0050    | GET_GLOBAL          0 'd'
-0052    | DUP
-0053    | GET_FIELD_OFFSET    0 (index)
-0055    | GET_GLOBAL_ADDRESS    5 'dummy_vtable'
-0057    | SET_INDIRECT
-0058    | POP
-0059    9 GET_GLOBAL          0 'd'
-0061    | DUP
-0062    | GET_FIELD_OFFSET    0 (index)
-0064    | GET_INDIRECT
-0065    | CONSTANT            2 '0'
-0067    | SWAP
-0068    | GET_ELEMENT_ADDRESS    1 (dims)
-0070    | GET_INDIRECT
-0071    | PROC_CALL_INDIRECT (args=1)
-0073    0 HALT
+--- Procedure dummy.test (at 0019) ---
+0019    4 GET_LOCAL           0 (slot)
+0021    | GET_FIELD_OFFSET    2 (index)
+0023    | GET_INDIRECT
+0024    | CONSTANT            5 '0'
+0026    | EQUAL
+0027    | SET_LOCAL           1 (slot)
+0029    5 GET_LOCAL           1 (slot)
+0031    | JUMP_IF_FALSE       8 (to 0042)
+0034    | CONSTANT            6 '1'
+0036    | GET_LOCAL           0 (slot)
+0038    | GET_FIELD_OFFSET    2 (index)
+0040    | SWAP
+0041    | SET_INDIRECT
+0042    3 RETURN
+0043    0 CONSTANT            7 'Value type ARRAY'
+0045    | DEFINE_GLOBAL    NameIdx:8   'dummy_vtable' Type:ARRAY Dims:1 [0..0] of INTEGER ('integer')
+0055    | SET_GLOBAL          8 'dummy_vtable'
+0057    | GET_GLOBAL          3 'd'
+0059    | DUP
+0060    | GET_FIELD_OFFSET    0 (index)
+0062    | GET_GLOBAL_ADDRESS    8 'dummy_vtable'
+0064    | SET_INDIRECT
+0065    | POP
+0066    9 GET_GLOBAL          3 'd'
+0068    | DUP
+0069    | GET_FIELD_OFFSET    0 (index)
+0071    | GET_INDIRECT
+0072    | CONSTANT            5 '0'
+0074    | SWAP
+0075    | GET_ELEMENT_ADDRESS    1 (dims)
+0077    | GET_INDIRECT
+0078    | PROC_CALL_INDIRECT (args=1)
+0080    0 HALT
 == End Disassembly: Tests/rea/myself_keyword.rea ==
 
-Constants (7):\n  0000: STR   "d"
-  0001: STR   "Dummy"
-  0002: INT   0
-  0003: INT   1
-  0004: Value type ARRAY
-  0005: STR   "dummy_vtable"
-  0006: STR   "integer"
+Constants (10):\n  0000: STR   "myself"
+  0001: NIL
+  0002: STR   ""
+  0003: STR   "d"
+  0004: STR   "Dummy"
+  0005: INT   0
+  0006: INT   1
+  0007: Value type ARRAY
+  0008: STR   "dummy_vtable"
+  0009: STR   "integer"
 

--- a/Tests/rea/new_alloc.err
+++ b/Tests/rea/new_alloc.err
@@ -2,12 +2,17 @@
 == Disassembly: Tests/rea/new_alloc.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
-0000    3 DEFINE_GLOBAL    NameIdx:0   'p' Type:POINTER ('Point')
-0005    | ALLOC_OBJECT        3 (fields)
-0007    | SET_GLOBAL          0 'p'
-0009    0 HALT
+0000    0 CONSTANT            1 'nil'
+0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
+0007    3 DEFINE_GLOBAL    NameIdx:3   'p' Type:POINTER ('Point')
+0012    | ALLOC_OBJECT        3 (fields)
+0014    | SET_GLOBAL          3 'p'
+0016    0 HALT
 == End Disassembly: Tests/rea/new_alloc.rea ==
 
-Constants (2):\n  0000: STR   "p"
-  0001: STR   "Point"
+Constants (5):\n  0000: STR   "myself"
+  0001: NIL
+  0002: STR   ""
+  0003: STR   "p"
+  0004: STR   "Point"
 

--- a/Tests/rea/new_assign_ptr.err
+++ b/Tests/rea/new_assign_ptr.err
@@ -2,14 +2,19 @@
 == Disassembly: Tests/rea/new_assign_ptr.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
-0000    2 DEFINE_GLOBAL    NameIdx:0   'p' Type:POINTER ('Point')
-0005    3 ALLOC_OBJECT        2 (fields)
-0007    | GET_GLOBAL_ADDRESS    0 'p'
-0009    | SWAP
-0010    | SET_INDIRECT
-0011    0 HALT
+0000    0 CONSTANT            1 'nil'
+0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
+0007    2 DEFINE_GLOBAL    NameIdx:3   'p' Type:POINTER ('Point')
+0012    3 ALLOC_OBJECT        2 (fields)
+0014    | GET_GLOBAL_ADDRESS    3 'p'
+0016    | SWAP
+0017    | SET_INDIRECT
+0018    0 HALT
 == End Disassembly: Tests/rea/new_assign_ptr.rea ==
 
-Constants (2):\n  0000: STR   "p"
-  0001: STR   "Point"
+Constants (5):\n  0000: STR   "myself"
+  0001: NIL
+  0002: STR   ""
+  0003: STR   "p"
+  0004: STR   "Point"
 

--- a/Tests/rea/new_local_vtable.err
+++ b/Tests/rea/new_local_vtable.err
@@ -2,32 +2,37 @@
 == Disassembly: Tests/rea/new_local_vtable.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
-0000    1 JUMP                1 (to 0004)
+0000    0 CONSTANT            1 'nil'
+0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
+0007    1 JUMP                1 (to 0011)
 
---- Procedure mixedcase.hi (at 0003) ---
-0003    | RETURN
-0004    2 JUMP               15 (to 0022)
+--- Procedure mixedcase.hi (at 0010) ---
+0010    | RETURN
+0011    2 JUMP               15 (to 0029)
 
---- Procedure run (at 0007) ---
-0007    3 INIT_LOCAL_POINTER    0 (slot)    0 'MixedCase'
-0011    | ALLOC_OBJECT        2 (fields)
-0013    | DUP
-0014    | GET_FIELD_OFFSET    0 (index)
-0016    | GET_GLOBAL_ADDRESS    1 'mixedcase_vtable'
-0018    | SET_INDIRECT
-0019    | SET_LOCAL           0 (slot)
-0021    2 RETURN
-0022    0 CONSTANT            2 'Value type ARRAY'
-0024    | DEFINE_GLOBAL    NameIdx:1   'mixedcase_vtable' Type:ARRAY Dims:1 [0..0] of INTEGER ('integer')
-0034    | SET_GLOBAL          1 'mixedcase_vtable'
-0036    5 CALL             0007 (run) (0 args)
-0042    0 HALT
+--- Procedure run (at 0014) ---
+0014    3 INIT_LOCAL_POINTER    0 (slot)    3 'MixedCase'
+0018    | ALLOC_OBJECT        2 (fields)
+0020    | DUP
+0021    | GET_FIELD_OFFSET    0 (index)
+0023    | GET_GLOBAL_ADDRESS    4 'mixedcase_vtable'
+0025    | SET_INDIRECT
+0026    | SET_LOCAL           0 (slot)
+0028    2 RETURN
+0029    0 CONSTANT            5 'Value type ARRAY'
+0031    | DEFINE_GLOBAL    NameIdx:4   'mixedcase_vtable' Type:ARRAY Dims:1 [0..0] of INTEGER ('integer')
+0041    | SET_GLOBAL          4 'mixedcase_vtable'
+0043    5 CALL             0014 (run) (0 args)
+0049    0 HALT
 == End Disassembly: Tests/rea/new_local_vtable.rea ==
 
-Constants (6):\n  0000: STR   "MixedCase"
-  0001: STR   "mixedcase_vtable"
-  0002: Value type ARRAY
-  0003: INT   0
-  0004: STR   "integer"
-  0005: STR   "run"
+Constants (9):\n  0000: STR   "myself"
+  0001: NIL
+  0002: STR   ""
+  0003: STR   "MixedCase"
+  0004: STR   "mixedcase_vtable"
+  0005: Value type ARRAY
+  0006: INT   0
+  0007: STR   "integer"
+  0008: STR   "run"
 

--- a/Tests/rea/printf_format.err
+++ b/Tests/rea/printf_format.err
@@ -2,23 +2,28 @@
 == Disassembly: Tests/rea/printf_format.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
-0000    1 CONSTANT            0 '0'
-0002    | CONSTANT            1 'X='
-0004    | CONSTANT            2 '7'
-0006    | FORMAT_VALUE     width:5 prec:-1
-0009    | CONSTANT            3 ' Y='
-0011    | CONSTANT            4 '1.234560'
-0013    | FORMAT_VALUE     width:0 prec:2
-0016    | CONSTANT            5 '\n'
-0018    | CALL_BUILTIN         6 'write' (6 args)
-0022    0 HALT
+0000    0 CONSTANT            1 'nil'
+0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
+0007    1 CONSTANT            3 '0'
+0009    | CONSTANT            4 'X='
+0011    | CONSTANT            5 '7'
+0013    | FORMAT_VALUE     width:5 prec:-1
+0016    | CONSTANT            6 ' Y='
+0018    | CONSTANT            7 '1.234560'
+0020    | FORMAT_VALUE     width:0 prec:2
+0023    | CONSTANT            8 '\n'
+0025    | CALL_BUILTIN         9 'write' (6 args)
+0029    0 HALT
 == End Disassembly: Tests/rea/printf_format.rea ==
 
-Constants (7):\n  0000: INT   0
-  0001: STR   "X="
-  0002: INT   7
-  0003: STR   " Y="
-  0004: REAL  1.234560
-  0005: CHAR  '\n'
-  0006: STR   "write"
+Constants (10):\n  0000: STR   "myself"
+  0001: NIL
+  0002: STR   ""
+  0003: INT   0
+  0004: STR   "X="
+  0005: INT   7
+  0006: STR   " Y="
+  0007: REAL  1.234560
+  0008: CHAR  '\n'
+  0009: STR   "write"
 

--- a/Tests/rea/super_constructor.err
+++ b/Tests/rea/super_constructor.err
@@ -2,41 +2,46 @@
 == Disassembly: Tests/rea/super_constructor.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
-0000    3 DEFINE_GLOBAL    NameIdx:0   'c' Type:POINTER ('Child')
-0005    | ALLOC_OBJECT        3 (fields)
-0007    | DUP
-0008    | CONSTANT            2 '42'
-0010    | CALL             0033 (child) (2 args)
-0016    | SET_GLOBAL          0 'c'
-0018    1 JUMP                9 (to 0030)
+0000    0 CONSTANT            1 'nil'
+0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
+0007    3 DEFINE_GLOBAL    NameIdx:3   'c' Type:POINTER ('Child')
+0012    | ALLOC_OBJECT        3 (fields)
+0014    | DUP
+0015    | CONSTANT            5 '42'
+0017    | CALL             0040 (child) (2 args)
+0023    | SET_GLOBAL          3 'c'
+0025    1 JUMP                9 (to 0037)
 
---- Procedure base.base (at 0021) ---
-0021    | GET_LOCAL           1 (slot)
-0023    | GET_LOCAL           0 (slot)
-0025    | GET_FIELD_OFFSET    1 (index)
-0027    | SWAP
-0028    | SET_INDIRECT
-0029    | RETURN
-0030    2 JUMP               11 (to 0044)
+--- Procedure base.base (at 0028) ---
+0028    | GET_LOCAL           1 (slot)
+0030    | GET_LOCAL           0 (slot)
+0032    | GET_FIELD_OFFSET    1 (index)
+0034    | SWAP
+0035    | SET_INDIRECT
+0036    | RETURN
+0037    2 JUMP               11 (to 0051)
 
---- Procedure child.child (at 0033) ---
-0033    | GET_LOCAL           0 (slot)
-0035    | GET_LOCAL           1 (slot)
-0037    | CALL             0021 (Base.Base) (2 args)
-0043    | RETURN
-0044    4 CONSTANT            5 '1'
-0046    | GET_GLOBAL          0 'c'
-0048    | GET_FIELD_OFFSET    1 (index)
-0050    | GET_INDIRECT
-0051    | CALL_BUILTIN         6 'write' (2 args)
-0055    0 HALT
+--- Procedure child.child (at 0040) ---
+0040    | GET_LOCAL           0 (slot)
+0042    | GET_LOCAL           1 (slot)
+0044    | CALL             0028 (base.base) (2 args)
+0050    | RETURN
+0051    4 CONSTANT            8 '1'
+0053    | GET_GLOBAL          3 'c'
+0055    | GET_FIELD_OFFSET    1 (index)
+0057    | GET_INDIRECT
+0058    | CALL_BUILTIN         9 'write' (2 args)
+0062    0 HALT
 == End Disassembly: Tests/rea/super_constructor.rea ==
 
-Constants (7):\n  0000: STR   "c"
-  0001: STR   "Child"
-  0002: INT   42
-  0003: STR   "child"
-  0004: STR   "Base.Base"
-  0005: INT   1
-  0006: STR   "write"
+Constants (10):\n  0000: STR   "myself"
+  0001: NIL
+  0002: STR   ""
+  0003: STR   "c"
+  0004: STR   "Child"
+  0005: INT   42
+  0006: STR   "child"
+  0007: STR   "base.base"
+  0008: INT   1
+  0009: STR   "write"
 

--- a/Tests/rea/super_method.err
+++ b/Tests/rea/super_method.err
@@ -2,67 +2,72 @@
 == Disassembly: Tests/rea/super_method.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
-0000    3 DEFINE_GLOBAL    NameIdx:0   'c' Type:POINTER ('Child')
-0005    | ALLOC_OBJECT        3 (fields)
-0007    | SET_GLOBAL          0 'c'
-0009    1 JUMP                1 (to 0013)
+0000    0 CONSTANT            1 'nil'
+0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
+0007    3 DEFINE_GLOBAL    NameIdx:3   'c' Type:POINTER ('Child')
+0012    | ALLOC_OBJECT        3 (fields)
+0014    | SET_GLOBAL          3 'c'
+0016    1 JUMP                1 (to 0020)
 
---- Procedure base.base (at 0012) ---
-0012    | RETURN
-0013    | JUMP                9 (to 0025)
+--- Procedure base.base (at 0019) ---
+0019    | RETURN
+0020    | JUMP                9 (to 0032)
 
---- Procedure base.speak (at 0016) ---
-0016    | CONSTANT            2 '1'
-0018    | CONSTANT            3 'base'
-0020    | CALL_BUILTIN         4 'write' (2 args)
-0024    | RETURN
-0025    2 JUMP                9 (to 0037)
+--- Procedure base.speak (at 0023) ---
+0023    | CONSTANT            5 '1'
+0025    | CONSTANT            6 'base'
+0027    | CALL_BUILTIN         7 'write' (2 args)
+0031    | RETURN
+0032    2 JUMP                9 (to 0044)
 
---- Procedure child.child (at 0028) ---
-0028    | GET_LOCAL           0 (slot)
-0030    | CALL             0012 (Base.Base) (1 args)
-0036    | RETURN
-0037    | JUMP                9 (to 0049)
+--- Procedure child.child (at 0035) ---
+0035    | GET_LOCAL           0 (slot)
+0037    | CALL             0019 (base.base) (1 args)
+0043    | RETURN
+0044    | JUMP                9 (to 0056)
 
---- Procedure child.speak (at 0040) ---
-0040    | GET_LOCAL           0 (slot)
-0042    | CALL             0016 (Base.speak) (1 args)
-0048    | RETURN
-0049    0 CONSTANT            7 'Value type ARRAY'
-0051    | DEFINE_GLOBAL    NameIdx:8   'child_vtable' Type:ARRAY Dims:1 [0..1] of INTEGER ('integer')
-0061    | SET_GLOBAL          8 'child_vtable'
-0063    | CONSTANT           11 'Value type ARRAY'
-0065    | DEFINE_GLOBAL    NameIdx:12  'base_vtable' Type:ARRAY Dims:1 [0..1] of INTEGER ('integer')
-0075    | SET_GLOBAL         12 'base_vtable'
-0077    | GET_GLOBAL          0 'c'
-0079    | DUP
-0080    | GET_FIELD_OFFSET    0 (index)
-0082    | GET_GLOBAL_ADDRESS    8 'child_vtable'
-0084    | SET_INDIRECT
-0085    | POP
-0086    4 GET_GLOBAL          0 'c'
-0088    | DUP
-0089    | GET_FIELD_OFFSET    0 (index)
-0091    | GET_INDIRECT
-0092    | CONSTANT            2 '1'
-0094    | SWAP
-0095    | GET_ELEMENT_ADDRESS    1 (dims)
-0097    | GET_INDIRECT
-0098    | PROC_CALL_INDIRECT (args=1)
-0100    0 HALT
+--- Procedure child.speak (at 0047) ---
+0047    | GET_LOCAL           0 (slot)
+0049    | CALL             0023 (base.speak) (1 args)
+0055    | RETURN
+0056    0 CONSTANT           10 'Value type ARRAY'
+0058    | DEFINE_GLOBAL    NameIdx:11  'child_vtable' Type:ARRAY Dims:1 [0..1] of INTEGER ('integer')
+0068    | SET_GLOBAL         11 'child_vtable'
+0070    | CONSTANT           14 'Value type ARRAY'
+0072    | DEFINE_GLOBAL    NameIdx:15  'base_vtable' Type:ARRAY Dims:1 [0..1] of INTEGER ('integer')
+0082    | SET_GLOBAL         15 'base_vtable'
+0084    | GET_GLOBAL          3 'c'
+0086    | DUP
+0087    | GET_FIELD_OFFSET    0 (index)
+0089    | GET_GLOBAL_ADDRESS   11 'child_vtable'
+0091    | SET_INDIRECT
+0092    | POP
+0093    4 GET_GLOBAL          3 'c'
+0095    | DUP
+0096    | GET_FIELD_OFFSET    0 (index)
+0098    | GET_INDIRECT
+0099    | CONSTANT            5 '1'
+0101    | SWAP
+0102    | GET_ELEMENT_ADDRESS    1 (dims)
+0104    | GET_INDIRECT
+0105    | PROC_CALL_INDIRECT (args=1)
+0107    0 HALT
 == End Disassembly: Tests/rea/super_method.rea ==
 
-Constants (13):\n  0000: STR   "c"
-  0001: STR   "Child"
-  0002: INT   1
-  0003: STR   "base"
-  0004: STR   "write"
-  0005: STR   "Base.Base"
-  0006: STR   "Base.speak"
-  0007: Value type ARRAY
-  0008: STR   "child_vtable"
-  0009: INT   0
-  0010: STR   "integer"
-  0011: Value type ARRAY
-  0012: STR   "base_vtable"
+Constants (16):\n  0000: STR   "myself"
+  0001: NIL
+  0002: STR   ""
+  0003: STR   "c"
+  0004: STR   "Child"
+  0005: INT   1
+  0006: STR   "base"
+  0007: STR   "write"
+  0008: STR   "base.base"
+  0009: STR   "base.speak"
+  0010: Value type ARRAY
+  0011: STR   "child_vtable"
+  0012: INT   0
+  0013: STR   "integer"
+  0014: Value type ARRAY
+  0015: STR   "base_vtable"
 

--- a/Tests/rea/switch_stmt.err
+++ b/Tests/rea/switch_stmt.err
@@ -2,39 +2,44 @@
 == Disassembly: Tests/rea/switch_stmt.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
-0000    1 DEFINE_GLOBAL    NameIdx:0   'x' Type:INT64 ('int')
-0005    | CONSTANT            2 '2'
-0007    | SET_GLOBAL          0 'x'
-0009    2 GET_GLOBAL          0 'x'
-0011    | DUP
-0012    3 CONSTANT            3 '1'
-0014    2 EQUAL
-0015    | JUMP_IF_FALSE      12 (to 0030)
-0018    | POP
-0019    4 CONSTANT            3 '1'
-0021    | CONSTANT            3 '1'
-0023    | CALL_BUILTIN         4 'write' (2 args)
-0027    2 JUMP               28 (to 0058)
-0030    | DUP
-0031    6 CONSTANT            2 '2'
-0033    2 EQUAL
-0034    | JUMP_IF_FALSE      12 (to 0049)
-0037    | POP
-0038    7 CONSTANT            3 '1'
-0040    | CONSTANT            2 '2'
-0042    | CALL_BUILTIN         4 'write' (2 args)
-0046    2 JUMP                9 (to 0058)
-0049    | POP
-0050   10 CONSTANT            3 '1'
-0052    | CONSTANT            5 '3'
-0054    | CALL_BUILTIN         4 'write' (2 args)
-0058    0 HALT
+0000    0 CONSTANT            1 'nil'
+0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
+0007    1 DEFINE_GLOBAL    NameIdx:3   'x' Type:INT64 ('int')
+0012    | CONSTANT            5 '2'
+0014    | SET_GLOBAL          3 'x'
+0016    2 GET_GLOBAL          3 'x'
+0018    | DUP
+0019    3 CONSTANT            6 '1'
+0021    2 EQUAL
+0022    | JUMP_IF_FALSE      12 (to 0037)
+0025    | POP
+0026    4 CONSTANT            6 '1'
+0028    | CONSTANT            6 '1'
+0030    | CALL_BUILTIN         7 'write' (2 args)
+0034    2 JUMP               28 (to 0065)
+0037    | DUP
+0038    6 CONSTANT            5 '2'
+0040    2 EQUAL
+0041    | JUMP_IF_FALSE      12 (to 0056)
+0044    | POP
+0045    7 CONSTANT            6 '1'
+0047    | CONSTANT            5 '2'
+0049    | CALL_BUILTIN         7 'write' (2 args)
+0053    2 JUMP                9 (to 0065)
+0056    | POP
+0057   10 CONSTANT            6 '1'
+0059    | CONSTANT            8 '3'
+0061    | CALL_BUILTIN         7 'write' (2 args)
+0065    0 HALT
 == End Disassembly: Tests/rea/switch_stmt.rea ==
 
-Constants (6):\n  0000: STR   "x"
-  0001: STR   "int"
-  0002: INT   2
-  0003: INT   1
-  0004: STR   "write"
-  0005: INT   3
+Constants (9):\n  0000: STR   "myself"
+  0001: NIL
+  0002: STR   ""
+  0003: STR   "x"
+  0004: STR   "int"
+  0005: INT   2
+  0006: INT   1
+  0007: STR   "write"
+  0008: INT   3
 

--- a/Tests/rea/write_sugar.err
+++ b/Tests/rea/write_sugar.err
@@ -2,19 +2,24 @@
 == Disassembly: Tests/rea/write_sugar.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
-0000    1 CONSTANT            0 '1'
-0002    | CONSTANT            1 'A'
-0004    | CONSTANT            0 '1'
-0006    | CALL_BUILTIN         2 'write' (3 args)
-0010    2 CONSTANT            3 '0'
-0012    | CONSTANT            4 'B'
-0014    | CALL_BUILTIN         2 'write' (2 args)
-0018    0 HALT
+0000    0 CONSTANT            1 'nil'
+0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
+0007    1 CONSTANT            3 '1'
+0009    | CONSTANT            4 'A'
+0011    | CONSTANT            3 '1'
+0013    | CALL_BUILTIN         5 'write' (3 args)
+0017    2 CONSTANT            6 '0'
+0019    | CONSTANT            7 'B'
+0021    | CALL_BUILTIN         5 'write' (2 args)
+0025    0 HALT
 == End Disassembly: Tests/rea/write_sugar.rea ==
 
-Constants (5):\n  0000: INT   1
-  0001: CHAR  'A'
-  0002: STR   "write"
-  0003: INT   0
-  0004: CHAR  'B'
+Constants (8):\n  0000: STR   "myself"
+  0001: NIL
+  0002: STR   ""
+  0003: INT   1
+  0004: CHAR  'A'
+  0005: STR   "write"
+  0006: INT   0
+  0007: CHAR  'B'
 

--- a/Tests/rea/writeln_format.err
+++ b/Tests/rea/writeln_format.err
@@ -2,14 +2,19 @@
 == Disassembly: Tests/rea/writeln_format.rea ==
 Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
-0000    1 CONSTANT            0 '1'
-0002    | CONSTANT            1 '3.141590'
-0004    | FORMAT_VALUE     width:0 prec:2
-0007    | CALL_BUILTIN         2 'write' (2 args)
-0011    0 HALT
+0000    0 CONSTANT            1 'nil'
+0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
+0007    1 CONSTANT            3 '1'
+0009    | CONSTANT            4 '3.141590'
+0011    | FORMAT_VALUE     width:0 prec:2
+0014    | CALL_BUILTIN         5 'write' (2 args)
+0018    0 HALT
 == End Disassembly: Tests/rea/writeln_format.rea ==
 
-Constants (3):\n  0000: INT   1
-  0001: REAL  3.141590
-  0002: STR   "write"
+Constants (6):\n  0000: STR   "myself"
+  0001: NIL
+  0002: STR   ""
+  0003: INT   1
+  0004: REAL  3.141590
+  0005: STR   "write"
 

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -161,6 +161,16 @@ static void ensureMyselfGlobalDefined(BytecodeChunk* chunk, int line) {
     int myself_idx = ensureMyselfGlobalNameIndex(chunk);
     emitConstant(chunk, addNilConstant(chunk), line);
     emitGlobalNameIdx(chunk, DEFINE_GLOBAL, DEFINE_GLOBAL16, myself_idx, line);
+    // Declare the implicit "myself" variable as a generic pointer with a
+    // placeholder type name.  The VM's DEFINE_GLOBAL handler expects every
+    // global definition to include the declared VarType and an associated
+    // type-name constant index.  Previously we omitted these operands, which
+    // caused the VM to misinterpret the bytecode stream for the first
+    // statement following the implicit declaration (often a WRITELN), leading
+    // to stack underflows at runtime.
+    writeBytecodeChunk(chunk, (uint8_t)TYPE_POINTER, line);
+    int pointer_type_name_idx = addStringConstant(chunk, "");
+    emitConstantIndex16(chunk, pointer_type_name_idx, line);
     compiler_defined_myself_global = true;
 }
 


### PR DESCRIPTION
## Summary
- emit pointer type metadata when defining the implicit Rea `myself` global so DEFINE_GLOBAL no longer consumes subsequent bytecode
- regenerate Rea disassembly fixtures to account for the new global prologue and shifted constant indices
- update the Pascal RealIntOverflow test offset after the bytecode layout change

## Testing
- ctest --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68c97241e4f4832a8e2678e6f5d2f390