### PR TITLE
Add seeded Rea terrain demo and SDL helpers

### DIFF
--- a/Docs/pscal_vm_builtins.md
+++ b/Docs/pscal_vm_builtins.md
@@ -223,6 +223,8 @@ imported from each front end (Pascal, CLike, and Rea).
 | glpushmatrix | () | void | Push a copy of the current matrix onto the stack. |
 | glrotatef | (angle: Real, x: Real, y: Real, z: Real) | void | Apply a rotation (degrees) about the supplied axis. |
 | glscalef | (x: Real, y: Real, z: Real) | void | Apply a non-uniform scale to the current matrix. |
+| glfrustum | (left: Real, right: Real, bottom: Real, top: Real, near: Real, far: Real) | void | Configure a perspective frustum using `glFrustum`. |
+| glperspective | (fovY: Real, aspect: Real, near: Real, far: Real) | void | Convenience helper that computes a symmetric frustum from a field of view and aspect ratio. |
 | glsetswapinterval | (interval: Integer) | void | Set the OpenGL swap interval (0 disables vsync, 1 enables it). |
 | glswapwindow | () | void | Swap the OpenGL window buffers to present the rendered frame. |
 | gltranslatef | (x: Real, y: Real, z: Real) | void | Apply a translation to the current matrix. |
@@ -267,6 +269,7 @@ imported from each front end (Pascal, CLike, and Rea).
 | getmousestate | (var x: Integer, var y: Integer, var buttons: Integer) | void | Query mouse position and buttons. |
 | getticks | () | Integer | Milliseconds since start. |
 | pollkey | () | Integer | Poll for key press. |
+| iskeydown | (key: String\|Integer) | Boolean | Return `true` while the requested key is held down (uses SDL scancodes/key names). |
 
 ### Basic OpenGL render loop
 

--- a/Docs/rea_language_reference.md
+++ b/Docs/rea_language_reference.md
@@ -111,7 +111,7 @@ Rea code can call any PSCAL VM built‑in, including I/O (`writeln`, `printf`),
 string helpers, math functions, and threading primitives such as `spawn`,
 `join`, `mutex`, `lock`, and `unlock`.
 
-When PSCAL is compiled with SDL support, the same graphics and audio helpers used by Pascal are available to Rea programs. The 3D layer includes `InitGraph3D`, `GLSwapWindow`, `GLSetSwapInterval`, and a collection of fixed-function helpers (`GLClearColor`, `GLClear`, `GLClearDepth`, `GLMatrixMode`, `GLLoadIdentity`, `GLTranslatef`, `GLRotatef`, `GLScalef`, `GLBegin`/`GLEnd`, `GLColor3f`, `GLVertex3f`, `GLViewport`, `GLDepthTest`, ...). A short render loop looks like:
+When PSCAL is compiled with SDL support, the same graphics and audio helpers used by Pascal are available to Rea programs. The 3D layer includes `InitGraph3D`, `GLSwapWindow`, `GLSetSwapInterval`, and a collection of fixed-function helpers (`GLClearColor`, `GLClear`, `GLClearDepth`, `GLMatrixMode`, `GLLoadIdentity`, `GLTranslatef`, `GLRotatef`, `GLScalef`, `GLPerspective`, `GLFrustum`, `GLBegin`/`GLEnd`, `GLColor3f`, `GLVertex3f`, `GLViewport`, `GLDepthTest`, ...). A short render loop looks like:
 
 ```rea
 int main() {
@@ -154,7 +154,9 @@ int main() {
 
 The repository includes `Examples/rea/sdl_demo`, which expands this into a
 complete rotating cube rendered with per-face colors, depth testing, and periodic
-swap-interval toggling.
+swap-interval toggling. `Examples/rea/sdl_landscape` builds on the same helpers
+to generate a seeded terrain height field and lets you roam it with `IsKeyDown`
+and `GLPerspective` for a first-person view.
 
 ### **Example**
 

--- a/Examples/rea/sdl_landscape
+++ b/Examples/rea/sdl_landscape
@@ -1,0 +1,410 @@
+#!/usr/bin/env rea
+// Procedural landscape demo for the Rea front end. Generates a deterministic
+// height field from a seed, renders it with the SDL/OpenGL helpers, and lets
+// the user walk or rotate the camera with classic WASD controls.
+
+const int WindowWidth = 1280;
+const int WindowHeight = 720;
+const int TerrainSize = 128;
+const float TileScale = 1.2;
+const int NoiseOctaves = 5;
+const float HeightScale = 32.0;
+const float EyeHeight = 4.5;
+const float MoveSpeed = 18.0;
+const float TurnSpeed = 85.0;
+const float PitchSpeed = 65.0;
+const float MaxPitch = 75.0;
+
+bool hasDigit(str s) {
+  int i = 1;
+  while (i <= length(s)) {
+    char ch = s[i];
+    if (ch >= '0' && ch <= '9') return true;
+    i = i + 1;
+  }
+  return false;
+}
+
+int parseIntegerFromString(str s, int fallback) {
+  int len = length(s);
+  int idx = 1;
+  while (idx <= len) {
+    char ch = s[idx];
+    if ((ch >= '0' && ch <= '9') || ch == '+' || ch == '-') break;
+    idx = idx + 1;
+  }
+  if (idx > len) return fallback;
+  int sign = 1;
+  if (s[idx] == '+') {
+    idx = idx + 1;
+  } else if (s[idx] == '-') {
+    sign = -1;
+    idx = idx + 1;
+  }
+  int value = 0;
+  bool any = false;
+  while (idx <= len) {
+    char ch = s[idx];
+    if (ch >= '0' && ch <= '9') {
+      any = true;
+      value = value * 10 + (ch - '0');
+    } else {
+      break;
+    }
+    idx = idx + 1;
+  }
+  if (!any) return fallback;
+  return value * sign;
+}
+
+int extractSeedFromArgs(int fallback) {
+  int count = paramcount();
+  if (count == 0) return fallback;
+  int i = 1;
+  while (i <= count) {
+    str arg = paramstr(i);
+    if (hasDigit(arg)) {
+      return parseIntegerFromString(arg, fallback);
+    }
+    i = i + 1;
+  }
+  return fallback;
+}
+
+class TerrainField {
+  float heights[(TerrainSize + 1) * (TerrainSize + 1)];
+  float minHeight;
+  float maxHeight;
+  int seed;
+
+  void TerrainField() {
+    my.seed = 0;
+    my.minHeight = 0.0;
+    my.maxHeight = 0.0;
+    int total = (TerrainSize + 1) * (TerrainSize + 1);
+    int i = 0;
+    while (i < total) {
+      my.heights[i] = 0.0;
+      i = i + 1;
+    }
+  }
+
+  int index(int x, int z) { return z * (TerrainSize + 1) + x; }
+
+  float baseNoise(int x, int z) {
+    int n = x * 374761393 + z * 668265263 + my.seed * 362437;
+    n = n % 2147483647;
+    if (n < 0) n = n + 2147483647;
+    float value = n / 2147483647.0;
+    return value * 2.0 - 1.0;
+  }
+
+  float fade(float t) { return t * t * (3.0 - 2.0 * t); }
+
+  float valueNoise(float x, float z) {
+    int xi = floor(x);
+    int zi = floor(z);
+    float xf = x - xi;
+    float zf = z - zi;
+    float v00 = my.baseNoise(xi, zi);
+    float v10 = my.baseNoise(xi + 1, zi);
+    float v01 = my.baseNoise(xi, zi + 1);
+    float v11 = my.baseNoise(xi + 1, zi + 1);
+    float u = my.fade(xf);
+    float v = my.fade(zf);
+    float i1 = v00 + (v10 - v00) * u;
+    float i2 = v01 + (v11 - v01) * u;
+    return i1 + (i2 - i1) * v;
+  }
+
+  float fbm(float x, float z) {
+    float amplitude = 1.0;
+    float frequency = 1.0;
+    float sum = 0.0;
+    float total = 0.0;
+    int octave = 0;
+    while (octave < NoiseOctaves) {
+      sum = sum + my.valueNoise(x * frequency, z * frequency) * amplitude;
+      total = total + amplitude;
+      amplitude = amplitude * 0.5;
+      frequency = frequency * 2.0;
+      octave = octave + 1;
+    }
+    if (total == 0.0) return 0.0;
+    return sum / total;
+  }
+
+  void build(int s) {
+    my.seed = s;
+    my.minHeight = 1e9;
+    my.maxHeight = -1e9;
+    float baseFrequency = 0.035;
+    int z = 0;
+    while (z <= TerrainSize) {
+      int x = 0;
+      while (x <= TerrainSize) {
+        float sampleX = (x + s * 0.13) * baseFrequency;
+        float sampleZ = (z + s * 0.29) * baseFrequency;
+        float h = my.fbm(sampleX, sampleZ) * HeightScale;
+        int idx = my.index(x, z);
+        my.heights[idx] = h;
+        if (h < my.minHeight) my.minHeight = h;
+        if (h > my.maxHeight) my.maxHeight = h;
+        x = x + 1;
+      }
+      z = z + 1;
+    }
+    if (my.minHeight == my.maxHeight) {
+      my.maxHeight = my.minHeight + 0.001;
+    }
+  }
+
+  float rawHeight(int x, int z) {
+    if (x < 0) x = 0;
+    if (x > TerrainSize) x = TerrainSize;
+    if (z < 0) z = 0;
+    if (z > TerrainSize) z = TerrainSize;
+    return my.heights[my.index(x, z)];
+  }
+
+  float normalized(float h) {
+    float span = my.maxHeight - my.minHeight;
+    if (span <= 0.0001) return 0.0;
+    float t = (h - my.minHeight) / span;
+    if (t < 0.0) t = 0.0;
+    if (t > 1.0) t = 1.0;
+    return t;
+  }
+
+  float heightAt(float gx, float gz) {
+    if (gx < 0.0) gx = 0.0;
+    if (gx > TerrainSize) gx = TerrainSize;
+    if (gz < 0.0) gz = 0.0;
+    if (gz > TerrainSize) gz = TerrainSize;
+    int x0 = floor(gx);
+    int z0 = floor(gz);
+    int x1 = x0 + 1;
+    int z1 = z0 + 1;
+    if (x1 > TerrainSize) x1 = TerrainSize;
+    if (z1 > TerrainSize) z1 = TerrainSize;
+    float h00 = my.rawHeight(x0, z0);
+    float h10 = my.rawHeight(x1, z0);
+    float h01 = my.rawHeight(x0, z1);
+    float h11 = my.rawHeight(x1, z1);
+    float tx = gx - x0;
+    float tz = gz - z0;
+    float hx0 = h00 + (h10 - h00) * tx;
+    float hx1 = h01 + (h11 - h01) * tx;
+    return hx0 + (hx1 - hx0) * tz;
+  }
+}
+
+class LandscapeDemo {
+  TerrainField field;
+  int seed;
+  float camX;
+  float camZ;
+  float camY;
+  float yaw;
+  float pitch;
+  int lastTicks;
+  bool running;
+
+  void LandscapeDemo(int initialSeed) {
+    my.field = new TerrainField();
+    my.seed = initialSeed;
+    my.field.build(initialSeed);
+    my.camX = TerrainSize * 0.5;
+    my.camZ = TerrainSize * 0.5;
+    my.camY = my.field.heightAt(my.camX, my.camZ) + EyeHeight;
+    my.yaw = 135.0;
+    my.pitch = -20.0;
+    my.lastTicks = getticks();
+    my.running = true;
+  }
+
+  void initGraphics() {
+    InitGraph3D(WindowWidth, WindowHeight, "Rea Terrain", 24, 8);
+    GLViewport(0, 0, WindowWidth, WindowHeight);
+    GLClearDepth(1.0);
+    GLDepthTest(true);
+    GLSetSwapInterval(1);
+    writeln("Controls: WASD to move, hold Shift to rotate view. N/P change seed, R randomizes, Q or Esc exits.");
+  }
+
+  void regenerate(int newSeed) {
+    my.seed = newSeed;
+    my.field.build(newSeed);
+    my.camX = TerrainSize * 0.5;
+    my.camZ = TerrainSize * 0.5;
+    my.camY = my.field.heightAt(my.camX, my.camZ) + EyeHeight;
+    writeln("Generated landscape for seed ", my.seed, ".");
+  }
+
+  void handleDiscreteInput() {
+    int key = pollkey();
+    while (key != 0) {
+      if (key == 'q' || key == 'Q' || key == 27) {
+        my.running = false;
+        return;
+      } else if (key == 'n' || key == 'N') {
+        my.regenerate(my.seed + 1);
+      } else if (key == 'p' || key == 'P') {
+        my.regenerate(my.seed - 1);
+      } else if (key == 'r' || key == 'R') {
+        int tickSeed = getticks();
+        if (tickSeed == 0) tickSeed = my.seed + 7;
+        my.regenerate(tickSeed);
+      }
+      key = pollkey();
+    }
+  }
+
+  void applyColor(float h) {
+    float t = my.field.normalized(h);
+    if (t < 0.35) {
+      float w = t / 0.35;
+      float r = 0.0;
+      float g = 0.28 + 0.35 * w;
+      float b = 0.45 + 0.4 * w;
+      GLColor3f(r, g, b);
+    } else if (t < 0.6) {
+      float w = (t - 0.35) / 0.25;
+      float r = 0.15 + 0.25 * w;
+      float g = 0.42 + 0.35 * w;
+      float b = 0.18 + 0.08 * w;
+      GLColor3f(r, g, b);
+    } else if (t < 0.85) {
+      float w = (t - 0.6) / 0.25;
+      float r = 0.52 + 0.2 * w;
+      float g = 0.40 + 0.18 * w;
+      float b = 0.30 + 0.15 * w;
+      GLColor3f(r, g, b);
+    } else {
+      float w = (t - 0.85) / 0.15;
+      if (w < 0.0) w = 0.0;
+      if (w > 1.0) w = 1.0;
+      float c = 0.82 + 0.18 * w;
+      GLColor3f(c, c, c);
+    }
+  }
+
+  void drawTerrain() {
+    float half = TerrainSize * 0.5;
+    int z = 0;
+    while (z < TerrainSize) {
+      GLBegin("triangle_strip");
+      int x = 0;
+      while (x <= TerrainSize) {
+        float h0 = my.field.rawHeight(x, z);
+        float h1 = my.field.rawHeight(x, z + 1);
+        float worldX = (x - half) * TileScale;
+        float worldZ0 = (z - half) * TileScale;
+        float worldZ1 = ((z + 1) - half) * TileScale;
+        my.applyColor(h0);
+        GLVertex3f(worldX, h0, worldZ0);
+        my.applyColor(h1);
+        GLVertex3f(worldX, h1, worldZ1);
+        x = x + 1;
+      }
+      GLEnd();
+      z = z + 1;
+    }
+  }
+
+  void updateCamera(float dt) {
+    if (dt > 0.1) dt = 0.1;
+    bool shiftHeld = IsKeyDown("Left Shift") || IsKeyDown("Right Shift");
+    bool forward = IsKeyDown("W") || IsKeyDown("Up");
+    bool backward = IsKeyDown("S") || IsKeyDown("Down");
+    bool left = IsKeyDown("A") || IsKeyDown("Left");
+    bool right = IsKeyDown("D") || IsKeyDown("Right");
+
+    if (shiftHeld) {
+      if (left) my.yaw = my.yaw - TurnSpeed * dt;
+      if (right) my.yaw = my.yaw + TurnSpeed * dt;
+      if (forward) my.pitch = my.pitch + PitchSpeed * dt;
+      if (backward) my.pitch = my.pitch - PitchSpeed * dt;
+    } else {
+      float moveForward = 0.0;
+      float moveSide = 0.0;
+      if (forward) moveForward = moveForward + 1.0;
+      if (backward) moveForward = moveForward - 1.0;
+      if (right) moveSide = moveSide + 1.0;
+      if (left) moveSide = moveSide - 1.0;
+      float len = sqrt(moveForward * moveForward + moveSide * moveSide);
+      if (len > 0.0) {
+        moveForward = moveForward / len;
+        moveSide = moveSide / len;
+        float speed = MoveSpeed * dt;
+        float forwardX = sin(my.yaw);
+        float forwardZ = cos(my.yaw);
+        float rightX = sin(my.yaw + 90.0);
+        float rightZ = cos(my.yaw + 90.0);
+        float deltaX = (forwardX * moveForward + rightX * moveSide) * (speed / TileScale);
+        float deltaZ = (forwardZ * moveForward + rightZ * moveSide) * (speed / TileScale);
+        my.camX = my.camX + deltaX;
+        my.camZ = my.camZ + deltaZ;
+      }
+    }
+
+    if (my.yaw >= 360.0) my.yaw = my.yaw - 360.0;
+    if (my.yaw < 0.0) my.yaw = my.yaw + 360.0;
+    if (my.pitch > MaxPitch) my.pitch = MaxPitch;
+    if (my.pitch < -MaxPitch) my.pitch = -MaxPitch;
+
+    if (my.camX < 1.0) my.camX = 1.0;
+    if (my.camX > TerrainSize - 1) my.camX = TerrainSize - 1;
+    if (my.camZ < 1.0) my.camZ = 1.0;
+    if (my.camZ > TerrainSize - 1) my.camZ = TerrainSize - 1;
+
+    my.camY = my.field.heightAt(my.camX, my.camZ) + EyeHeight;
+  }
+
+  void drawFrame() {
+    GLClearColor(0.36, 0.55, 0.78, 1.0);
+    GLClear();
+
+    GLMatrixMode("projection");
+    GLLoadIdentity();
+    float aspect = WindowWidth / float(WindowHeight);
+    GLPerspective(68.0, aspect, 0.1, 320.0);
+
+    GLMatrixMode("modelview");
+    GLLoadIdentity();
+    GLRotatef(-my.pitch, 1.0, 0.0, 0.0);
+    GLRotatef(-my.yaw, 0.0, 1.0, 0.0);
+    float half = TerrainSize * 0.5;
+    float worldX = (my.camX - half) * TileScale;
+    float worldZ = (my.camZ - half) * TileScale;
+    GLTranslatef(-worldX, -my.camY, -worldZ);
+
+    my.drawTerrain();
+    GLSwapWindow();
+  }
+
+  void run() {
+    my.initGraphics();
+    my.lastTicks = getticks();
+    while (my.running) {
+      my.handleDiscreteInput();
+      if (QuitRequested()) break;
+      int now = getticks();
+      float dt = (now - my.lastTicks) / 1000.0;
+      my.lastTicks = now;
+      if (dt < 0.0) dt = 0.0;
+      my.updateCamera(dt);
+      my.drawFrame();
+      GraphLoop(1);
+    }
+    CloseGraph3D();
+  }
+}
+
+int main() {
+  int defaultSeed = 1337;
+  int seed = extractSeedFromArgs(defaultSeed);
+  LandscapeDemo demo = new LandscapeDemo(seed);
+  demo.run();
+  return 0;
+}

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -297,12 +297,14 @@ static const VmBuiltinMapping vmBuiltinDispatchTable[] = {
     {"glcolor3f", vmBuiltinGlcolor3f},
     {"gldepthtest", vmBuiltinGldepthtest},
     {"glend", vmBuiltinGlend},
+    {"glfrustum", vmBuiltinGlfrustum},
     {"glloadidentity", vmBuiltinGlloadidentity},
     {"glmatrixmode", vmBuiltinGlmatrixmode},
     {"glpopmatrix", vmBuiltinGlpopmatrix},
     {"glpushmatrix", vmBuiltinGlpushmatrix},
     {"glrotatef", vmBuiltinGlrotatef},
     {"glscalef", vmBuiltinGlscalef},
+    {"glperspective", vmBuiltinGlperspective},
     {"glsetswapinterval", vmBuiltinGlsetswapinterval},
     {"glswapwindow", vmBuiltinGlswapwindow},
     {"gltranslatef", vmBuiltinGltranslatef},
@@ -366,6 +368,7 @@ static const VmBuiltinMapping vmBuiltinDispatchTable[] = {
 #ifdef SDL
     {"playsound", vmBuiltinPlaysound},
     {"pollkey", vmBuiltinPollkey},
+    {"iskeydown", vmBuiltinIskeydown},
 #endif
     {"popscreen", vmBuiltinPopscreen},
     {"pos", vmBuiltinPos},
@@ -3726,6 +3729,7 @@ static const char *const sdl_gl_builtin_names[] = {
     "GLColor3f",
     "GLDepthTest",
     "GLEnd",
+    "GLFrustum",
     "GLLoadIdentity",
     "GLMatrixMode",
     "GLPopMatrix",
@@ -3735,6 +3739,7 @@ static const char *const sdl_gl_builtin_names[] = {
     "GLSetSwapInterval",
     "GLSwapWindow",
     "GLTranslatef",
+    "GLPerspective",
     "GLVertex3f",
     "GLViewport",
 };
@@ -3786,6 +3791,7 @@ void registerAllBuiltins(void) {
     registerBuiltinFunction("OutTextXY", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("PlaySound", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("PollKey", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("IsKeyDown", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("PutPixel", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("QuitSoundSystem", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("QuitTextSystem", AST_PROCEDURE_DECL, NULL);

--- a/src/backend_ast/gl.h
+++ b/src/backend_ast/gl.h
@@ -23,6 +23,8 @@ Value vmBuiltinGlpopmatrix(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinGlpushmatrix(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinGlrotatef(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinGlscalef(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinGlfrustum(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinGlperspective(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinGltranslatef(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinGlvertex3f(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinGlviewport(struct VM_s* vm, int arg_count, Value* args);

--- a/src/backend_ast/sdl.h
+++ b/src/backend_ast/sdl.h
@@ -81,6 +81,7 @@ Value vmBuiltinRendercopyex(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinSetcolor(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinSetrendertarget(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinPollkey(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinIskeydown(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinWaitkeyevent(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinUpdatetexture(struct VM_s* vm, int arg_count, Value* args);
 


### PR DESCRIPTION
## Summary
- add GLFrustum and GLPerspective built-ins plus a convenient IsKeyDown helper for SDL input
- document the new runtime helpers and reference a new Rea SDL landscape sample
- create Examples/rea/sdl_landscape that renders a deterministic, seeded height field with WASD navigation

## Testing
- `cmake -S . -B build -DSDL=ON` *(fails: SDL2 development package missing in environment)*
- `cmake -S . -B build -DSDL=OFF`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68c9e14d5368832a8062c1700554e908