### PR TITLE
Add 3D SDL demos for each front end

### DIFF
--- a/Docs/clike_language_reference.md
+++ b/Docs/clike_language_reference.md
@@ -268,6 +268,10 @@ int main() {
 #endif
 ```
 
+For a fuller walkthrough that renders a shaded, rotating cube with depth
+testing, matrix manipulation, and swap-interval toggling, refer to
+`Examples/clike/sdl_smoke`.
+
 ### **Example Code**
 
 Here is a simple "Hello, World!" program to demonstrate the language's syntax:

--- a/Docs/pascal_language_reference.md
+++ b/Docs/pascal_language_reference.md
@@ -222,6 +222,9 @@ The Pascal front end exposes the PSCAL VM's built-ins, including:
 - Concurrency (see below): `spawn`, `join`, `mutex`, `rcmutex`, `lock`, `unlock`, `destroy`.
 - SDL-based graphics/sound (when built with `-DSDL=ON`): e.g., `InitGraph`, `InitGraph3D`, `CloseGraph`, `CloseGraph3D`, `UpdateScreen`, `GLClearColor`, `GLClear`, `GLClearDepth`, `GLMatrixMode`, `GLLoadIdentity`, `GLTranslatef`, `GLRotatef`, `GLScalef`, `GLBegin`/`GLEnd`, `GLColor3f`, `GLVertex3f`, `GLViewport`, `GLDepthTest`, `GLSwapWindow`, `GLSetSwapInterval`, `SetRGBColor`, `DrawLine`, `FillRect`, `FillCircle`, `CreateTexture`, `UpdateTexture`, `DestroyTexture`, text helpers like `InitTextSystem(FontFileName, FontSize)`, `OutTextXY`, and audio: `InitSoundSystem`, `LoadSound`, `PlaySound`, `IsSoundPlaying`, `FreeSound`, `QuitSoundSystem`.
 
+See `Examples/Pascal/SDLGLCube` for a complete rotating cube demo that showcases
+the 3D helpers in action.
+
 Note: SDL built-ins are available only in SDL-enabled builds. Headless CI typically skips these routines.
 
 ### **Threading and Synchronization**

--- a/Docs/rea_language_reference.md
+++ b/Docs/rea_language_reference.md
@@ -152,6 +152,10 @@ int main() {
 }
 ```
 
+The repository includes `Examples/rea/sdl_demo`, which expands this into a
+complete rotating cube rendered with per-face colors, depth testing, and periodic
+swap-interval toggling.
+
 ### **Example**
 
 ```rea

--- a/Examples/Pascal/SDLGLCube
+++ b/Examples/Pascal/SDLGLCube
@@ -6,8 +6,9 @@ const
   Height = 600;
 
 var
-  frame : Integer;
-  angle : Real;
+  frame  : Integer;
+  angle  : Real;
+  VSyncOn: Boolean;
 
 procedure DrawCube;
 begin
@@ -57,10 +58,21 @@ begin
   GLViewport(0, 0, Width, Height);
   GLClearDepth(1.0);
   GLDepthTest(true);
+  VSyncOn := true;
+  GLSetSwapInterval(1);
 
   for frame := 0 to 599 do
   begin
     angle := frame * 0.6;
+
+    if (frame > 0) and (frame mod 180 = 0) then
+    begin
+      VSyncOn := not VSyncOn;
+      if VSyncOn then
+        GLSetSwapInterval(1)
+      else
+        GLSetSwapInterval(0);
+    end;
 
     GLClearColor(0.1, 0.1, 0.15, 1.0);
     GLClear();

--- a/Examples/clike/README.md
+++ b/Examples/clike/README.md
@@ -26,6 +26,7 @@ build/bin/clike Examples/Clike/<program>
    library search path.
 - `sdl_multibouncingballs` – SDL multi bouncing balls demo ported from Pascal.
 - `sdl_mandelbrot_interactive` – SDL Mandelbrot renderer using the MandelbrotRow builtin; left click to zoom in, right click to zoom out.
+- `sdl_smoke` – Rotating 3D cube demo that exercises the OpenGL helpers (requires building with SDL support).
 - `sdl_getmousestate` – SDL demo printing mouse coordinates and button states.
 - `show_pid` – Uses an extended builtin function to show the process ID
 - `sort_string` – Shows how to copy and sort a string via a `str*` parameter

--- a/Examples/clike/sdl_smoke
+++ b/Examples/clike/sdl_smoke
@@ -1,26 +1,89 @@
 #!/usr/bin/env clike
 #ifdef SDL_ENABLED
-// initgraph3d(widthPixels, heightPixels, title, depthBits, stencilBits) builds
-// an OpenGL-capable SDL window. glswapwindow() presents the frame and
-// glsetswapinterval() toggles vsync.
+// Rotating cube demo showcasing the 3D SDL/OpenGL builtins exposed to CLike.
+// Requires building Pscal with SDL support (`-DSDL=ON`).
+
+const int WIDTH = 800;
+const int HEIGHT = 600;
+
+void draw_cube() {
+    glbegin("quads");
+
+    glcolor3f(1.0, 0.0, 0.0);
+    glvertex3f(-0.5, -0.5,  0.5);
+    glvertex3f( 0.5, -0.5,  0.5);
+    glvertex3f( 0.5,  0.5,  0.5);
+    glvertex3f(-0.5,  0.5,  0.5);
+
+    glcolor3f(0.0, 1.0, 0.0);
+    glvertex3f(-0.5, -0.5, -0.5);
+    glvertex3f(-0.5,  0.5, -0.5);
+    glvertex3f( 0.5,  0.5, -0.5);
+    glvertex3f( 0.5, -0.5, -0.5);
+
+    glcolor3f(0.0, 0.0, 1.0);
+    glvertex3f(-0.5, -0.5, -0.5);
+    glvertex3f(-0.5, -0.5,  0.5);
+    glvertex3f(-0.5,  0.5,  0.5);
+    glvertex3f(-0.5,  0.5, -0.5);
+
+    glcolor3f(1.0, 1.0, 0.0);
+    glvertex3f(0.5, -0.5, -0.5);
+    glvertex3f(0.5,  0.5, -0.5);
+    glvertex3f(0.5,  0.5,  0.5);
+    glvertex3f(0.5, -0.5,  0.5);
+
+    glcolor3f(0.0, 1.0, 1.0);
+    glvertex3f(-0.5,  0.5, -0.5);
+    glvertex3f(-0.5,  0.5,  0.5);
+    glvertex3f( 0.5,  0.5,  0.5);
+    glvertex3f( 0.5,  0.5, -0.5);
+
+    glcolor3f(1.0, 0.0, 1.0);
+    glvertex3f(-0.5, -0.5, -0.5);
+    glvertex3f( 0.5, -0.5, -0.5);
+    glvertex3f( 0.5, -0.5,  0.5);
+    glvertex3f(-0.5, -0.5,  0.5);
+
+    glend();
+}
+
 int main() {
     int frame;
+    double angle;
     int vsync_on = 1;
 
-    initgraph3d(640, 480, "SDL Swap Demo", 24, 8);
+    initgraph3d(WIDTH, HEIGHT, "CLike SDL GL Cube", 24, 8);
+    glviewport(0, 0, WIDTH, HEIGHT);
+    glcleardepth(1.0);
+    gldepthtest(1);
     glsetswapinterval(1);
 
     for (frame = 0; frame < 600; frame = frame + 1) {
-        if (frame > 0 && frame % 120 == 0) {
+        angle = frame * 0.6;
+
+        if (frame > 0 && frame % 180 == 0) {
             vsync_on = !vsync_on;
-            if (vsync_on) {
-                glsetswapinterval(1);
-            } else {
-                glsetswapinterval(0);
-            }
+            glsetswapinterval(vsync_on ? 1 : 0);
         }
 
-        /* Submit your OpenGL draw calls here before swapping. */
+        glclearcolor(0.1, 0.1, 0.15, 1.0);
+        glclear();
+
+        glmatrixmode("projection");
+        glloadidentity();
+        glscalef(1.3, 1.3, 1.3);
+
+        glmatrixmode("modelview");
+        glloadidentity();
+        gltranslatef(0.0, 0.0, -0.2);
+        glrotatef(angle, 1.0, 1.0, 0.0);
+
+        glpushmatrix();
+        glrotatef(angle * 0.25, 0.0, 0.0, 1.0);
+        draw_cube();
+        glpopmatrix();
+
         glswapwindow();
         graphloop(1);
     }

--- a/Examples/rea/sdl_demo
+++ b/Examples/rea/sdl_demo
@@ -1,17 +1,66 @@
 #!/usr/bin/env rea
-// Rea SDL demo (requires building with -DSDL=ON)
-// InitGraph3D(widthPixels, heightPixels, title, depthBits, stencilBits) creates
-// an SDL window backed by an OpenGL context. GLSwapWindow presents the frame
-// while GLSetSwapInterval toggles vsync.
+// Rotating cube demo for the Rea front end. Exercises the 3D SDL/OpenGL
+// builtins (`InitGraph3D`, `GL*` helpers, `GraphLoop`) that were recently added
+// to the runtime. Requires building with SDL enabled (`-DSDL=ON`).
+
+void DrawCube() {
+  GLBegin("quads");
+
+  GLColor3f(1.0, 0.0, 0.0);
+  GLVertex3f(-0.5, -0.5,  0.5);
+  GLVertex3f( 0.5, -0.5,  0.5);
+  GLVertex3f( 0.5,  0.5,  0.5);
+  GLVertex3f(-0.5,  0.5,  0.5);
+
+  GLColor3f(0.0, 1.0, 0.0);
+  GLVertex3f(-0.5, -0.5, -0.5);
+  GLVertex3f(-0.5,  0.5, -0.5);
+  GLVertex3f( 0.5,  0.5, -0.5);
+  GLVertex3f( 0.5, -0.5, -0.5);
+
+  GLColor3f(0.0, 0.0, 1.0);
+  GLVertex3f(-0.5, -0.5, -0.5);
+  GLVertex3f(-0.5, -0.5,  0.5);
+  GLVertex3f(-0.5,  0.5,  0.5);
+  GLVertex3f(-0.5,  0.5, -0.5);
+
+  GLColor3f(1.0, 1.0, 0.0);
+  GLVertex3f(0.5, -0.5, -0.5);
+  GLVertex3f(0.5,  0.5, -0.5);
+  GLVertex3f(0.5,  0.5,  0.5);
+  GLVertex3f(0.5, -0.5,  0.5);
+
+  GLColor3f(0.0, 1.0, 1.0);
+  GLVertex3f(-0.5,  0.5, -0.5);
+  GLVertex3f(-0.5,  0.5,  0.5);
+  GLVertex3f( 0.5,  0.5,  0.5);
+  GLVertex3f( 0.5,  0.5, -0.5);
+
+  GLColor3f(1.0, 0.0, 1.0);
+  GLVertex3f(-0.5, -0.5, -0.5);
+  GLVertex3f( 0.5, -0.5, -0.5);
+  GLVertex3f( 0.5, -0.5,  0.5);
+  GLVertex3f(-0.5, -0.5,  0.5);
+
+  GLEnd();
+}
 
 int main() {
+  const int Width = 800;
+  const int Height = 600;
   bool vsyncOn = true;
+  float angle;
 
-  InitGraph3D(640, 480, "Rea SDL swap demo", 24, 8);
+  InitGraph3D(Width, Height, "Rea SDL GL Cube", 24, 8);
+  GLViewport(0, 0, Width, Height);
+  GLClearDepth(1.0);
+  GLDepthTest(true);
   GLSetSwapInterval(1);
 
   for (int frame = 0; frame < 600; frame = frame + 1) {
-    if (frame > 0 && frame % 120 == 0) {
+    angle = frame * 0.6;
+
+    if (frame > 0 && frame % 180 == 0) {
       vsyncOn = !vsyncOn;
       if (vsyncOn) {
         GLSetSwapInterval(1);
@@ -20,7 +69,23 @@ int main() {
       }
     }
 
-    // Submit OpenGL draw calls here before swapping.
+    GLClearColor(0.1, 0.1, 0.15, 1.0);
+    GLClear();
+
+    GLMatrixMode("projection");
+    GLLoadIdentity();
+    GLScalef(1.3, 1.3, 1.3);
+
+    GLMatrixMode("modelview");
+    GLLoadIdentity();
+    GLTranslatef(0.0, 0.0, -0.2);
+    GLRotatef(angle, 1.0, 1.0, 0.0);
+
+    GLPushMatrix();
+    GLRotatef(angle * 0.25, 0.0, 0.0, 1.0);
+    DrawCube();
+    GLPopMatrix();
+
     GLSwapWindow();
     GraphLoop(1);
   }


### PR DESCRIPTION
## Summary
- expand the Pascal SDL cube example with swap-interval toggling
- replace the clike and rea SDL demos with full rotating cube render loops using the new 3D helpers
- document the new demos in the language references and clike example README

## Testing
- not run (examples and docs only)


------
https://chatgpt.com/codex/tasks/task_e_68c9da906ed8832a80b4bfe7d5d61a10