### PR TITLE
Fix VM local frame sizing and improve font detection

### DIFF
--- a/Examples/clike/sdl_mandelbrot_interactive
+++ b/Examples/clike/sdl_mandelbrot_interactive
@@ -54,6 +54,14 @@ void setQuit(int v) {
     unlock(quitMutex);
 }
 
+int tryInitFont(str path, int fontSize) {
+    if (path == NULL) return 0;
+    if (strlen(path) == 0) return 0;
+    if (!fileexists(path)) return 0;
+    inittextsystem(path, fontSize);
+    return 1;
+}
+
 /*
  * Poll SDL briefly and detect a fresh left/right click that occurred inside
  * the window. Click coordinates are clamped to [0..Width-1]/[0..Height-1].
@@ -141,26 +149,22 @@ int main() {
     int tid[ThreadCount], i, y, rowsPerThread, extra, startY, endY;
     int textReady;
     const int fontSize = 18;
-    str systemFontPath;
-    str repoFontPath1;
-    str repoFontPath2;
+    str envFontPath;
 
     printf("Calculating Mandelbrot set. The window will update as rows are drawn...\n");
     initgraph(Width, Height, "Mandelbrot in CLike (threaded)");
     textReady = 0;
-    systemFontPath = "/usr/local/pscal/fonts/Roboto/static/Roboto-Regular.ttf";
-    repoFontPath1 = "fonts/Roboto/static/Roboto-Regular.ttf";
-    repoFontPath2 = "../../fonts/Roboto/static/Roboto-Regular.ttf";
-    if (fileexists(systemFontPath)) {
-        inittextsystem(systemFontPath, fontSize);
-        textReady = 1;
-    } else if (fileexists(repoFontPath1)) {
-        inittextsystem(repoFontPath1, fontSize);
-        textReady = 1;
-    } else if (fileexists(repoFontPath2)) {
-        inittextsystem(repoFontPath2, fontSize);
-        textReady = 1;
-    } else {
+    envFontPath = getenv("PSCAL_FONT_PATH");
+    if (!textReady) textReady = tryInitFont(envFontPath, fontSize);
+    if (!textReady) textReady = tryInitFont("/usr/local/pscal/fonts/Roboto/static/Roboto-Regular.ttf", fontSize);
+    if (!textReady) textReady = tryInitFont("/usr/local/share/pscal/fonts/Roboto/static/Roboto-Regular.ttf", fontSize);
+    if (!textReady) textReady = tryInitFont("/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf", fontSize);
+    if (!textReady) textReady = tryInitFont("/usr/local/share/Pscal/fonts/Roboto/static/Roboto-Regular.ttf", fontSize);
+    if (!textReady) textReady = tryInitFont("/Library/Pscal/fonts/Roboto/static/Roboto-Regular.ttf", fontSize);
+    if (!textReady) textReady = tryInitFont("fonts/Roboto/static/Roboto-Regular.ttf", fontSize);
+    if (!textReady) textReady = tryInitFont("../fonts/Roboto/static/Roboto-Regular.ttf", fontSize);
+    if (!textReady) textReady = tryInitFont("../../fonts/Roboto/static/Roboto-Regular.ttf", fontSize);
+    if (!textReady) {
         printf("Warning: Unable to locate Roboto font. Text rendering disabled.\n");
     }
     textureID = createtexture(Width, Height);

--- a/src/vm/vm.h
+++ b/src/vm/vm.h
@@ -53,6 +53,7 @@ typedef struct {
     Symbol* function_symbol;    // Pointer to the Symbol of the function being called (for arity/locals_count)
                                 // Note: Storing Symbol* is one way; alternatively, CALL could carry locals_count,
                                 // or RETURN could be generic if stack is always reset to frame->slots.
+    uint16_t slotCount;         // Total slots (arguments + locals) reserved for this frame
     uint8_t locals_count;       // Number of local variables (excluding params)
     uint8_t upvalue_count;
     Value** upvalues;


### PR DESCRIPTION
## Summary
- track the total argument/local window for each call frame so local slot lookups no longer depend on the live stack height
- update VM call setup paths and local access opcodes to use the recorded window size and reset it when frames unwind
- expand the SDL Mandelbrot font discovery to honor `PSCAL_FONT_PATH` and search additional install prefixes instead of rechecking the same location

## Testing
- not run (SDL interactive sample requires a GUI environment)


------
https://chatgpt.com/codex/tasks/task_e_68cabacf4918832a83aa9f2e8decc4a4