### PR TITLE
Add IPv6 support to socket API and WebSocket demo

### DIFF
--- a/Docs/clike_tutorial.md
+++ b/Docs/clike_tutorial.md
@@ -176,7 +176,8 @@ int main() {
 
 The VM also exposes thin wrappers over BSD sockets:
 
-- `socketcreate(type)` – create TCP (`0`) or UDP (`1`) sockets.
+- `socketcreate(type[, family])` – create TCP (`0`) or UDP (`1`) sockets.
+  Pass `6` (or an `AF_INET6` constant) for IPv6 sockets; the default is IPv4.
 - `socketconnect(s, host, port)` – connect to a remote host/port.
 - `socketbind(s, port)`, `socketlisten(s, backlog)`, `socketaccept(s)` – server helpers.
 - `socketsend(s, data)` and `socketreceive(s, maxlen)` – send or receive strings or memory streams.

--- a/Examples/clike/WebSocketEcho
+++ b/Examples/clike/WebSocketEcho
@@ -1,16 +1,35 @@
 #!/usr/bin/env clike
 
 int main() {
+  const char *host = "echo.websocket.events";
+  int port = 80;
+
   int s = socketcreate(0);
   if (s < 0) {
     printf("socketcreate failed: %d\n", socketlasterror());
     return 1;
   }
 
-  if (socketconnect(s, "echo.websocket.events", 80) != 0) {
-    printf("socketconnect failed: %d\n", socketlasterror());
-    socketclose(s);
-    return 1;
+  if (socketconnect(s, host, port) != 0) {
+    int err = socketlasterror();
+    if (err == 5) {
+      printf("socketconnect failed (IPv4): %d, retrying with IPv6...\n", err);
+      socketclose(s);
+      s = socketcreate(0, 6);
+      if (s < 0) {
+        printf("socketcreate IPv6 failed: %d\n", socketlasterror());
+        return 1;
+      }
+      if (socketconnect(s, host, port) != 0) {
+        printf("socketconnect (IPv6) failed: %d\n", socketlasterror());
+        socketclose(s);
+        return 1;
+      }
+    } else {
+      printf("socketconnect failed: %d\n", err);
+      socketclose(s);
+      return 1;
+    }
   }
 
   if (socketsend(s,


### PR DESCRIPTION
## Summary
- track socket address families so the networking builtins can create/bind/connect using IPv6 when requested
- let the WebSocket echo example retry with an IPv6 socket if IPv4 resolution fails and document the optional family argument
- update the CLike networking docs to describe the IPv6-aware socketCreate signature

## Testing
- cmake --build build
- ctest


------
https://chatgpt.com/codex/tasks/task_e_68cb8fa03740832aada546b64b75c845