### PR TITLE
Fix SDL text initialization in CLike Mandelbrot examples

### DIFF
--- a/Examples/clike/builtins.h
+++ b/Examples/clike/builtins.h
@@ -85,7 +85,7 @@ int highvideo();
 int inc();
 int initgraph();
 int initsoundsystem();
-int inittextsystem();
+int inittextsystem(str fontPath, int fontSize);
 int insline();
 int inttostr();
 int invertcolors();

--- a/Examples/clike/sdl_mandelbrot
+++ b/Examples/clike/sdl_mandelbrot
@@ -35,6 +35,11 @@ int main() {
     int MandelBytesPerPixel;
     int textureID;
     int bufferBaseIdx;
+    int FontSize;
+    int TextReady;
+    str systemFontPath;
+    str repoFontPath1;
+    str repoFontPath2;
     byte pixelData[1024 * 768 * 4];
 
     WindowWidth = 1024;
@@ -45,10 +50,26 @@ int main() {
 
     ScreenUpdateInterval = 1;
     MandelBytesPerPixel = 4;
+    FontSize = 18;
+    TextReady = 0;
+    systemFontPath = "/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf";
+    repoFontPath1 = "fonts/Roboto/static/Roboto-Regular.ttf";
+    repoFontPath2 = "../../fonts/Roboto/static/Roboto-Regular.ttf";
 
     printf("Calculating Mandelbrot set. The window will update as rows are drawn...\n");
     initgraph(WindowWidth, WindowHeight, "Mandelbrot in CLike (No Acceleration)");
-    inittextsystem();
+    if (fileexists(systemFontPath)) {
+        inittextsystem(systemFontPath, FontSize);
+        TextReady = 1;
+    } else if (fileexists(repoFontPath1)) {
+        inittextsystem(repoFontPath1, FontSize);
+        TextReady = 1;
+    } else if (fileexists(repoFontPath2)) {
+        inittextsystem(repoFontPath2, FontSize);
+        TextReady = 1;
+    } else {
+        printf("Warning: Unable to locate Roboto font. Text rendering disabled.\n");
+    }
     textureID = createtexture(WindowWidth, WindowHeight);
     if (textureID < 0) {
         printf("Error: unable to create texture.\n");
@@ -104,7 +125,9 @@ int main() {
             updatetexture(textureID, pixelData);
             cleardevice();
             rendercopy(textureID);
-            outtextxy(8, 8, "Rendering...");
+            if (TextReady) {
+                outtextxy(8, 8, "Rendering...");
+            }
             updatescreen();
             graphloop(0);
         }
@@ -128,7 +151,9 @@ int main() {
         graphloop(16);
     }
     destroytexture(textureID);
-    quittextsystem();
+    if (TextReady) {
+        quittextsystem();
+    }
     closegraph();
     return 0;
 #else

--- a/Examples/clike/sdl_mandelbrot_interactive
+++ b/Examples/clike/sdl_mandelbrot_interactive
@@ -139,10 +139,30 @@ void computeRowsThread3() { computeRows(threadStart[3], threadEnd[3]); }
 int main() {
 #ifdef SDL_ENABLED
     int tid[ThreadCount], i, y, rowsPerThread, extra, startY, endY;
+    int textReady;
+    const int fontSize = 18;
+    str systemFontPath;
+    str repoFontPath1;
+    str repoFontPath2;
 
     printf("Calculating Mandelbrot set. The window will update as rows are drawn...\n");
     initgraph(Width, Height, "Mandelbrot in CLike (threaded)");
-    inittextsystem();
+    textReady = 0;
+    systemFontPath = "/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf";
+    repoFontPath1 = "fonts/Roboto/static/Roboto-Regular.ttf";
+    repoFontPath2 = "../../fonts/Roboto/static/Roboto-Regular.ttf";
+    if (fileexists(systemFontPath)) {
+        inittextsystem(systemFontPath, fontSize);
+        textReady = 1;
+    } else if (fileexists(repoFontPath1)) {
+        inittextsystem(repoFontPath1, fontSize);
+        textReady = 1;
+    } else if (fileexists(repoFontPath2)) {
+        inittextsystem(repoFontPath2, fontSize);
+        textReady = 1;
+    } else {
+        printf("Warning: Unable to locate Roboto font. Text rendering disabled.\n");
+    }
     textureID = createtexture(Width, Height);
     if (textureID < 0) { printf("Error: unable to create texture.\n"); halt(); }
     cleardevice(); updatescreen();
@@ -220,7 +240,9 @@ int main() {
                 updatetexture(textureID, pixelData);
                 cleardevice();
                 rendercopy(textureID);
-                outtextxy(8, 8, "Rendering...");
+                if (textReady) {
+                    outtextxy(8, 8, "Rendering...");
+                }
                 updatescreen();
                 redraw = 0;
             }
@@ -283,7 +305,9 @@ int main() {
         }
     }
     destroytexture(textureID);
-    quittextsystem();
+    if (textReady) {
+        quittextsystem();
+    }
     closegraph();
     return 0;
 #else

--- a/Examples/clike/sdl_mandelbrot_threaded
+++ b/Examples/clike/sdl_mandelbrot_threaded
@@ -94,10 +94,30 @@ void waitForQuit() {
 int main() {
 #ifdef SDL_ENABLED
     int i, startY, endY, rowsPerThread, extra, tid[5], y, quit;
+    int textReady;
+    const int fontSize = 18;
+    str systemFontPath;
+    str repoFontPath1;
+    str repoFontPath2;
 
     printf("Calculating Mandelbrot set with threads. The window will update as rows are drawn...\n");
     initgraph(WindowWidth, WindowHeight, "Threaded Mandelbrot (mandelbrotrow)");
-    inittextsystem();
+    textReady = 0;
+    systemFontPath = "/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf";
+    repoFontPath1 = "fonts/Roboto/static/Roboto-Regular.ttf";
+    repoFontPath2 = "../../fonts/Roboto/static/Roboto-Regular.ttf";
+    if (fileexists(systemFontPath)) {
+        inittextsystem(systemFontPath, fontSize);
+        textReady = 1;
+    } else if (fileexists(repoFontPath1)) {
+        inittextsystem(repoFontPath1, fontSize);
+        textReady = 1;
+    } else if (fileexists(repoFontPath2)) {
+        inittextsystem(repoFontPath2, fontSize);
+        textReady = 1;
+    } else {
+        printf("Warning: Unable to locate Roboto font. Text rendering disabled.\n");
+    }
     textureID = createtexture(WindowWidth, WindowHeight);
     if (textureID < 0) { printf("Error: unable to create texture.\n"); halt(); }
     cleardevice(); updatescreen();
@@ -137,7 +157,9 @@ int main() {
                 updatetexture(textureID, pixelData);
                 cleardevice();
                 rendercopy(textureID);
-                outtextxy(8, 8, "Rendering...");
+                if (textReady) {
+                    outtextxy(8, 8, "Rendering...");
+                }
                 updatescreen();
                 graphloop(0);
             }
@@ -155,7 +177,11 @@ int main() {
         graphloop(16);
 
     join tid[4];
-    destroytexture(textureID); quittextsystem(); closegraph();
+    destroytexture(textureID);
+    if (textReady) {
+        quittextsystem();
+    }
+    closegraph();
     return 0;
 #else
     printf("SDL support not enabled.\n");


### PR DESCRIPTION
## Summary
- ensure all CLike SDL Mandelbrot examples locate and initialize a font before drawing text
- guard status text rendering and shutdown paths when the text system is unavailable
- update the CLike builtins reference so inittextsystem documents its required parameters

## Testing
- not run (examples only)


------
https://chatgpt.com/codex/tasks/task_e_68ca4040ccd8832aa0741cfee540de2e