### PR TITLE
Support scientific notation in Rea numbers

### DIFF
--- a/Tests/rea/scientific_number.args
+++ b/Tests/rea/scientific_number.args
@@ -1,0 +1,1 @@
+--dump-ast-json

--- a/Tests/rea/scientific_number.out
+++ b/Tests/rea/scientific_number.out
@@ -1,0 +1,108 @@
+{
+
+  "node_type": "PROGRAM",
+  "var_type_annotated": "VOID",
+  "main_block": 
+  {
+
+    "node_type": "BLOCK",
+    "var_type_annotated": "VOID",
+    "is_global_scope": false,
+    "declarations": 
+    {
+
+      "node_type": "COMPOUND",
+      "var_type_annotated": "VOID",
+      "children": [
+        {
+
+          "node_type": "VAR_DECL",
+          "var_type_annotated": "REAL",
+          "left": 
+          {
+
+            "node_type": "NUMBER",
+            "token": {
+                "type": "REAL_CONST",
+                "value": "1e9"
+            },
+            "var_type_annotated": "REAL",
+            "i_val": 0
+          }
+,
+          "right": 
+          {
+
+            "node_type": "TYPE_IDENTIFIER",
+            "token": {
+                "type": "IDENTIFIER",
+                "value": "float"
+            },
+            "var_type_annotated": "REAL"
+          }
+,
+          "children": [
+            {
+
+              "node_type": "VARIABLE",
+              "token": {
+                  "type": "IDENTIFIER",
+                  "value": "big"
+              },
+              "var_type_annotated": "REAL"
+            }
+          ]
+        },
+        {
+
+          "node_type": "VAR_DECL",
+          "var_type_annotated": "REAL",
+          "left": 
+          {
+
+            "node_type": "NUMBER",
+            "token": {
+                "type": "REAL_CONST",
+                "value": "2.5e-3"
+            },
+            "var_type_annotated": "REAL",
+            "i_val": 0
+          }
+,
+          "right": 
+          {
+
+            "node_type": "TYPE_IDENTIFIER",
+            "token": {
+                "type": "IDENTIFIER",
+                "value": "float"
+            },
+            "var_type_annotated": "REAL"
+          }
+,
+          "children": [
+            {
+
+              "node_type": "VARIABLE",
+              "token": {
+                  "type": "IDENTIFIER",
+                  "value": "small"
+              },
+              "var_type_annotated": "REAL"
+            }
+          ]
+        }
+      ]
+    }
+,
+    "body": 
+    {
+
+      "node_type": "COMPOUND",
+      "var_type_annotated": "VOID"
+    }
+
+  }
+
+}
+

--- a/Tests/rea/scientific_number.rea
+++ b/Tests/rea/scientific_number.rea
@@ -1,0 +1,2 @@
+float big = 1e9;
+float small = 2.5e-3;

--- a/src/rea/lexer.c
+++ b/src/rea/lexer.c
@@ -259,6 +259,18 @@ ReaToken reaNextToken(ReaLexer *lexer) {
             advance(lexer);
             while (isDigit(peek(lexer))) advance(lexer);
         }
+        if (peek(lexer) == 'e' || peek(lexer) == 'E') {
+            size_t exponent_start = lexer->pos;
+            advance(lexer);
+            if (peek(lexer) == '+' || peek(lexer) == '-') {
+                advance(lexer);
+            }
+            if (isDigit(peek(lexer))) {
+                while (isDigit(peek(lexer))) advance(lexer);
+            } else {
+                lexer->pos = exponent_start;
+            }
+        }
         return makeToken(lexer, REA_TOKEN_NUMBER, start);
     }
 


### PR DESCRIPTION
## Summary
- allow the Rea lexer to treat exponent suffixes as part of numeric literals
- add a regression test that verifies scientific notation values compile to REAL constants

## Testing
- Tests/run_rea_tests.sh

------
https://chatgpt.com/codex/tasks/task_e_68c9ea23b148832a824cd5dc241b600a