### PR TITLE
Add StopAllSounds builtin and use it to halt pwav playback

### DIFF
--- a/Docs/pascal_language_reference.md
+++ b/Docs/pascal_language_reference.md
@@ -220,7 +220,7 @@ The Pascal front end exposes the PSCAL VM's built-ins, including:
 - Memory: `New`, `Dispose`.
 - Console/text: `GotoXY`, `TextColor`, `TextBackground`, `ClrScr`, `WhereX`, `WhereY`.
 - Concurrency (see below): `spawn`, `join`, `mutex`, `rcmutex`, `lock`, `unlock`, `destroy`.
-- SDL-based graphics/sound (when built with `-DSDL=ON`): e.g., `InitGraph`, `CloseGraph`, `UpdateScreen`, `SetRGBColor`, `DrawLine`, `FillRect`, `FillCircle`, `CreateTexture`, `UpdateTexture`, `DestroyTexture`, text helpers like `InitTextSystem(FontFileName, FontSize)`, `OutTextXY`, and audio: `InitSoundSystem`, `LoadSound`, `PlaySound`, `IsSoundPlaying`, `FreeSound`, `QuitSoundSystem`.
+- SDL-based graphics/sound (when built with `-DSDL=ON`): e.g., `InitGraph`, `CloseGraph`, `UpdateScreen`, `SetRGBColor`, `DrawLine`, `FillRect`, `FillCircle`, `CreateTexture`, `UpdateTexture`, `DestroyTexture`, text helpers like `InitTextSystem(FontFileName, FontSize)`, `OutTextXY`, and audio: `InitSoundSystem`, `LoadSound`, `PlaySound`, `StopAllSounds`, `IsSoundPlaying`, `FreeSound`, `QuitSoundSystem`.
 
 Note: SDL built-ins are available only in SDL-enabled builds. Headless CI typically skips these routines.
 

--- a/Docs/pscal_vm_builtins.md
+++ b/Docs/pscal_vm_builtins.md
@@ -240,6 +240,7 @@ These built-ins are available when Pscal is built with SDL support.
 | loadsound | (file: String) | Sound | Load sound file. |
 | freesound | (sound: Sound) | void | Free a loaded sound. |
 | playsound | (sound: Sound) | void | Play sound. |
+| stopallsounds | () | void | Halt all playing sounds immediately. |
 | issoundplaying | (sound: Sound) | Boolean | Query if sound playing. |
 | inittextsystem | (fontPath: String, fontSize: Integer) | void | Initialize text subsystem with a TTF font. |
 | quittextsystem | () | void | Shut down text subsystem. |

--- a/Examples/Pascal/pwav
+++ b/Examples/Pascal/pwav
@@ -51,6 +51,21 @@ begin
   PlaybackFinished := True;
 end;
 
+procedure WaitForPlaybackToStopBeforeCleanup;
+begin
+  if not IsSoundPlaying() then
+    exit;
+
+  writeln('Waiting for sound playback to stop before cleanup...');
+
+  while IsSoundPlaying() do
+  begin
+    Delay(10);
+  end;
+
+  writeln('Playback stopped.');
+end;
+
 
 begin
   writeln('Pscal WAV Player');
@@ -113,6 +128,7 @@ begin
           begin
             QuitRequested := True;
             writeln('Q pressed. Stopping playback early.');
+            StopAllSounds;
             break;
           end;
         end;
@@ -142,6 +158,7 @@ begin
           begin
             QuitRequested := True;
             writeln('Q pressed. Requesting playback thread to stop...');
+            StopAllSounds;
             break;
           end;
         end;
@@ -159,11 +176,13 @@ begin
 
       WaitForThread(PlaybackThreadID);
 
-      if (not PlaybackCompleted) and (not IsSoundPlaying()) then
+      if (not QuitRequested) and (not PlaybackCompleted) and (not IsSoundPlaying()) then
       begin
         PlaybackCompleted := True;
       end;
     end;
+
+    WaitForPlaybackToStopBeforeCleanup;
 
     if QuitRequested and (not PlaybackCompleted) then
     begin

--- a/src/backend_ast/audio.c
+++ b/src/backend_ast/audio.c
@@ -208,6 +208,19 @@ void audioFreeSound(int soundID) {
     DEBUG_PRINT("[DEBUG AUDIO] Sound ID %d freed successfully.\n", soundID);
 }
 
+// Stop all currently playing sounds (including music) without tearing down the
+// sound system. Safe to call even if nothing is playing.
+void audioStopAllSounds(void) {
+    if (!gSoundSystemInitialized) {
+        DEBUG_PRINT("[DEBUG AUDIO] Sound system not initialized. Skipping StopAllSounds.\n");
+        return;
+    }
+
+    Mix_HaltGroup(-1);
+    Mix_HaltMusic();
+    DEBUG_PRINT("[DEBUG AUDIO] StopAllSounds halted all channels and music.\n");
+}
+
 // Shut down SDL_mixer and the SDL audio subsystem
 void audioQuitSystem(void) {
     if (!gSoundSystemInitialized) {
@@ -272,6 +285,15 @@ Value vmBuiltinFreesound(VM* vm, int arg_count, Value* args) {
         runtimeError(vm, "FreeSound expects 1 integer argument.");
     } else {
         audioFreeSound((int)AS_INTEGER(args[0]));
+    }
+    return makeVoid();
+}
+
+Value vmBuiltinStopallsounds(VM* vm, int arg_count, Value* args) {
+    if (arg_count != 0) {
+        runtimeError(vm, "StopAllSounds expects 0 arguments.");
+    } else {
+        audioStopAllSounds();
     }
     return makeVoid();
 }

--- a/src/backend_ast/audio.h
+++ b/src/backend_ast/audio.h
@@ -26,6 +26,7 @@ void audioInitSystem(void);
 int audioLoadSound(const char* filename);
 void audioPlaySound(int soundID);
 void audioFreeSound(int soundID);
+void audioStopAllSounds(void);
 void audioQuitSystem(void);
 
 // AST-based built-ins
@@ -35,6 +36,7 @@ Value vmBuiltinInitsoundsystem(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinLoadsound(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinPlaysound(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinFreesound(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinStopallsounds(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinQuitsoundsystem(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinIssoundplaying(struct VM_s* vm, int arg_count, Value* args);
 

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -344,6 +344,7 @@ static const VmBuiltinMapping vmBuiltinDispatchTable[] = {
     {"paramstr", vmBuiltinParamstr},
 #ifdef SDL
     {"playsound", vmBuiltinPlaysound},
+    {"stopallsounds", vmBuiltinStopallsounds},
     {"pollkey", vmBuiltinPollkey},
 #endif
     {"popscreen", vmBuiltinPopscreen},
@@ -3763,6 +3764,7 @@ void registerAllBuiltins(void) {
     registerBuiltinFunction("LoadSound", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("OutTextXY", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("PlaySound", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("StopAllSounds", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("PollKey", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("PutPixel", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("QuitSoundSystem", AST_PROCEDURE_DECL, NULL);


### PR DESCRIPTION
## Summary
- add a helper routine that waits for playback to stop before cleaning up
- ensure pwav waits for the audio system to finish playback prior to freeing the sound buffer when the user aborts early
- expose a StopAllSounds builtin and invoke it from pwav so aborting halts playback immediately

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc946e75f4832abe713c9e76658da4