### PR TITLE
Ensure CRT default colors apply immediately

### DIFF
--- a/lib/pascal/crt.pl
+++ b/lib/pascal/crt.pl
@@ -24,6 +24,9 @@ const
   White        = 15;
   Blink        = 128;
 
+var
+  TextAttr: byte;
+
 type
   TOSType = (osUnknown, osLinux, osMac);
 

--- a/src/Pascal/globals.c
+++ b/src/Pascal/globals.c
@@ -42,6 +42,7 @@ bool gCurrentColorIsExt    = false;   // Flag for extended 256-color foreground 
 bool gCurrentBgIsExt       = false;   // Flag for extended 256-color background mode.
 bool gCurrentTextUnderline = false;   // Default underline state.
 bool gCurrentTextBlink     = false;   // Default blink state.
+bool gConsoleAttrDirty     = true;    // Force the initial console colors to be applied.
 int gWindowLeft            = 1;
 int gWindowTop             = 1;
 int gWindowRight           = 80;

--- a/src/Pascal/globals.h
+++ b/src/Pascal/globals.h
@@ -54,6 +54,7 @@ extern bool gCurrentColorIsExt;
 extern bool gCurrentBgIsExt;
 extern bool gCurrentTextUnderline;
 extern bool gCurrentTextBlink;
+extern bool gConsoleAttrDirty;
 extern int gWindowLeft;
 extern int gWindowTop;
 extern int gWindowRight;

--- a/src/Pascal/main.c
+++ b/src/Pascal/main.c
@@ -56,6 +56,9 @@ void initSymbolSystem(void) {
     }
     DEBUG_PRINT("[DEBUG MAIN] Created global symbol table %p.\n", (void*)globalSymbols);
 
+    insertGlobalSymbol("TextAttr", TYPE_BYTE, NULL);
+    syncTextAttrSymbol();
+
     constGlobalSymbols = createHashTable();
     if (!constGlobalSymbols) {
         fprintf(stderr, "FATAL: Failed to create constant symbol hash table.\n");

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -1552,6 +1552,8 @@ Value vmBuiltinTextcolor(VM* vm, int arg_count, Value* args) {
     gCurrentTextColor = (int)(colorCode % 16);
     gCurrentTextBold = (colorCode >= 8 && colorCode <= 15);
     gCurrentColorIsExt = false;
+    markTextAttrDirty();
+    syncTextAttrSymbol();
     return makeVoid();
 }
 
@@ -1562,6 +1564,8 @@ Value vmBuiltinTextbackground(VM* vm, int arg_count, Value* args) {
     }
     gCurrentTextBackground = (int)(AS_INTEGER(args[0]) % 8);
     gCurrentBgIsExt = false;
+    markTextAttrDirty();
+    syncTextAttrSymbol();
     return makeVoid();
 }
 Value vmBuiltinTextcolore(VM* vm, int arg_count, Value* args) {
@@ -1572,6 +1576,8 @@ Value vmBuiltinTextcolore(VM* vm, int arg_count, Value* args) {
     gCurrentTextColor = (int)AS_INTEGER(args[0]);
     gCurrentTextBold = false;
     gCurrentColorIsExt = true;
+    markTextAttrDirty();
+    syncTextAttrSymbol();
     return makeVoid();
 }
 
@@ -1582,6 +1588,8 @@ Value vmBuiltinTextbackgrounde(VM* vm, int arg_count, Value* args) {
     }
     gCurrentTextBackground = (int)AS_INTEGER(args[0]);
     gCurrentBgIsExt = true;
+    markTextAttrDirty();
+    syncTextAttrSymbol();
     return makeVoid();
 }
 
@@ -1592,6 +1600,8 @@ Value vmBuiltinBoldtext(VM* vm, int arg_count, Value* args) {
         return makeVoid();
     }
     gCurrentTextBold = true;
+    markTextAttrDirty();
+    syncTextAttrSymbol();
     return makeVoid();
 }
 
@@ -1602,6 +1612,7 @@ Value vmBuiltinUnderlinetext(VM* vm, int arg_count, Value* args) {
         return makeVoid();
     }
     gCurrentTextUnderline = true;
+    markTextAttrDirty();
     return makeVoid();
 }
 
@@ -1612,6 +1623,8 @@ Value vmBuiltinBlinktext(VM* vm, int arg_count, Value* args) {
         return makeVoid();
     }
     gCurrentTextBlink = true;
+    markTextAttrDirty();
+    syncTextAttrSymbol();
     return makeVoid();
 }
 
@@ -1622,6 +1635,9 @@ Value vmBuiltinLowvideo(VM* vm, int arg_count, Value* args) {
         return makeVoid();
     }
     gCurrentTextBold = false;
+    gCurrentTextColor &= 0x07;
+    markTextAttrDirty();
+    syncTextAttrSymbol();
     return makeVoid();
 }
 
@@ -1640,6 +1656,8 @@ Value vmBuiltinNormvideo(VM* vm, int arg_count, Value* args) {
     gCurrentTextBlink = false;
     printf("\x1B[0m");
     fflush(stdout);
+    markTextAttrDirty();
+    syncTextAttrSymbol();
     return makeVoid();
 }
 
@@ -1753,6 +1771,8 @@ Value vmBuiltinNormalcolors(VM* vm, int arg_count, Value* args) {
     gCurrentTextBlink = false;
     printf("\x1B[0m");
     fflush(stdout);
+    markTextAttrDirty();
+    syncTextAttrSymbol();
     return makeVoid();
 }
 

--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -2229,12 +2229,15 @@ int map16BgColorToAnsi(int pscalColorCode) {
 }
 
 bool applyCurrentTextAttributes(FILE* stream) {
+    bool stream_is_stdout = (stream == stdout);
     bool is_default_state = (gCurrentTextColor == 7 && gCurrentTextBackground == 0 &&
                              !gCurrentTextBold && !gCurrentTextUnderline &&
                              !gCurrentTextBlink && !gCurrentColorIsExt &&
                              !gCurrentBgIsExt);
 
-    if (is_default_state) return false;
+    if (is_default_state && (!stream_is_stdout || !gConsoleAttrDirty)) {
+        return false;
+    }
 
     char escape_sequence[64] = "\x1B[";
     char code_str[64];
@@ -2271,9 +2274,67 @@ bool applyCurrentTextAttributes(FILE* stream) {
     strcat(escape_sequence, code_str);
     strcat(escape_sequence, "m");
     fprintf(stream, "%s", escape_sequence);
+    if (stream_is_stdout) {
+        gConsoleAttrDirty = false;
+    }
     return true;
 }
 
 void resetTextAttributes(FILE* stream) {
     fprintf(stream, "\x1B[0m");
+    if (stream == stdout) {
+        gConsoleAttrDirty = true;
+    }
+}
+
+static Symbol* lookupTextAttrSymbol(void) {
+    if (!globalSymbols) {
+        return NULL;
+    }
+    return hashTableLookup(globalSymbols, "textattr");
+}
+
+uint8_t computeCurrentTextAttr(void) {
+    uint8_t fg = (uint8_t)(gCurrentTextColor & 0x0F);
+
+    if (gCurrentTextBold && fg < 8) {
+        fg |= 0x08;
+    }
+
+    uint8_t bg = (uint8_t)(gCurrentTextBackground & 0x07);
+
+    uint8_t attr = (uint8_t)((bg << 4) | (fg & 0x0F));
+    if (gCurrentTextBlink) {
+        attr |= 0x80;
+    }
+    return attr;
+}
+
+void syncTextAttrSymbol(void) {
+    Symbol* sym = lookupTextAttrSymbol();
+    if (!sym || !sym->value) {
+        return;
+    }
+    sym->value->type = TYPE_BYTE;
+    SET_INT_VALUE(sym->value, computeCurrentTextAttr());
+}
+
+void markTextAttrDirty(void) {
+    gConsoleAttrDirty = true;
+}
+
+void setCurrentTextAttrFromByte(uint8_t attr) {
+    uint8_t fg = (uint8_t)(attr & 0x0F);
+    uint8_t bg = (uint8_t)((attr >> 4) & 0x07);
+    bool blink = (attr & 0x80) != 0;
+
+    gCurrentTextColor = fg;
+    gCurrentTextBold = (fg & 0x08) != 0;
+    gCurrentColorIsExt = false;
+    gCurrentTextBackground = bg;
+    gCurrentBgIsExt = false;
+    gCurrentTextBlink = blink;
+
+    markTextAttrDirty();
+    syncTextAttrSymbol();
 }

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -241,6 +241,10 @@ int map16FgColorToAnsi(int pscalColorCode, bool isBold);
 int map16BgColorToAnsi(int pscalColorCode);
 bool applyCurrentTextAttributes(FILE* stream);
 void resetTextAttributes(FILE* stream);
+uint8_t computeCurrentTextAttr(void);
+void syncTextAttrSymbol(void);
+void markTextAttrDirty(void);
+void setCurrentTextAttrFromByte(uint8_t attr);
 
 // Arrays
 Value makeArrayND(int dimensions, int *lower_bounds, int *upper_bounds, VarType element_type, AST *type_def);

--- a/src/symbol/symbol.c
+++ b/src/symbol/symbol.c
@@ -826,22 +826,22 @@ void updateSymbol(const char *name, Value val) {
 
     // --- Perform Assignment ---
     // Use a switch on the TARGET symbol's type to handle assignments correctly.
-      switch (sym->type) {
-          case TYPE_INTEGER:
-              if (isIntlikeType(val.type)) {
-                  SET_INT_VALUE(sym->value, asI64(val));
-              } else if (isRealType(val.type)) {
-                  SET_INT_VALUE(sym->value, (long long)AS_REAL(val)); // Implicit Truncation
-              }
-              break;
+    switch (sym->type) {
+        case TYPE_INTEGER:
+            if (isIntlikeType(val.type)) {
+                SET_INT_VALUE(sym->value, asI64(val));
+            } else if (isRealType(val.type)) {
+                SET_INT_VALUE(sym->value, (long long)AS_REAL(val)); // Implicit Truncation
+            }
+            break;
 
-          case TYPE_INT64:
-              if (isIntlikeType(val.type)) {
-                  SET_INT_VALUE(sym->value, asI64(val));
-              } else if (isRealType(val.type)) {
-                  SET_INT_VALUE(sym->value, (long long)AS_REAL(val));
-              }
-              break;
+        case TYPE_INT64:
+            if (isIntlikeType(val.type)) {
+                SET_INT_VALUE(sym->value, asI64(val));
+            } else if (isRealType(val.type)) {
+                SET_INT_VALUE(sym->value, (long long)AS_REAL(val));
+            }
+            break;
 
         case TYPE_REAL:
             if (isRealType(val.type) || isIntlikeType(val.type)) {
@@ -976,6 +976,11 @@ void updateSymbol(const char *name, Value val) {
                     varTypeToString(sym->type), name);
             EXIT_FAILURE_HANDLER();
             break;
+    }
+
+    if (sym->name && strcmp(sym->name, "textattr") == 0) {
+        uint8_t attr_byte = (uint8_t)(sym->value->i_val & 0xFF);
+        setCurrentTextAttrFromByte(attr_byte);
     }
 
     // Free the incoming temporary Value's contents now that its data has been used.


### PR DESCRIPTION
## Summary
- track whether the CRT color state still needs to be applied by introducing a dirty flag in the globals
- update the ANSI application/reset helpers to consult the dirty flag and expose a helper to mark it when state changes
- mark the flag from CRT builtins and TextAttr assignments so the default black background appears before the first draw

## Testing
- cmake -S . -B build
- cmake --build build
- PASCAL_LIB_DIR=$(pwd)/lib/pascal ./build/bin/pascal --dump-bytecode-only Examples/Pascal/DiceGame


------
https://chatgpt.com/codex/tasks/task_e_68cc36c498f8832a9514699937803320