### PR TITLE
Fix SDL quit flag deadlock

### DIFF
--- a/src/Pascal/globals.c
+++ b/src/Pascal/globals.c
@@ -49,7 +49,7 @@ int gWindowBottom          = 24;
 // --- End CRT State Variables ---
 
 // Flag used by builtins like GraphLoop to signal a quit request from the user.
-int break_requested = 0;
+atomic_int break_requested = ATOMIC_VAR_INIT(0);
 // Flag used by builtin 'exit' to request unwinding the current routine (not program termination).
 int exit_requested = 0;
 // Semantic/type error counter for the Pascal front end

--- a/src/Pascal/globals.h
+++ b/src/Pascal/globals.h
@@ -5,6 +5,7 @@
 #include <stdio.h>  // For fprintf, stderr
 #include <stdlib.h> // For exit, EXIT_FAILURE
 #include <pthread.h> // For mutex guarding of global tables
+#include <stdatomic.h> // For atomic flags shared across threads
 
 #include "types.h" // Provides TypeEntry, Value, List, AST forward decl etc.
 #ifdef SDL
@@ -74,7 +75,7 @@ extern int dumpExec;
 extern List *inserted_global_names;
 #endif
 
-extern int break_requested;
+extern atomic_int break_requested;
 extern int exit_requested; // Flag set by builtin 'exit' to unwind the current routine
 extern int pascal_semantic_error_count; // Count of semantic/type errors during analysis
 extern int pascal_parser_error_count;   // Count of parser (syntax) errors

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -1503,7 +1503,7 @@ Value vmBuiltinQuitrequested(VM* vm, int arg_count, Value* args) {
         return makeBoolean(false);
     }
     // Access the global flag and return it as a Pscal boolean
-    return makeBoolean(break_requested != 0);
+    return makeBoolean(atomic_load(&break_requested) != 0);
 }
 
 Value vmBuiltinGotoxy(VM* vm, int arg_count, Value* args) {

--- a/src/backend_ast/sdl.c
+++ b/src/backend_ast/sdl.c
@@ -999,11 +999,11 @@ Value vmBuiltinPollkey(VM* vm, int arg_count, Value* args) {
     SDL_Event event;
     while (SDL_PollEvent(&event)) {
         if (event.type == SDL_QUIT) {
-            break_requested = 1;
+            atomic_store(&break_requested, 1);
             return makeInt(0);
         } else if (event.type == SDL_KEYDOWN) {
             if (event.key.keysym.sym == SDLK_q) {
-                break_requested = 1;
+                atomic_store(&break_requested, 1);
             }
             return makeInt((int)event.key.keysym.sym);
         }
@@ -1136,7 +1136,7 @@ Value vmBuiltinGraphloop(VM* vm, int arg_count, Value* args) {
              * code can process them on the next iteration.
              */
             if (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_QUIT, SDL_QUIT) > 0) {
-                break_requested = 1;
+                atomic_store(&break_requested, 1);
                 return makeVoid();
             }
 

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -699,9 +699,9 @@ static Value peek(VM* vm, int distance) { // Using your original name 'peek'
 
 // --- Host Function C Implementations ---
 static Value vmHostQuitRequested(VM* vm) {
-    // break_requested is extern int from globals.h, defined in globals.c
+    // break_requested is an atomic flag from globals.h/globals.c
     // makeBoolean is from core/utils.h
-    return makeBoolean(break_requested);
+    return makeBoolean(atomic_load(&break_requested));
 }
 
 static Value vmHostCreateThreadAddr(VM* vm) {
@@ -1319,7 +1319,7 @@ static bool builtinUsesGlobalStructures(const char* name) {
         "reset",          "rewrite",       "screenrows",    "screencols",
         "showcursor",     "textbackground", "textbackgrounde","textcolor",
         "textcolore",     "underlinetext", "window",        "wherex",
-        "wherey", "pollkey", "waitkeyevent", "graphloop", 
+        "wherey",
     };
 
     for (size_t i = 0; i < sizeof(needs_lock)/sizeof(needs_lock[0]); i++) {


### PR DESCRIPTION
## Summary
- make the global break_requested flag atomic and update consumers
- switch SDL event helpers to use atomic stores when signalling quit
- remove pollkey/waitkeyevent/graphloop from the globals-mutex whitelist to avoid lock ordering deadlocks

## Testing
- cmake -S . -B build
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_e_68c98cf63250832aa9b5014dbf00a541