### PR TITLE
Fix SDL planets example mutex lock

### DIFF
--- a/Examples/rea/sdl_planets_sun
+++ b/Examples/rea/sdl_planets_sun
@@ -153,30 +153,36 @@ class SolarSystemApp {
     }
   }
 
-  void draw() {
-    lock(posMutex);
-    cleardevice();
-    setrgbcolor(255, 255, 0); // Sun
-    fillcircle(myself.centerX, myself.centerY, myself.sunRadius);
-    int i = 1;
-    while (i <= NumPlanets) {
-      myself.planets[i].draw();
-      i = i + 1;
+    void draw() {
+      int i;
+      float mx;
+      float my;
+      int moonDrawRadius;
+      str monthStr;
+
+      lock(posMutex);
+      cleardevice();
+      setrgbcolor(255, 255, 0); // Sun
+      fillcircle(myself.centerX, myself.centerY, myself.sunRadius);
+      i = 1;
+      while (i <= NumPlanets) {
+        myself.planets[i].draw();
+        i = i + 1;
+      }
+      // Update and draw Earth's Moon
+      myself.moonAngle = myself.moonAngle + myself.moonSpeed;
+      if (myself.moonAngle >= 6.283185307179586) myself.moonAngle = myself.moonAngle - 6.283185307179586;
+      mx = myself.planets[3].posX + cos(myself.moonAngle) * myself.moonOrbit;
+      my = myself.planets[3].posY + sin(myself.moonAngle) * myself.moonOrbit;
+      setrgbcolor(200, 200, 200);
+      moonDrawRadius = round(myself.moonSize * PlanetVisualScale);
+      if (moonDrawRadius < 1) moonDrawRadius = 1;
+      fillcircle(trunc(mx), trunc(my), moonDrawRadius);
+      monthStr = "Earth months elapsed: " + inttostr(trunc(earthMonths));
+      outtextxy(getmaxx() - 220, 16, monthStr);
+      unlock(posMutex);
+      updatescreen();
     }
-    // Update and draw Earth's Moon
-    myself.moonAngle = myself.moonAngle + myself.moonSpeed;
-    if (myself.moonAngle >= 6.283185307179586) myself.moonAngle = myself.moonAngle - 6.283185307179586;
-    float mx = myself.planets[3].posX + cos(myself.moonAngle) * myself.moonOrbit;
-    float my = myself.planets[3].posY + sin(myself.moonAngle) * myself.moonOrbit;
-    setrgbcolor(200, 200, 200);
-    int moonDrawRadius = round(myself.moonSize * PlanetVisualScale);
-    if (moonDrawRadius < 1) moonDrawRadius = 1;
-    fillcircle(trunc(mx), trunc(my), moonDrawRadius);
-    str monthStr = "Earth months elapsed: " + inttostr(trunc(earthMonths));
-    outtextxy(getmaxx() - 220, 16, monthStr);
-    unlock(posMutex);
-    updatescreen();
-  }
 
   void joinThreads() {
     int i = 1;


### PR DESCRIPTION
## Summary
- declare draw-time locals up front in `SolarSystemApp.draw` so the mutex is always released and the screen updates

## Testing
- not run (GUI example)


------
https://chatgpt.com/codex/tasks/task_e_68c98012721c832aae63d65ae3f691ac