### PR TITLE
Fix weather example parsing crash and use builtin FileExists

### DIFF
--- a/Examples/Pascal/weather
+++ b/Examples/Pascal/weather
@@ -110,10 +110,12 @@ begin
   if keyPos > 0 then
   begin
     valueStartPos := startSearchPos + keyPos + length(searchPattern) - 1;
-    // Skip leading spaces after colon
-    while (valueStartPos <= length(jsonString)) and (jsonString[valueStartPos] = ' ') do
+    // Skip leading spaces after colon without relying on short-circuit evaluation
+    while valueStartPos <= length(jsonString) do
     begin
-       inc(valueStartPos);
+      if jsonString[valueStartPos] <> ' ' then
+        break;
+      inc(valueStartPos);
     end;
 
     // Use min for safety when searching for end delimiter
@@ -142,54 +144,92 @@ end;
 // Returns position of error (1-based) in code, or 0 on success.
 function StrToReal(s: string; var code: integer): real;
 var
-  i: integer;
+  i, lenS: integer;
   negative: boolean;
   intPart, fracPart: real;
   divisor: real;
+  ch: char;
+  digitsFound: boolean;
 begin
+  lenS := length(s);
   code := 0;
   i := 1;
   negative := False;
   intPart := 0;
   fracPart := 0;
   divisor := 1;
+  digitsFound := False;
 
-  if length(s) = 0 then
+  if lenS = 0 then
   begin
     code := 1;
     StrToReal := 0;
     exit;
   end;
 
-  if s[i] = '-' then
+  if i <= lenS then
   begin
-    negative := True;
-    inc(i);
-  end
-  else if s[i] = '+' then
-    inc(i);
+    ch := s[i];
+    if ch = '-' then
+    begin
+      negative := True;
+      inc(i);
+    end
+    else if ch = '+' then
+      inc(i);
+  end;
 
   // Parse integer part
-  while (i <= length(s)) and (s[i] >= '0') and (s[i] <= '9') do
+  while i <= lenS do
   begin
-    intPart := intPart * 10 + (Ord(s[i]) - Ord('0'));
+    ch := s[i];
+    if (ch < '0') or (ch > '9') then
+      break;
+    intPart := intPart * 10 + (Ord(ch) - Ord('0'));
     inc(i);
+    digitsFound := True;
+    if i > lenS then
+      break;
   end;
 
   // Parse fractional part
-  if (i <= length(s)) and (s[i] = '.') then
+  if i <= lenS then
   begin
-    inc(i);
-    while (i <= length(s)) and (s[i] >= '0') and (s[i] <= '9') do
+    if s[i] = '.' then
     begin
-      fracPart := fracPart * 10 + (Ord(s[i]) - Ord('0'));
-      divisor := divisor * 10;
       inc(i);
+      while i <= lenS do
+      begin
+        ch := s[i];
+        if (ch < '0') or (ch > '9') then
+          break;
+        fracPart := fracPart * 10 + (Ord(ch) - Ord('0'));
+        divisor := divisor * 10;
+        inc(i);
+        digitsFound := True;
+        if i > lenS then
+          break;
+      end;
     end;
   end;
 
+  if not digitsFound then
+  begin
+    code := i;
+    StrToReal := 0;
+    exit;
+  end;
+
+  // Skip any trailing spaces without triggering out-of-bounds access
+  while i <= lenS do
+  begin
+    if s[i] <> ' ' then
+      break;
+    inc(i);
+  end;
+
   // If there are leftover characters, report position of error
-  if i <= length(s) then
+  if i <= lenS then
     code := i
   else
     code := 0;

--- a/lib/pascal/sysutils.pl
+++ b/lib/pascal/sysutils.pl
@@ -11,7 +11,7 @@ function TrimRight(S: string): string;
 function QuotedStr(S: string): string; // Simplified: Doesn't handle internal quotes
 
 // --- File System ---
-function FileExists(FileName: string): Boolean;
+// FileExists is provided as a VM builtin.
 
 // --- Conversions ---
 // function StrToIntDef(S: string; Default: Longint): Longint; // Needs TryStrToInt built-in
@@ -83,8 +83,12 @@ var
 begin
   Len := Length(S);
   First := 1;
-  while (First <= Len) and (S[First] = ' ') do
+  while First <= Len do
+  begin
+    if S[First] <> ' ' then
+      break;
     Inc(First);
+  end;
   if First > Len then
     TrimLeft := ''
   else
@@ -96,8 +100,12 @@ var
   Last: Integer;
 begin
   Last := Length(S);
-  while (Last > 0) and (S[Last] = ' ') do
+  while Last > 0 do
+  begin
+    if S[Last] <> ' ' then
+      break;
     Dec(Last);
+  end;
   if Last < 1 then
     TrimRight := ''
   else
@@ -111,13 +119,21 @@ begin
   Len := Length(S);
   First := 1;
   // Find first non-space character
-  while (First <= Len) and (S[First] = ' ') do
+  while First <= Len do
+  begin
+    if S[First] <> ' ' then
+      break;
     Inc(First);
+  end;
 
   // Find last non-space character
   Last := Len;
-  while (Last >= First) and (S[Last] = ' ') do
+  while Last >= First do
+  begin
+    if S[Last] <> ' ' then
+      break;
     Dec(Last);
+  end;
 
   if First > Last then // String was all spaces or empty
     Trim := ''
@@ -133,30 +149,7 @@ end;
 
 
 // --- File System ---
-
-function FileExists(FileName: string): Boolean;
-var
-  F: Text; // Use Text for Reset/IOResult checking
-  IOStatus: Integer;
-begin
-  // Standard Pascal trick: Try to open for reading, check IOResult
-  {$I-} // Disable IO checking temporarily
-  Assign(F, FileName);
-  Reset(F); // Try to open for reading
-  {$I+} // Re-enable IO checking
-
-  IOStatus := IOResult; // Get result of Reset
-
-  if IOStatus = 0 then // If Reset succeeded (file exists and readable)
-  begin
-    Close(F); // Close the file we opened
-    FileExists := True;
-  end
-  else // Reset failed
-  begin
-    FileExists := False;
-  end;
-end;
+// FileExists is provided as a VM builtin; no wrapper needed here.
 
 // --- Other sections would go here ---
 


### PR DESCRIPTION
## Summary
- prevent out-of-bounds string access in the weather demo by guarding numeric parsing loops and checking for parsed digits before converting to real values
- rely on the VM's FileExists builtin from SysUtils and harden the trim helpers to avoid indexing past the end of strings

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68ccbf4720f0832abf6fc772284d7942