### PR TITLE
Fix nil check in SDL Mandelbrot example

### DIFF
--- a/Examples/clike/sdl_mandelbrot_interactive
+++ b/Examples/clike/sdl_mandelbrot_interactive
@@ -55,7 +55,12 @@ void setQuit(int v) {
 }
 
 int tryInitFont(str path, int fontSize) {
-    if (path == NULL) return 0;
+    /*
+     * getenv() in the VM returns an empty string when the variable is not
+     * present.  Comparing the string directly against NULL triggers a runtime
+     * type error because strings cannot be compared with NIL in CLike.  Treat
+     * an empty string as "not available" instead.
+     */
     if (strlen(path) == 0) return 0;
     if (!fileexists(path)) return 0;
     inittextsystem(path, fontSize);


### PR DESCRIPTION
## Summary
- avoid comparing the font path string to NULL in `tryInitFont`, preventing a runtime type error
- document why an empty string check is sufficient for detecting missing font paths

## Testing
- not run (clike interpreter is not available in the container environment)

------
https://chatgpt.com/codex/tasks/task_e_68caeea95840832a9392453bdefe9b86