### PR TITLE
Allow initializing char pointers from string literals

### DIFF
--- a/src/clike/codegen.c
+++ b/src/clike/codegen.c
@@ -9,6 +9,7 @@
 #include "symbol/symbol.h"
 #include "Pascal/globals.h"
 #include "compiler/compiler.h"
+#include "vm/string_sentinels.h"
 #include <string.h>
 #include <strings.h>
 #include <stdlib.h>
@@ -19,6 +20,7 @@ typedef struct {
     char *name;
     int name_idx;   // constant pool index for the variable name
     VarType type;
+    VarType elemType;
 } GlobalVar;
 
 static GlobalVar globalVars[256];
@@ -143,23 +145,31 @@ static int addLocal(FuncContext* ctx, const char* name, VarType type, int isArra
     return ctx->localCount - 1;
 }
 
-static void registerGlobal(const char* name, VarType type, int name_idx) {
+static GlobalVar* findGlobalEntry(const char* name) {
+    for (int i = 0; i < globalVarCount; ++i) {
+        if (strcmp(globalVars[i].name, name) == 0) {
+            return &globalVars[i];
+        }
+    }
+    return NULL;
+}
+
+static void registerGlobal(const char* name, VarType type, VarType elemType, int name_idx) {
     if (globalVarCount >= (int)(sizeof(globalVars)/sizeof(globalVars[0]))) {
         fprintf(stderr, "CLike codegen error: too many globals (limit %zu)\n",
                 sizeof(globalVars)/sizeof(globalVars[0]));
         return;
     }
-    globalVars[globalVarCount].name = strdup(name);
-    globalVars[globalVarCount].type = type;
-    globalVars[globalVarCount].name_idx = name_idx;
-    globalVarCount++;
+    GlobalVar* entry = &globalVars[globalVarCount++];
+    entry->name = strdup(name);
+    entry->type = type;
+    entry->elemType = elemType;
+    entry->name_idx = name_idx;
 }
 
 static int resolveGlobal(const char* name) {
-    for (int i = 0; i < globalVarCount; i++) {
-        if (strcmp(globalVars[i].name, name) == 0) return globalVars[i].name_idx;
-    }
-    return -1;
+    GlobalVar* entry = findGlobalEntry(name);
+    return entry ? entry->name_idx : -1;
 }
 
 // Return the constant-pool index of the global's name string. If the global
@@ -170,6 +180,76 @@ static int getGlobalNameConstIndex(BytecodeChunk* chunk, const char* name) {
     int gidx = resolveGlobal(name);
     if (gidx >= 0) return gidx; // already present in globals registry
     return addStringConstant(chunk, name);
+}
+
+static int resolveLocal(FuncContext* ctx, const char* name); // forward declaration for helpers
+
+static int isCharPointerLocal(FuncContext* ctx, int idx) {
+    if (!ctx) return 0;
+    if (idx < 0 || idx >= ctx->localCount) return 0;
+    LocalVar* local = &ctx->locals[idx];
+    return local->type == TYPE_POINTER && local->elemType == TYPE_CHAR;
+}
+
+static int identifierIsCharPointer(ASTNodeClike* ident, FuncContext* ctx) {
+    if (!ident || ident->type != TCAST_IDENTIFIER) return 0;
+    char* name = tokenToCString(ident->token);
+    int isCharPtr = 0;
+    if (ctx) {
+        int idx = resolveLocal(ctx, name);
+        if (idx >= 0) {
+            isCharPtr = isCharPointerLocal(ctx, idx);
+        } else {
+            GlobalVar* entry = findGlobalEntry(name);
+            if (entry && entry->type == TYPE_POINTER && entry->elemType == TYPE_CHAR) {
+                isCharPtr = 1;
+            }
+        }
+    } else {
+        GlobalVar* entry = findGlobalEntry(name);
+        if (entry && entry->type == TYPE_POINTER && entry->elemType == TYPE_CHAR) {
+            isCharPtr = 1;
+        }
+    }
+    free(name);
+    return isCharPtr;
+}
+
+static int shouldEmitStringAsCharPointer(ASTNodeClike* node, FuncContext* ctx) {
+    if (!node || node->type != TCAST_STRING) return 0;
+    ASTNodeClike* parent = node->parent;
+    if (!parent) return 0;
+
+    if (parent->type == TCAST_VAR_DECL && parent->left == node) {
+        return parent->var_type == TYPE_POINTER && parent->element_type == TYPE_CHAR;
+    }
+
+    if (parent->type == TCAST_ASSIGN && parent->right == node) {
+        ASTNodeClike* lhs = parent->left;
+        if (!lhs) return 0;
+        if (lhs->type == TCAST_IDENTIFIER) {
+            return identifierIsCharPointer(lhs, ctx);
+        }
+        if (lhs->var_type == TYPE_POINTER && lhs->element_type == TYPE_CHAR) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+static void emitCharPointerConstant(ASTNodeClike* node, BytecodeChunk* chunk) {
+    if (!node || !chunk) return;
+    char* raw = tokenStringToCString(node->token);
+    Value strVal = makeString(raw);
+    free(raw);
+    int strIdx = addConstantToChunk(chunk, &strVal);
+    freeValue(&strVal);
+    Value ptrVal = makePointer(chunk->constants[strIdx].s_val, STRING_CHAR_PTR_SENTINEL);
+    int ptrIdx = addConstantToChunk(chunk, &ptrVal);
+    freeValue(&ptrVal);
+    writeBytecodeChunk(chunk, CONSTANT, node->token.line);
+    writeBytecodeChunk(chunk, (uint8_t)ptrIdx, node->token.line);
 }
 
 static int resolveLocal(FuncContext* ctx, const char* name) {
@@ -630,7 +710,7 @@ static void compileGlobalVar(ASTNodeClike *node, BytecodeChunk *chunk) {
     if (!node) return;
     char* name = tokenToCString(node->token);
     int name_idx = addStringConstant(chunk, name);
-    registerGlobal(name, node->var_type, name_idx);
+    registerGlobal(name, node->var_type, node->element_type, name_idx);
     if (name_idx < 256) {
         writeBytecodeChunk(chunk, DEFINE_GLOBAL, node->token.line);
         writeBytecodeChunk(chunk, (uint8_t)name_idx, node->token.line);
@@ -711,13 +791,17 @@ static void compileExpression(ASTNodeClike *node, BytecodeChunk *chunk, FuncCont
             break;
         }
         case TCAST_STRING: {
-            char* s = tokenStringToCString(node->token);
-            Value v = makeString(s);
-            free(s);
-            int idx = addConstantToChunk(chunk, &v);
-            freeValue(&v);
-            writeBytecodeChunk(chunk, CONSTANT, node->token.line);
-            writeBytecodeChunk(chunk, (uint8_t)idx, node->token.line);
+            if (shouldEmitStringAsCharPointer(node, ctx)) {
+                emitCharPointerConstant(node, chunk);
+            } else {
+                char* s = tokenStringToCString(node->token);
+                Value v = makeString(s);
+                free(s);
+                int idx = addConstantToChunk(chunk, &v);
+                freeValue(&v);
+                writeBytecodeChunk(chunk, CONSTANT, node->token.line);
+                writeBytecodeChunk(chunk, (uint8_t)idx, node->token.line);
+            }
             break;
         }
         case TCAST_BINOP: {
@@ -1307,7 +1391,7 @@ static void compileFunction(ASTNodeClike *func, BytecodeChunk *chunk) {
         for (int i = 0; i < func->left->child_count; i++) {
             ASTNodeClike* p = func->left->children[i];
             char* name = tokenToCString(p->token);
-            addLocal(&ctx, name, p->var_type, 0, 0, NULL, TYPE_UNKNOWN);
+            addLocal(&ctx, name, p->var_type, 0, 0, NULL, p->element_type);
             free(name);
             ctx.paramCount++;
         }

--- a/src/vm/string_sentinels.h
+++ b/src/vm/string_sentinels.h
@@ -1,0 +1,13 @@
+#ifndef VM_STRING_SENTINELS_H
+#define VM_STRING_SENTINELS_H
+
+#include "ast/ast.h"
+
+// Special sentinel values stored in Value.base_type_node to distinguish
+// pointers that reference characters within a string buffer (as opposed to
+// general pointers to Value instances) or the synthetic element 0 used to
+// expose a string's length via indexing.
+#define STRING_CHAR_PTR_SENTINEL   ((AST*)0xDEADBEEF)
+#define STRING_LENGTH_SENTINEL     ((AST*)0xFEEDBEEF)
+
+#endif // VM_STRING_SENTINELS_H

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -19,16 +19,12 @@
 #include "backend_ast/audio.h"
 #include "Pascal/parser.h"
 #include "ast/ast.h"
+#include "vm/string_sentinels.h"
 #include <termios.h>
 #include <unistd.h>
 #include <sys/ioctl.h>
 #include "backend_ast/builtin.h"
 
-
-// Special sentinel values used in pointer.base_type_node to signal
-// non-standard dereference behavior in GET_INDIRECT.
-#define STRING_CHAR_PTR_SENTINEL   ((AST*)0xDEADBEEF)
-#define STRING_LENGTH_SENTINEL     ((AST*)0xFEEDBEEF)
 
 // --- VM Helper Functions ---
 static void resetStack(VM* vm) {


### PR DESCRIPTION
## Summary
- teach the CLike semantic checker to treat char-pointer declarations as compatible with string literal initializers
- allow assignments to previously declared char pointers to accept string values when the underlying declaration is a char pointer

## Testing
- cmake -S . -B build
- cmake --build build --target clike
- build/bin/clike --dump-bytecode-only Examples/clike/WebSocketEcho


------
https://chatgpt.com/codex/tasks/task_e_68cb98e87818832a8a15a80140ea82b3