### PR TITLE
Move SDL GL swap builtins to 3D module and document front-end usage

### DIFF
--- a/Docs/clike_language_reference.md
+++ b/Docs/clike_language_reference.md
@@ -225,6 +225,30 @@ join tid;
 
 The C-like front end has access to the rich set of built-in functions provided by the PSCAL VM, including file I/O, string manipulation, mathematical functions, and more. Some common C library functions are also mapped to their Pascal equivalents (e.g., `strlen` is mapped to `length`).
 
+When PSCAL is built with SDL support (`-DSDL=ON`), clike programs can also call the SDL graphics and audio helpers. This includes the 3D routines `initgraph3d`, `glsetswapinterval`, and `glswapwindow`, which manage an OpenGL-backed window and control its swap interval. A minimal render loop looks like:
+
+```c
+#ifdef SDL_ENABLED
+int main() {
+  int vsync_on = 1;
+  initgraph3d(640, 480, "Swap Demo", 24, 8);
+  glsetswapinterval(1);
+
+  for (int frame = 0; frame < 600; frame = frame + 1) {
+    if (frame > 0 && frame % 120 == 0) {
+      vsync_on = !vsync_on;
+      glsetswapinterval(vsync_on ? 1 : 0);
+    }
+    glswapwindow();
+    graphloop(1);
+  }
+
+  closegraph3d();
+  return 0;
+}
+#endif
+```
+
 ### **Example Code**
 
 Here is a simple "Hello, World!" program to demonstrate the language's syntax:

--- a/Docs/pascal_language_reference.md
+++ b/Docs/pascal_language_reference.md
@@ -220,7 +220,7 @@ The Pascal front end exposes the PSCAL VM's built-ins, including:
 - Memory: `New`, `Dispose`.
 - Console/text: `GotoXY`, `TextColor`, `TextBackground`, `ClrScr`, `WhereX`, `WhereY`.
 - Concurrency (see below): `spawn`, `join`, `mutex`, `rcmutex`, `lock`, `unlock`, `destroy`.
-- SDL-based graphics/sound (when built with `-DSDL=ON`): e.g., `InitGraph`, `InitGraph3D`, `CloseGraph`, `CloseGraph3D`, `UpdateScreen`, `SetRGBColor`, `DrawLine`, `FillRect`, `FillCircle`, `CreateTexture`, `UpdateTexture`, `DestroyTexture`, text helpers like `InitTextSystem(FontFileName, FontSize)`, `OutTextXY`, and audio: `InitSoundSystem`, `LoadSound`, `PlaySound`, `IsSoundPlaying`, `FreeSound`, `QuitSoundSystem`.
+- SDL-based graphics/sound (when built with `-DSDL=ON`): e.g., `InitGraph`, `InitGraph3D`, `CloseGraph`, `CloseGraph3D`, `UpdateScreen`, `GLSwapWindow`, `GLSetSwapInterval`, `SetRGBColor`, `DrawLine`, `FillRect`, `FillCircle`, `CreateTexture`, `UpdateTexture`, `DestroyTexture`, text helpers like `InitTextSystem(FontFileName, FontSize)`, `OutTextXY`, and audio: `InitSoundSystem`, `LoadSound`, `PlaySound`, `IsSoundPlaying`, `FreeSound`, `QuitSoundSystem`.
 
 Note: SDL built-ins are available only in SDL-enabled builds. Headless CI typically skips these routines.
 

--- a/Docs/pscal_vm_builtins.md
+++ b/Docs/pscal_vm_builtins.md
@@ -200,7 +200,8 @@ Numeric builtins preserve integer types when all inputs are integral. In particu
 
 ## SDL graphics and audio
 
-These built-ins are available when Pscal is built with SDL support.
+These built-ins are available when Pscal is built with SDL support and can be
+imported from each front end (Pascal, CLike, and Rea).
 
 | Name | Parameters | Returns | Description |
 | ---- | ---------- | ------- | ----------- |
@@ -209,6 +210,8 @@ These built-ins are available when Pscal is built with SDL support.
 | closegraph | () | void | Close graphics. |
 | closegraph3d | () | void | Close the OpenGL window and delete its context. |
 | graphloop | () | void | Poll events and delay. |
+| glsetswapinterval | (interval: Integer) | void | Set the OpenGL swap interval (0 disables vsync, 1 enables it). |
+| glswapwindow | () | void | Swap the OpenGL window buffers to present the rendered frame. |
 | updatescreen | () | void | Present renderer. |
 | cleardevice | () | void | Clear renderer. |
 | setcolor | (color: Integer) | void | Set drawing color. |
@@ -248,6 +251,31 @@ These built-ins are available when Pscal is built with SDL support.
 | getmousestate | (var x: Integer, var y: Integer, var buttons: Integer) | void | Query mouse position and buttons. |
 | getticks | () | Integer | Milliseconds since start. |
 | pollkey | () | Integer | Poll for key press. |
+
+### Basic OpenGL render loop
+
+```pascal
+program SwapDemo;
+var
+  frame: Integer;
+begin
+  InitGraph3D(640, 480, 'Swap Demo', 24, 8);
+  GLSetSwapInterval(1); { enable vsync }
+
+  for frame := 0 to 599 do
+  begin
+    { Issue your OpenGL rendering here }
+
+    if frame = 300 then
+      GLSetSwapInterval(0); { drop vsync after five seconds }
+
+    GLSwapWindow;          { present the frame }
+    GraphLoop(1);          { keep SDL responsive without busy waiting }
+  end;
+
+  CloseGraph3D;
+end.
+```
 
 ## Examples
 

--- a/Docs/rea_language_reference.md
+++ b/Docs/rea_language_reference.md
@@ -111,6 +111,28 @@ Rea code can call any PSCAL VM built‑in, including I/O (`writeln`, `printf`),
 string helpers, math functions, and threading primitives such as `spawn`,
 `join`, `mutex`, `lock`, and `unlock`.
 
+When PSCAL is compiled with SDL support, the same graphics and audio helpers used by Pascal are available to Rea programs. The 3D routines `InitGraph3D`, `GLSetSwapInterval`, and `GLSwapWindow` expose an OpenGL-backed window and its swap interval. A short render loop looks like:
+
+```rea
+int main() {
+  bool vsyncOn = true;
+  InitGraph3D(640, 480, "Swap Demo", 24, 8);
+  GLSetSwapInterval(1);
+
+  for (int frame = 0; frame < 600; frame = frame + 1) {
+    if (frame > 0 && frame % 120 == 0) {
+      vsyncOn = !vsyncOn;
+      GLSetSwapInterval(vsyncOn ? 1 : 0);
+    }
+    GLSwapWindow();
+    GraphLoop(1);
+  }
+
+  CloseGraph3D();
+  return 0;
+}
+```
+
 ### **Example**
 
 ```rea

--- a/Examples/Pascal/SDLSmoke
+++ b/Examples/Pascal/SDLSmoke
@@ -1,10 +1,33 @@
 #!/usr/bin/env pascal
 program SDLSmoke;
+var
+  frame: Integer;
+  vsyncOn: Boolean;
 begin
   // InitGraph3D(WindowWidth, WindowHeight, Title, DepthBits, StencilBits)
   // creates an SDL window with an OpenGL context. Use CloseGraph or
   // CloseGraph3D to tear it down when finished.
-  InitGraph(320, 240, 'SDL Smoke');
-  CloseGraph;
+  InitGraph3D(640, 480, 'SDL Swap Demo', 24, 8);
+  GLSetSwapInterval(1); // start with vsync enabled
+  vsyncOn := True;
+
+  for frame := 0 to 599 do
+  begin
+    // Toggle vsync every two seconds just to demonstrate the new builtin.
+    if (frame > 0) and (frame mod 120 = 0) then
+    begin
+      vsyncOn := not vsyncOn;
+      if vsyncOn then
+        GLSetSwapInterval(1)
+      else
+        GLSetSwapInterval(0);
+    end;
+
+    // Submit your OpenGL draw calls here before swapping.
+    GLSwapWindow;
+    GraphLoop(1); // keep the window responsive
+  end;
+
+  CloseGraph3D;
 end.
 

--- a/Examples/clike/builtins.h
+++ b/Examples/clike/builtins.h
@@ -77,6 +77,8 @@ void getmousestate(int* x, int* y, int* buttons);
 int getpixelcolor();
 int gettextsize();
 int getticks();
+int glsetswapinterval();
+int glswapwindow();
 int gotoxy();
 int graphloop();
 int halt();

--- a/Examples/clike/sdl_smoke
+++ b/Examples/clike/sdl_smoke
@@ -1,11 +1,31 @@
 #!/usr/bin/env clike
 #ifdef SDL_ENABLED
 // initgraph3d(widthPixels, heightPixels, title, depthBits, stencilBits) builds
-// an OpenGL-capable SDL window. closegraph3d() or closegraph() releases the
-// GL context and any associated window/renderer state.
+// an OpenGL-capable SDL window. glswapwindow() presents the frame and
+// glsetswapinterval() toggles vsync.
 int main() {
-    initgraph(320, 240, "SDL Smoke");
-    closegraph();
+    int frame;
+    int vsync_on = 1;
+
+    initgraph3d(640, 480, "SDL Swap Demo", 24, 8);
+    glsetswapinterval(1);
+
+    for (frame = 0; frame < 600; frame = frame + 1) {
+        if (frame > 0 && frame % 120 == 0) {
+            vsync_on = !vsync_on;
+            if (vsync_on) {
+                glsetswapinterval(1);
+            } else {
+                glsetswapinterval(0);
+            }
+        }
+
+        /* Submit your OpenGL draw calls here before swapping. */
+        glswapwindow();
+        graphloop(1);
+    }
+
+    closegraph3d();
     return 0;
 }
 #else

--- a/Examples/rea/sdl_demo
+++ b/Examples/rea/sdl_demo
@@ -1,24 +1,31 @@
 #!/usr/bin/env rea
 // Rea SDL demo (requires building with -DSDL=ON)
 // InitGraph3D(widthPixels, heightPixels, title, depthBits, stencilBits) creates
-// an SDL window backed by an OpenGL context. CloseGraph3D() (or CloseGraph())
-// releases that context along with the window.
+// an SDL window backed by an OpenGL context. GLSwapWindow presents the frame
+// while GLSetSwapInterval toggles vsync.
 
-writeln("Starting Rea SDL demo (initializing text system)...");
-InitGraph(1, 1, "Rea SDL demo");
-string systemFontPath = "/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf";
-string repoFontPath1 = "fonts/Roboto/static/Roboto-Regular.ttf";
-string repoFontPath2 = "../../fonts/Roboto/static/Roboto-Regular.ttf";
-if (fileexists(systemFontPath)) {
-  InitTextSystem(systemFontPath, 18);
-} else if (fileexists(repoFontPath1)) {
-  InitTextSystem(repoFontPath1, 18);
-} else {
-  InitTextSystem(repoFontPath2, 18);
+int main() {
+  bool vsyncOn = true;
+
+  InitGraph3D(640, 480, "Rea SDL swap demo", 24, 8);
+  GLSetSwapInterval(1);
+
+  for (int frame = 0; frame < 600; frame = frame + 1) {
+    if (frame > 0 && frame % 120 == 0) {
+      vsyncOn = !vsyncOn;
+      if (vsyncOn) {
+        GLSetSwapInterval(1);
+      } else {
+        GLSetSwapInterval(0);
+      }
+    }
+
+    // Submit OpenGL draw calls here before swapping.
+    GLSwapWindow();
+    GraphLoop(1);
+  }
+
+  CloseGraph3D();
+  return 0;
 }
-SetColor(255, 255, 255, 255);
-writeln("Text system initialized.");
-QuitTextSystem();
-CloseGraph();
-writeln("Rea SDL demo finished.");
 

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -289,6 +289,8 @@ static const VmBuiltinMapping vmBuiltinDispatchTable[] = {
     {"getpixelcolor", vmBuiltinGetpixelcolor}, // Moved
     {"gettextsize", vmBuiltinGettextsize},
     {"getticks", vmBuiltinGetticks},
+    {"glsetswapinterval", vmBuiltinGlsetswapinterval},
+    {"glswapwindow", vmBuiltinGlswapwindow},
 #endif
     {"gettime", vmBuiltinDosGettime},
 #ifdef SDL
@@ -3714,6 +3716,7 @@ void registerAllBuiltins(void) {
 
 #ifdef SDL
     /* Additional SDL graphics and sound built-ins */
+    registerBuiltinFunction("CloseGraph3D", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("CreateTargetTexture", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("CreateTexture", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("DestroyTexture", AST_PROCEDURE_DECL, NULL);
@@ -3727,6 +3730,9 @@ void registerAllBuiltins(void) {
     registerBuiltinFunction("GetPixelColor", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("GetTextSize", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("GetTicks", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("GLSetSwapInterval", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("GLSwapWindow", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("InitGraph3D", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("InitSoundSystem", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("InitTextSystem", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("IsSoundPlaying", AST_FUNCTION_DECL, NULL);

--- a/src/backend_ast/sdl.h
+++ b/src/backend_ast/sdl.h
@@ -64,6 +64,8 @@ Value vmBuiltinSetalphablend(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinRendertexttotexture(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinFillcircle(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinGraphloop(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinGlsetswapinterval(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinGlswapwindow(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinPutpixel(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinCreatetargettexture(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinCreatetexture(struct VM_s* vm, int arg_count, Value* args);

--- a/src/backend_ast/sdl3d.c
+++ b/src/backend_ast/sdl3d.c
@@ -92,4 +92,36 @@ Value vmBuiltinClosegraph3d(VM* vm, int arg_count, Value* args) {
     return makeVoid();
 }
 
+Value vmBuiltinGlsetswapinterval(VM* vm, int arg_count, Value* args) {
+    if (arg_count != 1 || !IS_INTLIKE(args[0])) {
+        runtimeError(vm, "GLSetSwapInterval expects 1 integer argument.");
+        return makeVoid();
+    }
+    if (!gSdlInitialized || !gSdlWindow || !gSdlGLContext) {
+        runtimeError(vm, "Runtime error: GLSetSwapInterval requires an active OpenGL window. Call InitGraph3D first.");
+        return makeVoid();
+    }
+
+    int interval = (int)AS_INTEGER(args[0]);
+    if (SDL_GL_SetSwapInterval(interval) != 0) {
+        runtimeError(vm, "Runtime error: SDL_GL_SetSwapInterval failed: %s", SDL_GetError());
+    }
+
+    return makeVoid();
+}
+
+Value vmBuiltinGlswapwindow(VM* vm, int arg_count, Value* args) {
+    if (arg_count != 0) {
+        runtimeError(vm, "GLSwapWindow expects 0 arguments.");
+        return makeVoid();
+    }
+    if (!gSdlInitialized || !gSdlWindow || !gSdlGLContext) {
+        runtimeError(vm, "Runtime error: GLSwapWindow requires an active OpenGL window. Call InitGraph3D first.");
+        return makeVoid();
+    }
+
+    SDL_GL_SwapWindow(gSdlWindow);
+    return makeVoid();
+}
+
 #endif // SDL


### PR DESCRIPTION
## Summary
- move GLSetSwapInterval/GLSwapWindow VM builtins into sdl3d.c and register them alongside the other SDL3D helpers
- expose the swap routines to the CLike and Rea fronts via builtin registration, headers, and updated SDL smoke demos
- extend the SDL docs to note availability across all front ends and show render-loop usage in each language

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9c024d3cc832abaaf545bd5988b56