### PR TITLE
Handle data URLs in httpRequest

### DIFF
--- a/Tests/clike/HttpFetchDataURL.cl
+++ b/Tests/clike/HttpFetchDataURL.cl
@@ -1,0 +1,18 @@
+int main() {
+    int s = httpsession();
+    if (s < 0) {
+        printf("session error\n");
+        return 1;
+    }
+    mstream out;
+    out = mstreamcreate();
+    int code = httprequest(s, "GET", "data:text/plain,hello%20world", NULL, out);
+    if (code >= 0) {
+        printf("%s\n", mstreambuffer(out));
+    } else {
+        printf("http error\n");
+    }
+    mstreamfree(&out);
+    httpclose(s);
+    return 0;
+}

--- a/Tests/clike/HttpFetchDataURL.out
+++ b/Tests/clike/HttpFetchDataURL.out
@@ -1,0 +1,1 @@
+hello world


### PR DESCRIPTION
## Summary
- add helpers to decode data URLs for reuse across the HTTP APIs
- extend httpRequest, httpRequestToFile, and async jobs to serve data: scheme payloads without libcurl
- add a CLike regression test that fetches a text data URL

## Testing
- Tests/run_clike_tests.sh

------
https://chatgpt.com/codex/tasks/task_e_68ca2875ad88832aa8b6fadd50e9b41d