### PR TITLE
Handle socket errors in WebSocket echo demo

### DIFF
--- a/Examples/clike/WebSocketEcho
+++ b/Examples/clike/WebSocketEcho
@@ -2,23 +2,62 @@
 
 int main() {
   int s = socketcreate(0);
-  socketconnect(s, "echo.websocket.events", 80);
-  socketsend(s,
-    "GET / HTTP/1.1\r\n"
-    "Host: echo.websocket.events\r\n"
-    "Upgrade: websocket\r\n"
-    "Connection: Upgrade\r\n"
-    "Sec-WebSocket-Version: 13\r\n"
-    "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
-    "\r\n");
+  if (s < 0) {
+    printf("socketcreate failed: %d\n", socketlasterror());
+    return 1;
+  }
+
+  if (socketconnect(s, "echo.websocket.events", 80) != 0) {
+    printf("socketconnect failed: %d\n", socketlasterror());
+    socketclose(s);
+    return 1;
+  }
+
+  if (socketsend(s,
+        "GET / HTTP/1.1\r\n"
+        "Host: echo.websocket.events\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        "Sec-WebSocket-Version: 13\r\n"
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+        "\r\n") < 0) {
+    printf("failed to send handshake: %d\n", socketlasterror());
+    socketclose(s);
+    return 1;
+  }
+
   mstream resp = socketreceive(s, 1024);
-  printf("handshake:\n%s\n", mstreambuffer(resp));
+  if (resp == NULL) {
+    printf("handshake receive failed: %d\n", socketlasterror());
+    socketclose(s);
+    return 1;
+  }
+
+  str handshake = mstreambuffer(resp);
+  printf("handshake:\n%s\n", handshake);
   mstreamfree(&resp);
+
   // send masked text frame "hi"
-  socketsend(s, "\x81\x82\x12\x34\x56\x78\x7a\x5d");
+  if (socketsend(s, "\x81\x82\x12\x34\x56\x78\x7a\x5d") < 0) {
+    printf("failed to send WebSocket frame: %d\n", socketlasterror());
+    socketclose(s);
+    return 1;
+  }
+
   mstream msg = socketreceive(s, 1024);
+  if (msg == NULL) {
+    printf("echo receive failed: %d\n", socketlasterror());
+    socketclose(s);
+    return 1;
+  }
+
   str buf = mstreambuffer(msg);
-  printf("echo: %c%c\n", buf[3], buf[4]);
+  int msglen = strlen(buf);
+  if (msglen >= 4) {
+    printf("echo: %c%c\n", buf[3], buf[4]);
+  } else {
+    printf("unexpected echo payload (length=%d)\n", msglen);
+  }
   mstreamfree(&msg);
   socketclose(s);
   return 0;


### PR DESCRIPTION
## Summary
- add error handling for socket creation, connection, send, and receive calls in the WebSocket echo example
- avoid dereferencing null memory streams by checking results before using them and reporting failures
- validate the echoed frame length before indexing to prevent runtime crashes

## Testing
- not run (networked example requires external host)


------
https://chatgpt.com/codex/tasks/task_e_68cb7964405c832abe20f4f378e27b61