### PR TITLE
Expose and sync TextAttr CRT state

### DIFF
--- a/lib/pascal/crt.pl
+++ b/lib/pascal/crt.pl
@@ -24,6 +24,9 @@ const
   White        = 15;
   Blink        = 128;
 
+var
+  TextAttr: byte;
+
 type
   TOSType = (osUnknown, osLinux, osMac);
 

--- a/src/Pascal/main.c
+++ b/src/Pascal/main.c
@@ -56,6 +56,9 @@ void initSymbolSystem(void) {
     }
     DEBUG_PRINT("[DEBUG MAIN] Created global symbol table %p.\n", (void*)globalSymbols);
 
+    insertGlobalSymbol("TextAttr", TYPE_BYTE, NULL);
+    syncTextAttrSymbol();
+
     constGlobalSymbols = createHashTable();
     if (!constGlobalSymbols) {
         fprintf(stderr, "FATAL: Failed to create constant symbol hash table.\n");

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -1552,6 +1552,7 @@ Value vmBuiltinTextcolor(VM* vm, int arg_count, Value* args) {
     gCurrentTextColor = (int)(colorCode % 16);
     gCurrentTextBold = (colorCode >= 8 && colorCode <= 15);
     gCurrentColorIsExt = false;
+    syncTextAttrSymbol();
     return makeVoid();
 }
 
@@ -1562,6 +1563,7 @@ Value vmBuiltinTextbackground(VM* vm, int arg_count, Value* args) {
     }
     gCurrentTextBackground = (int)(AS_INTEGER(args[0]) % 8);
     gCurrentBgIsExt = false;
+    syncTextAttrSymbol();
     return makeVoid();
 }
 Value vmBuiltinTextcolore(VM* vm, int arg_count, Value* args) {
@@ -1572,6 +1574,7 @@ Value vmBuiltinTextcolore(VM* vm, int arg_count, Value* args) {
     gCurrentTextColor = (int)AS_INTEGER(args[0]);
     gCurrentTextBold = false;
     gCurrentColorIsExt = true;
+    syncTextAttrSymbol();
     return makeVoid();
 }
 
@@ -1582,6 +1585,7 @@ Value vmBuiltinTextbackgrounde(VM* vm, int arg_count, Value* args) {
     }
     gCurrentTextBackground = (int)AS_INTEGER(args[0]);
     gCurrentBgIsExt = true;
+    syncTextAttrSymbol();
     return makeVoid();
 }
 
@@ -1592,6 +1596,7 @@ Value vmBuiltinBoldtext(VM* vm, int arg_count, Value* args) {
         return makeVoid();
     }
     gCurrentTextBold = true;
+    syncTextAttrSymbol();
     return makeVoid();
 }
 
@@ -1612,6 +1617,7 @@ Value vmBuiltinBlinktext(VM* vm, int arg_count, Value* args) {
         return makeVoid();
     }
     gCurrentTextBlink = true;
+    syncTextAttrSymbol();
     return makeVoid();
 }
 
@@ -1622,6 +1628,8 @@ Value vmBuiltinLowvideo(VM* vm, int arg_count, Value* args) {
         return makeVoid();
     }
     gCurrentTextBold = false;
+    gCurrentTextColor &= 0x07;
+    syncTextAttrSymbol();
     return makeVoid();
 }
 
@@ -1640,6 +1648,7 @@ Value vmBuiltinNormvideo(VM* vm, int arg_count, Value* args) {
     gCurrentTextBlink = false;
     printf("\x1B[0m");
     fflush(stdout);
+    syncTextAttrSymbol();
     return makeVoid();
 }
 
@@ -1753,6 +1762,7 @@ Value vmBuiltinNormalcolors(VM* vm, int arg_count, Value* args) {
     gCurrentTextBlink = false;
     printf("\x1B[0m");
     fflush(stdout);
+    syncTextAttrSymbol();
     return makeVoid();
 }
 

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -241,6 +241,9 @@ int map16FgColorToAnsi(int pscalColorCode, bool isBold);
 int map16BgColorToAnsi(int pscalColorCode);
 bool applyCurrentTextAttributes(FILE* stream);
 void resetTextAttributes(FILE* stream);
+uint8_t computeCurrentTextAttr(void);
+void syncTextAttrSymbol(void);
+void setCurrentTextAttrFromByte(uint8_t attr);
 
 // Arrays
 Value makeArrayND(int dimensions, int *lower_bounds, int *upper_bounds, VarType element_type, AST *type_def);

--- a/src/symbol/symbol.c
+++ b/src/symbol/symbol.c
@@ -826,22 +826,22 @@ void updateSymbol(const char *name, Value val) {
 
     // --- Perform Assignment ---
     // Use a switch on the TARGET symbol's type to handle assignments correctly.
-      switch (sym->type) {
-          case TYPE_INTEGER:
-              if (isIntlikeType(val.type)) {
-                  SET_INT_VALUE(sym->value, asI64(val));
-              } else if (isRealType(val.type)) {
-                  SET_INT_VALUE(sym->value, (long long)AS_REAL(val)); // Implicit Truncation
-              }
-              break;
+    switch (sym->type) {
+        case TYPE_INTEGER:
+            if (isIntlikeType(val.type)) {
+                SET_INT_VALUE(sym->value, asI64(val));
+            } else if (isRealType(val.type)) {
+                SET_INT_VALUE(sym->value, (long long)AS_REAL(val)); // Implicit Truncation
+            }
+            break;
 
-          case TYPE_INT64:
-              if (isIntlikeType(val.type)) {
-                  SET_INT_VALUE(sym->value, asI64(val));
-              } else if (isRealType(val.type)) {
-                  SET_INT_VALUE(sym->value, (long long)AS_REAL(val));
-              }
-              break;
+        case TYPE_INT64:
+            if (isIntlikeType(val.type)) {
+                SET_INT_VALUE(sym->value, asI64(val));
+            } else if (isRealType(val.type)) {
+                SET_INT_VALUE(sym->value, (long long)AS_REAL(val));
+            }
+            break;
 
         case TYPE_REAL:
             if (isRealType(val.type) || isIntlikeType(val.type)) {
@@ -976,6 +976,11 @@ void updateSymbol(const char *name, Value val) {
                     varTypeToString(sym->type), name);
             EXIT_FAILURE_HANDLER();
             break;
+    }
+
+    if (sym->name && strcmp(sym->name, "textattr") == 0) {
+        uint8_t attr_byte = (uint8_t)(sym->value->i_val & 0xFF);
+        setCurrentTextAttrFromByte(attr_byte);
     }
 
     // Free the incoming temporary Value's contents now that its data has been used.


### PR DESCRIPTION
## Summary
- expose the CRT `TextAttr` variable to Pascal code and register it during interpreter startup
- add helpers that convert between CRT state and TextAttr, calling them from CRT builtins
- keep CRT colors in sync when Pascal code assigns directly to `TextAttr`

## Testing
- cmake --build build
- PASCAL_LIB_DIR=$(pwd)/lib/pascal ./build/bin/pascal --dump-bytecode-only Examples/Pascal/DiceGame

------
https://chatgpt.com/codex/tasks/task_e_68cc36c498f8832a9514699937803320