### PR TITLE
Fix global var adoption when collecting methods

### DIFF
--- a/src/rea/semantic.c
+++ b/src/rea/semantic.c
@@ -299,18 +299,23 @@ static void collectMethods(AST *node) {
                  */
                 AST *parent = node->parent;
                 for (int i = 0; i < parent->child_count; i++) {
-                    if (parent->children[i] == node && i > 0) {
-                        AST *prev = parent->children[i - 1];
-                        if (prev && prev->type == AST_VAR_DECL) {
-                            addChild(node, prev);
-                            for (int j = i - 1; j < parent->child_count - 1; j++) {
-                                parent->children[j] = parent->children[j + 1];
-                            }
-                            parent->child_count--;
-                            param = node->children[0];
+                    if (parent->children[i] != node) continue;
+                    for (int j = i - 1; j >= 0; j--) {
+                        AST *prev = parent->children[j];
+                        if (!prev || prev->type != AST_VAR_DECL) continue;
+                        AST *decl_var = (prev->child_count > 0) ? prev->children[0] : NULL;
+                        const char *decl_name = (decl_var && decl_var->token) ? decl_var->token->value : NULL;
+                        if (!decl_name || strcasecmp(decl_name, "myself") != 0) continue;
+
+                        addChild(node, prev);
+                        for (int k = j; k < parent->child_count - 1; k++) {
+                            parent->children[k] = parent->children[k + 1];
                         }
+                        parent->child_count--;
+                        param = node->children[0];
                         break;
                     }
+                    break;
                 }
             }
             if (param && param->type == AST_VAR_DECL) {


### PR DESCRIPTION
## Summary
- prevent the Rea semantic pass from treating arbitrary VAR_DECL siblings as implicit `myself` parameters when collecting methods
- ensure the guard only adopts preceding declarations whose variable name is `myself`, leaving unrelated globals at the top level

## Testing
- `build/bin/rea --no-cache Examples/rea/threads`


------
https://chatgpt.com/codex/tasks/task_e_68ca1be3ffb4832aaed3288e40797d8e