### PR TITLE
Fix MiscDemo base64 crash and background color

### DIFF
--- a/Examples/Pascal/MiscDemo
+++ b/Examples/Pascal/MiscDemo
@@ -21,6 +21,7 @@ var
 
 procedure WaitKey;
 begin
+  TextBackground(Black);
   TextColor(LightGray);
   writeln;
   writeln('Press any key to continue...');
@@ -31,6 +32,7 @@ end;
 
 procedure ShowMenu;
 begin
+  TextBackground(Black);
   ClrScr;
   TextColor(LightGreen);
   writeln('--- Pscal Demo ---');
@@ -128,6 +130,8 @@ end;
 
 procedure DemoBase64;
 begin
+  TextBackground(Black);
+  TextColor(White);
   write('Enter text to encode: ');
   readln(input);
   encoded := EncodeStringBase64(input);
@@ -165,9 +169,12 @@ begin
 end;
 
 begin
+  TextBackground(Black);
+  TextColor(White);
   repeat
     ShowMenu;
     readln(choice);
+    TextBackground(Black);
     ClrScr;
     case choice of
       1: DemoDateTime;

--- a/lib/pascal/base64.pl
+++ b/lib/pascal/base64.pl
@@ -2,35 +2,47 @@ unit Base64;
 
 interface
 
-const
-  Base64Chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
-
-var
-  DecodeTable: array[0..127] of integer; { Simple ASCII range is enough }
-
 function EncodeStringBase64(const s: string): string;
 function DecodeStringBase64(const s: string): string;
 
 implementation
 
-procedure InitializeDecodeTable;
-var
-  i: integer;
-  c: char;
+function EncodeBase64Char(value: integer): char;
 begin
-  { Initialize with -1 (invalid) }
-  for i := 0 to 127 do
-    DecodeTable[i] := -1;
+  if (value >= 0) and (value <= 25) then
+    EncodeBase64Char := chr(ord('A') + value)
+  else if (value >= 26) and (value <= 51) then
+    EncodeBase64Char := chr(ord('a') + (value - 26))
+  else if (value >= 52) and (value <= 61) then
+    EncodeBase64Char := chr(ord('0') + (value - 52))
+  else if value = 62 then
+    EncodeBase64Char := '+'
+  else if value = 63 then
+    EncodeBase64Char := '/'
+  else
+    EncodeBase64Char := '?';
+end;
 
-  { Map Base64 characters to their 6-bit values }
-  for i := 1 to length(Base64Chars) do
+function Base64Index(ch: char): integer;
+begin
+  if ch = '=' then
   begin
-    c := Base64Chars[i];
-    DecodeTable[Ord(c)] := i - 1;
+    Base64Index := -2; { Padding }
+    exit;
   end;
 
-  { Mark padding char (optional, useful for decoder logic) }
-  DecodeTable[Ord('=')] := -2;
+  if (ch >= 'A') and (ch <= 'Z') then
+    Base64Index := Ord(ch) - Ord('A')
+  else if (ch >= 'a') and (ch <= 'z') then
+    Base64Index := Ord(ch) - Ord('a') + 26
+  else if (ch >= '0') and (ch <= '9') then
+    Base64Index := Ord(ch) - Ord('0') + 52
+  else if ch = '+' then
+    Base64Index := 62
+  else if ch = '/' then
+    Base64Index := 63
+  else
+    Base64Index := -1; { Invalid character }
 end;
 
 { --- Encoding --- }
@@ -41,9 +53,7 @@ var
   b1, b2, b3: integer; { Byte values (0-255) }
   c1, c2, c3, c4: integer; { 6-bit chunk values (0-63) }
   encoded: string;
-  combined: integer; { Use integer for bit manipulation }
 begin
-  InitializeDecodeTable; { Ensure table is ready }
   encoded := '';
   len := length(s);
   i := 1;
@@ -73,17 +83,17 @@ begin
 
     if b2 = -1 then begin { One input byte, two padding chars (==) }
        c2 := (b1 and 3) shl 4; { Bottom 2 bits of b1, shifted left }
-       encoded := encoded + Base64Chars[c1+1] + Base64Chars[c2+1] + '==';
+       encoded := encoded + EncodeBase64Char(c1) + EncodeBase64Char(c2) + '==';
     end else begin { At least two input bytes }
        c2 := ((b1 and 3) shl 4) or (b2 shr 4); { Bottom 2 of b1 + top 4 of b2 }
 
        if b3 = -1 then begin { Two input bytes, one padding char (=) }
           c3 := (b2 and 15) shl 2; { Bottom 4 bits of b2, shifted left }
-          encoded := encoded + Base64Chars[c1+1] + Base64Chars[c2+1] + Base64Chars[c3+1] + '=';
+          encoded := encoded + EncodeBase64Char(c1) + EncodeBase64Char(c2) + EncodeBase64Char(c3) + '=';
        end else begin { Three input bytes, no padding }
           c3 := ((b2 and 15) shl 2) or (b3 shr 6); { Bottom 4 of b2 + top 2 of b3 }
           c4 := b3 and 63; { Bottom 6 bits of b3 }
-          encoded := encoded + Base64Chars[c1+1] + Base64Chars[c2+1] + Base64Chars[c3+1] + Base64Chars[c4+1];
+          encoded := encoded + EncodeBase64Char(c1) + EncodeBase64Char(c2) + EncodeBase64Char(c3) + EncodeBase64Char(c4);
        end;
     end;
   end;
@@ -94,17 +104,13 @@ end;
 
 function DecodeStringBase64(const s: string): string;
 var
-  i, len, padding: integer;
+  i, len: integer;
   c1, c2, c3, c4: integer; { 6-bit values }
   b1, b2, b3: integer; { Decoded byte values }
   decoded: string;
-  ch: char;
 begin
-  InitializeDecodeTable;
   decoded := '';
   len := length(s);
-  padding := 0;
-
   { Basic validation: length must be multiple of 4 }
   if (len mod 4) <> 0 then
   begin
@@ -113,55 +119,74 @@ begin
      exit;
   end;
 
-  { Count padding }
-  if len >= 1 then if s[len] = '=' then inc(padding);
-  if len >= 2 then if s[len-1] = '=' then inc(padding);
-
   i := 1;
   while i <= len do
   begin
-     { Read 4 chars, decode using table }
-     c1 := DecodeTable[Ord(s[i])]; inc(i);
-     c2 := DecodeTable[Ord(s[i])]; inc(i);
-     if i <= len then c3 := DecodeTable[Ord(s[i])] else c3 := -1; inc(i); // Handle end padding
-     if i <= len then c4 := DecodeTable[Ord(s[i])] else c4 := -1; inc(i); // Handle end padding
+     { Read 4 chars, decode using lookup helper }
+     c1 := Base64Index(s[i]); inc(i);
+     c2 := Base64Index(s[i]); inc(i);
+     c3 := Base64Index(s[i]); inc(i);
+     c4 := Base64Index(s[i]); inc(i);
 
-      { Check for invalid characters (ignore padding chars here) }
-      if (c1 = -1) or (c2 = -1) then
-      begin
-         writeln('Warning: Invalid character found in Base64 input.');
-         DecodeStringBase64 := '';
-         exit;
-      end;
+     { Check for invalid characters (ignore padding chars here) }
+     if (c1 < 0) or (c1 = -2) or (c2 < 0) or (c2 = -2) then
+     begin
+        writeln('Warning: Invalid character found in Base64 input.');
+        DecodeStringBase64 := '';
+        exit;
+     end;
 
-      if (c3 = -1) and ((i - 1) <= (len - padding)) then
-      begin
-         writeln('Warning: Invalid character found in Base64 input.');
-         DecodeStringBase64 := '';
-         exit;
-      end;
+     if c3 = -1 then
+     begin
+        writeln('Warning: Invalid character found in Base64 input.');
+        DecodeStringBase64 := '';
+        exit;
+     end;
 
-      if (c4 = -1) and (i <= (len - padding)) then
-      begin
-         writeln('Warning: Invalid character found in Base64 input.');
-         DecodeStringBase64 := '';
-         exit;
-      end;
+     if c4 = -1 then
+     begin
+        writeln('Warning: Invalid character found in Base64 input.');
+        DecodeStringBase64 := '';
+        exit;
+     end;
 
      { Combine 4x6 bits into 3x8 bits }
      b1 := (c1 shl 2) or (c2 shr 4);
      decoded := decoded + Chr(b1);
 
-     if c3 <> -2 then { Check not padding '=' }
+     if c3 >= 0 then { Check not padding '=' }
      begin
         b2 := ((c2 and 15) shl 4) or (c3 shr 2);
         decoded := decoded + Chr(b2);
-     end;
 
-     if c4 <> -2 then { Check not padding '=' }
+        if c4 >= 0 then { Full block }
+        begin
+          b3 := ((c3 and 3) shl 6) or c4;
+          decoded := decoded + Chr(b3);
+        end
+        else if c4 <> -2 then
+        begin
+          writeln('Warning: Invalid character found in Base64 input.');
+          DecodeStringBase64 := '';
+          exit;
+        end;
+     end
+     else
      begin
-         b3 := ((c3 and 3) shl 6) or c4;
-         decoded := decoded + Chr(b3);
+        { Padding should only appear in the last two positions }
+        if c3 <> -2 then
+        begin
+          writeln('Warning: Invalid character found in Base64 input.');
+          DecodeStringBase64 := '';
+          exit;
+        end;
+
+        if c4 <> -2 then
+        begin
+          writeln('Warning: Invalid character found in Base64 input.');
+          DecodeStringBase64 := '';
+          exit;
+        end;
      end;
   end;
 
@@ -169,6 +194,4 @@ begin
 end;
 
 begin
- { Unit initialization code (optional, runs when unit is used) }
- InitializeDecodeTable;
 end.


### PR DESCRIPTION
## Summary
- replace the Base64 unit's table-driven logic with arithmetic helpers so encoding/decoding works without undefined globals
- add additional validation while decoding to gracefully reject malformed Base64 input
- reset the CRT background to black before menu drawing and Base64 prompts in MiscDemo to preserve the expected appearance

## Testing
- `cmake ..`
- `make -j2`
- `build/bin/pascal tmp_base64_test.pas`


------
https://chatgpt.com/codex/tasks/task_e_68cc5d79f3dc832a96086f144a54c590