### PR TITLE
Fix SDL Mandelbrot example stability

### DIFF
--- a/Examples/clike/sdl_mandelbrot
+++ b/Examples/clike/sdl_mandelbrot
@@ -4,13 +4,19 @@
  * Press Q in the console to quit after rendering.
  */
 
+const int WindowWidth = 1024;
+const int WindowHeight = 768;
+const int MaxIterations = 128;
+const float MinRe = -2.0;
+const float MaxRe = 1.0;
+const int ScreenUpdateInterval = 1;
+const int MandelBytesPerPixel = 4;
+const int FontSize = 18;
+
+byte pixelData[WindowWidth * WindowHeight * MandelBytesPerPixel];
+
 int main() {
 #ifdef SDL_ENABLED
-    int WindowWidth;
-    int WindowHeight;
-    int MaxIterations;
-    float MinRe;
-    float MaxRe;
     float MinIm;
     float MaxIm;
     float ImRange;
@@ -31,28 +37,15 @@ int main() {
     int G;
     int B;
     int quit;
-    int ScreenUpdateInterval;
-    int MandelBytesPerPixel;
     int textureID;
     int bufferBaseIdx;
-    int FontSize;
     int TextReady;
     str systemFontPath;
     str repoFontPath1;
     str repoFontPath2;
-    byte pixelData[1024 * 768 * 4];
 
-    WindowWidth = 1024;
-    WindowHeight = 768;
-    MaxIterations = 128;
-    MinRe = -2.0;
-    MaxRe = 1.0;
-
-    ScreenUpdateInterval = 1;
-    MandelBytesPerPixel = 4;
-    FontSize = 18;
     TextReady = 0;
-    systemFontPath = "/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf";
+    systemFontPath = "/usr/local/pscal/fonts/Roboto/static/Roboto-Regular.ttf";
     repoFontPath1 = "fonts/Roboto/static/Roboto-Regular.ttf";
     repoFontPath2 = "../../fonts/Roboto/static/Roboto-Regular.ttf";
 

--- a/Examples/clike/sdl_mandelbrot_interactive
+++ b/Examples/clike/sdl_mandelbrot_interactive
@@ -148,7 +148,7 @@ int main() {
     printf("Calculating Mandelbrot set. The window will update as rows are drawn...\n");
     initgraph(Width, Height, "Mandelbrot in CLike (threaded)");
     textReady = 0;
-    systemFontPath = "/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf";
+    systemFontPath = "/usr/local/pscal/fonts/Roboto/static/Roboto-Regular.ttf";
     repoFontPath1 = "fonts/Roboto/static/Roboto-Regular.ttf";
     repoFontPath2 = "../../fonts/Roboto/static/Roboto-Regular.ttf";
     if (fileexists(systemFontPath)) {

--- a/Examples/clike/sdl_mandelbrot_threaded
+++ b/Examples/clike/sdl_mandelbrot_threaded
@@ -103,7 +103,7 @@ int main() {
     printf("Calculating Mandelbrot set with threads. The window will update as rows are drawn...\n");
     initgraph(WindowWidth, WindowHeight, "Threaded Mandelbrot (mandelbrotrow)");
     textReady = 0;
-    systemFontPath = "/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf";
+    systemFontPath = "/usr/local/pscal/fonts/Roboto/static/Roboto-Regular.ttf";
     repoFontPath1 = "fonts/Roboto/static/Roboto-Regular.ttf";
     repoFontPath2 = "../../fonts/Roboto/static/Roboto-Regular.ttf";
     if (fileexists(systemFontPath)) {


### PR DESCRIPTION
## Summary
- move the SDL Mandelbrot rendering constants and pixel buffer out of `main` so the example no longer allocates a multi-megabyte array on the stack
- normalize the Roboto font search path to `/usr/local/pscal/...` in all Mandelbrot variants so installed fonts are found on case-sensitive systems

## Testing
- build/bin/clike Examples/clike/sdl_mandelbrot *(fails: requires SDL display/XDG_RUNTIME_DIR)*
- build/bin/clike Examples/clike/sdl_mandelbrot_threaded *(fails: requires SDL display/XDG_RUNTIME_DIR)*
- build/bin/clike Examples/clike/sdl_mandelbrot_interactive *(fails: requires SDL display/XDG_RUNTIME_DIR)*

------
https://chatgpt.com/codex/tasks/task_e_68caa4b4dec8832a8ef8c3d827c8e8d3