### PR TITLE
Fix extended builtin registration for mandelbrotrow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -530,6 +530,7 @@ set(JSON2BC_SOURCES
     src/vm/vm.c
     src/Pascal/globals.c
 )
+list(APPEND JSON2BC_SOURCES ${PSCAL_EXT_BUILTIN_SOURCES})
 add_executable(pscaljson2bc ${JSON2BC_SOURCES})
 if(TARGET CURL::libcurl)
     target_link_libraries(pscaljson2bc PRIVATE CURL::libcurl m Threads::Threads)

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -496,10 +496,6 @@ void registerVmBuiltin(const char *name, VmBuiltinFn handler) {
     pthread_mutex_unlock(&builtin_registry_mutex);
 }
 
-/* Weak hook that external modules can override to register additional
- * built-ins.  The default implementation does nothing. */
-__attribute__((weak)) void registerExtendedBuiltins(void) {}
-
 // This function now comes AFTER the table and comparison function it uses.
 VmBuiltinFn getVmBuiltinHandler(const char *name) {
     if (!name) return NULL;


### PR DESCRIPTION
## Summary
- remove the weak fallback implementation of `registerExtendedBuiltins` so extended math builtins (including `mandelbrotrow`) are always registered
- add the extended builtin sources to the `pscaljson2bc` target so every frontend/tool sees the same registration logic

## Testing
- Tests/run_rea_tests.sh

------
https://chatgpt.com/codex/tasks/task_e_68ca03419a60832aa765899017825bf9