### PR TITLE
Fix tiny compiler bytecode footer

### DIFF
--- a/tools/tiny
+++ b/tools/tiny
@@ -512,8 +512,11 @@ def write_bytecode(builder: BytecodeBuilder, path: Path, version: int) -> None:
                         f.write(data)
             else:
                 raise NotImplementedError("Unsupported constant type")
-        # Procedure table, const symbol table, and type table counts (all zero)
-        f.write(struct.pack("<i", 0))
+        # Procedure table uses the convention stored_proc_count = -(count + 1).
+        # The tiny frontend never emits procedures, so we write -1 to signal
+        # an empty table to match the VM loader's expectations.
+        f.write(struct.pack("<i", -1))
+        # Constant symbol table and type table counts (both zero for tiny)
         f.write(struct.pack("<i", 0))
         f.write(struct.pack("<i", 0))
 


### PR DESCRIPTION
## Summary
- write the procedure table sentinel that the VM expects when emitting tiny bytecode

## Testing
- ./Tests/run_tiny_tests.sh

------
https://chatgpt.com/codex/tasks/task_e_68ccc5375b20832ab8ca1ff8e888a148