### PR TITLE
Allow comparing memory streams to nil

### DIFF
--- a/Tests/clike/MStreamNilComparison.cl
+++ b/Tests/clike/MStreamNilComparison.cl
@@ -1,0 +1,16 @@
+int main() {
+  mstream ms = mstreamcreate();
+  if (ms == NULL) {
+    printf("create failed\n");
+    return 1;
+  }
+  printf("allocated\n");
+  if (ms != NULL) {
+    printf("not nil\n");
+  }
+  mstreamfree(&ms);
+  if (ms == NULL) {
+    printf("freed\n");
+  }
+  return 0;
+}

--- a/Tests/clike/MStreamNilComparison.out
+++ b/Tests/clike/MStreamNilComparison.out
@@ -1,0 +1,3 @@
+allocated
+not nil
+freed


### PR DESCRIPTION
## Summary
- allow the VM comparison logic to treat memory streams as pointer-like values so they can be compared with nil
- add a regression test covering equality and inequality checks against NULL for freed memory streams

## Testing
- Tests/run_clike_tests.sh

------
https://chatgpt.com/codex/tasks/task_e_68cc06d1d604832abb2e9cfbf5b9220e