### PR TITLE
Restore terminal state after DiceGame

### DIFF
--- a/Examples/Pascal/DiceGame
+++ b/Examples/Pascal/DiceGame
@@ -38,31 +38,37 @@ var
   scoreStr: string[4];
   k: integer;
   hOffset, vOffset: integer; // Offsets for centering the game
+  originalForeground, originalBackground: byte;
+  originalBlink: boolean;
 
 // --- Custom Screen Clearing Procedure ---
 // This is a more reliable way to clear the screen with a specific background color.
 procedure ClearScreenWithColor(bgColor: byte);
 var
-  y, x: integer;
-  blankLine: string;
+  currentAttr: byte;
+  currentForeground: byte;
+  hadBlink: boolean;
 begin
-//  TextBackground(bgColor);
-//  blankLine := '';
-  // Create a string of spaces that matches the screen width
-//  for x := 1 to ScreenCols do
-//  begin
-//    blankLine := blankLine + ' ';
-//  end;
+  currentAttr := TextAttr;
+  currentForeground := currentAttr and $0F;
+  hadBlink := (currentAttr and $80) <> 0;
 
-  // Print the blank line on every row
-//  for y := 1 to ScreenRows do
-//  begin
-//    GotoXY(1, y);
-//    Write(blankLine);
-//  end;
-//  GotoXY(1, 1); // Move cursor to top-left after clearing
+  TextBackground(bgColor);
+  TextColor(currentForeground);
+  if hadBlink then
+    TextAttr := TextAttr or $80
+  else
+    TextAttr := TextAttr and $7F;
+
   ClrScr;
-  writeln('\e]11;#000000\a');
+
+  TextColor(currentForeground);
+  TextBackground(bgColor);
+  if hadBlink then
+    TextAttr := TextAttr or $80
+  else
+    TextAttr := TextAttr and $7F;
+  GotoXY(1, 1); // Move cursor to top-left after clearing
 end;
 
 // --- CRT Helper Procedures (Now with Centering) ---
@@ -530,6 +536,10 @@ begin
   if hOffset < 0 then hOffset := 0;
   if vOffset < 0 then vOffset := 0;
 
+  originalForeground := TextAttr and $0F;
+  originalBackground := (TextAttr and $70) shr 4;
+  originalBlink := (TextAttr and $80) <> 0;
+
   repeat
     ClearScreenWithColor(Black);
     HideCursor;
@@ -613,6 +623,13 @@ begin
     until userChoice in ['Y', 'N'];
   until userChoice = 'N';
 
+  TextColor(originalForeground);
+  TextBackground(originalBackground);
+  if originalBlink then
+    TextAttr := TextAttr or $80
+  else
+    TextAttr := TextAttr and $7F;
+  ClrScr;
   GotoXY(1, ScreenRows);
   ShowCursor;
 end.


### PR DESCRIPTION
## Summary
- replace the DiceGame screen clearing helper so it uses CRT color attributes rather than writing terminal escape sequences
- capture the terminal's original color attributes when the game starts and restore them when the program exits
- clear the screen with the restored colors before handing control back to the shell to leave the terminal in a clean state

## Testing
- Not run (pascal interpreter is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68cc27a2889c832a9baaf3111ef85103