### PR TITLE
Update CLike CALL emission for CALL_USER_PROC

### DIFF
--- a/Tests/Pascal/UserProcCallTest
+++ b/Tests/Pascal/UserProcCallTest
@@ -1,0 +1,26 @@
+program UserProcCallTest;
+
+type
+  TIntArray = array[1..3] of integer;
+
+function DoubleIt(x: integer): integer;
+begin
+  DoubleIt := x * 2;
+end;
+
+procedure PrintValue(value: integer);
+begin
+  writeln('value=', value);
+end;
+
+var
+  data: TIntArray;
+  i: integer;
+begin
+  writeln('double=', DoubleIt(5));
+  data[1] := 3;
+  data[2] := 4;
+  data[3] := 5;
+  for i := 1 to 3 do
+    PrintValue(data[i]);
+end.

--- a/Tests/Pascal/UserProcCallTest.disasm
+++ b/Tests/Pascal/UserProcCallTest.disasm
@@ -1,0 +1,84 @@
+--- Compiling Main Program AST to Bytecode ---
+== Disassembly: Pascal/UserProcCallTest ==
+Offset Line Opcode           Operand  Value / Target (Args)
+------ ---- ---------------- -------- --------------------------
+0000    1 CONSTANT            1 'nil'
+0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
+0007   17 DEFINE_GLOBAL    NameIdx:3   'data' Type:ARRAY Dims:1 [1..3] of INTEGER ('integer')
+0017   18 DEFINE_GLOBAL    NameIdx:7   'i' Type:INTEGER ('integer')
+0022    6 JUMP               10 (to 0035)
+
+--- Function doubleit (at 0025) ---
+0025    8 GET_LOCAL           0 (slot)
+0027    | CONSTANT            8 '2'
+0029    | MULTIPLY
+0030    | SET_LOCAL           1 (slot)
+0032    6 GET_LOCAL           1 (slot)
+0034    | RETURN
+0035   11 JUMP               13 (to 0051)
+
+--- Procedure printvalue (at 0038) ---
+0038   13 CONSTANT            4 '1'
+0040    | CONSTANT            9 'value='
+0042    | GET_LOCAL           0 (slot)
+0044    | CALL_BUILTIN_PROC   176 'write' (3 args)
+0050   11 RETURN
+0051   20 CONSTANT            4 '1'
+0053    | CONSTANT           11 'double='
+0055    | CONSTANT           12 '5'
+0057    | CALL_USER_PROC      13 'doubleit' @0025 (1 args)
+0061    | CALL_BUILTIN_PROC   176 'write' (3 args)
+0067   21 CONSTANT            5 '3'
+0069    | CONSTANT            4 '1'
+0071    | GET_GLOBAL_ADDRESS    3 'data'
+0073    | GET_ELEMENT_ADDRESS    1 (dims)
+0075    0 SWAP
+0076    | SET_INDIRECT
+0077   22 CONSTANT           14 '4'
+0079    | CONSTANT            8 '2'
+0081    | GET_GLOBAL_ADDRESS    3 'data'
+0083    | GET_ELEMENT_ADDRESS    1 (dims)
+0085    0 SWAP
+0086    | SET_INDIRECT
+0087   23 CONSTANT           12 '5'
+0089    | CONSTANT            5 '3'
+0091    | GET_GLOBAL_ADDRESS    3 'data'
+0093    | GET_ELEMENT_ADDRESS    1 (dims)
+0095    0 SWAP
+0096    | SET_INDIRECT
+0097   24 CONSTANT            4 '1'
+0099    | SET_GLOBAL          7 'i'
+0101    | GET_GLOBAL          7 'i'
+0103    | CONSTANT            5 '3'
+0105    | LESS_EQUAL
+0106    | JUMP_IF_FALSE      21 (to 0130)
+0109   25 GET_GLOBAL          7 'i'
+0111    | GET_GLOBAL_ADDRESS    3 'data'
+0113    | GET_ELEMENT_ADDRESS    1 (dims)
+0115    | GET_INDIRECT
+0116    | CALL_USER_PROC      15 'printvalue' @0038 (1 args)
+0120   24 GET_GLOBAL          7 'i'
+0122    | CONSTANT            4 '1'
+0124    | ADD
+0125    | SET_GLOBAL          7 'i'
+0127    | JUMP              -29 (to 0101)
+0130    1 HALT
+== End Disassembly: Pascal/UserProcCallTest ==
+
+Constants (16):\n  0000: STR   "myself"
+  0001: NIL
+  0002: STR   ""
+  0003: STR   "data"
+  0004: INT   1
+  0005: INT   3
+  0006: STR   "integer"
+  0007: STR   "i"
+  0008: INT   2
+  0009: STR   "value="
+  0010: STR   "write"
+  0011: STR   "double="
+  0012: INT   5
+  0013: STR   "doubleit"
+  0014: INT   4
+  0015: STR   "printvalue"
+

--- a/Tests/Pascal/UserProcCallTest.out
+++ b/Tests/Pascal/UserProcCallTest.out
@@ -1,0 +1,4 @@
+double=10
+value=3
+value=4
+value=5

--- a/Tests/clike/StringIndexBounds.err
+++ b/Tests/clike/StringIndexBounds.err
@@ -1,2 +1,2 @@
 Runtime Error: String index (9) out of bounds for string of length 8.
-[Error Location] Offset: 23, Line: 5
+[Error Location] Offset: 21, Line: 5

--- a/Tests/rea/constructor_init.err
+++ b/Tests/rea/constructor_init.err
@@ -8,18 +8,18 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0012    | ALLOC_OBJECT        2 (fields)
 0014    | DUP
 0015    | CONSTANT            5 '5'
-0017    | CALL             0028 (point) (2 args)
-0023    | SET_GLOBAL          3 'p'
-0025    1 JUMP                9 (to 0037)
+0017    | CALL_USER_PROC       6 'point' @0026 (2 args)
+0021    | SET_GLOBAL          3 'p'
+0023    1 JUMP                9 (to 0035)
 
---- Procedure point.point (at 0028) ---
-0028    | GET_LOCAL           1 (slot)
-0030    | GET_LOCAL           0 (slot)
-0032    | GET_FIELD_OFFSET    1 (index)
-0034    | SWAP
-0035    | SET_INDIRECT
-0036    | RETURN
-0037    0 HALT
+--- Procedure point.point (at 0026) ---
+0026    | GET_LOCAL           1 (slot)
+0028    | GET_LOCAL           0 (slot)
+0030    | GET_FIELD_OFFSET    1 (index)
+0032    | SWAP
+0033    | SET_INDIRECT
+0034    | RETURN
+0035    0 HALT
 == End Disassembly: Tests/rea/constructor_init.rea ==
 
 Constants (7):\n  0000: STR   "myself"

--- a/Tests/rea/new_local_vtable.err
+++ b/Tests/rea/new_local_vtable.err
@@ -22,8 +22,8 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0029    0 CONSTANT            5 'Value type ARRAY'
 0031    | DEFINE_GLOBAL    NameIdx:4   'mixedcase_vtable' Type:ARRAY Dims:1 [0..0] of INTEGER ('integer')
 0041    | SET_GLOBAL          4 'mixedcase_vtable'
-0043    5 CALL             0014 (run) (0 args)
-0049    0 HALT
+0043    5 CALL_USER_PROC       8 'run' @0014 (0 args)
+0047    0 HALT
 == End Disassembly: Tests/rea/new_local_vtable.rea ==
 
 Constants (9):\n  0000: STR   "myself"

--- a/Tests/rea/super_constructor.err
+++ b/Tests/rea/super_constructor.err
@@ -8,30 +8,30 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0012    | ALLOC_OBJECT        3 (fields)
 0014    | DUP
 0015    | CONSTANT            5 '42'
-0017    | CALL             0040 (child) (2 args)
-0023    | SET_GLOBAL          3 'c'
-0025    1 JUMP                9 (to 0037)
+0017    | CALL_USER_PROC       6 'child' @0038 (2 args)
+0021    | SET_GLOBAL          3 'c'
+0023    1 JUMP                9 (to 0035)
 
---- Procedure base.base (at 0028) ---
-0028    | GET_LOCAL           1 (slot)
-0030    | GET_LOCAL           0 (slot)
-0032    | GET_FIELD_OFFSET    1 (index)
-0034    | SWAP
-0035    | SET_INDIRECT
-0036    | RETURN
-0037    2 JUMP               11 (to 0051)
+--- Procedure base.base (at 0026) ---
+0026    | GET_LOCAL           1 (slot)
+0028    | GET_LOCAL           0 (slot)
+0030    | GET_FIELD_OFFSET    1 (index)
+0032    | SWAP
+0033    | SET_INDIRECT
+0034    | RETURN
+0035    2 JUMP                9 (to 0047)
 
---- Procedure child.child (at 0040) ---
-0040    | GET_LOCAL           0 (slot)
-0042    | GET_LOCAL           1 (slot)
-0044    | CALL             0028 (base.base) (2 args)
-0050    | RETURN
-0051    4 CONSTANT            8 '1'
-0053    | GET_GLOBAL          3 'c'
-0055    | GET_FIELD_OFFSET    1 (index)
-0057    | GET_INDIRECT
-0058    | CALL_BUILTIN_PROC   176 'write' (2 args)
-0064    0 HALT
+--- Procedure child.child (at 0038) ---
+0038    | GET_LOCAL           0 (slot)
+0040    | GET_LOCAL           1 (slot)
+0042    | CALL_USER_PROC       7 'base.base' @0026 (2 args)
+0046    | RETURN
+0047    4 CONSTANT            8 '1'
+0049    | GET_GLOBAL          3 'c'
+0051    | GET_FIELD_OFFSET    1 (index)
+0053    | GET_INDIRECT
+0054    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0060    0 HALT
 == End Disassembly: Tests/rea/super_constructor.rea ==
 
 Constants (10):\n  0000: STR   "myself"

--- a/Tests/rea/super_method.err
+++ b/Tests/rea/super_method.err
@@ -18,40 +18,40 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0025    | CONSTANT            6 'base'
 0027    | CALL_BUILTIN_PROC   176 'write' (2 args)
 0033    | RETURN
-0034    2 JUMP                9 (to 0046)
+0034    2 JUMP                7 (to 0044)
 
 --- Procedure child.child (at 0037) ---
 0037    | GET_LOCAL           0 (slot)
-0039    | CALL             0019 (base.base) (1 args)
-0045    | RETURN
-0046    | JUMP                9 (to 0058)
+0039    | CALL_USER_PROC       8 'base.base' @0019 (1 args)
+0043    | RETURN
+0044    | JUMP                7 (to 0054)
 
---- Procedure child.speak (at 0049) ---
-0049    | GET_LOCAL           0 (slot)
-0051    | CALL             0023 (base.speak) (1 args)
-0057    | RETURN
-0058    0 CONSTANT           10 'Value type ARRAY'
-0060    | DEFINE_GLOBAL    NameIdx:11  'child_vtable' Type:ARRAY Dims:1 [0..1] of INTEGER ('integer')
-0070    | SET_GLOBAL         11 'child_vtable'
-0072    | CONSTANT           14 'Value type ARRAY'
-0074    | DEFINE_GLOBAL    NameIdx:15  'base_vtable' Type:ARRAY Dims:1 [0..1] of INTEGER ('integer')
-0084    | SET_GLOBAL         15 'base_vtable'
-0086    | GET_GLOBAL          3 'c'
-0088    | DUP
-0089    | GET_FIELD_OFFSET    0 (index)
-0091    | GET_GLOBAL_ADDRESS   11 'child_vtable'
-0093    | SET_INDIRECT
-0094    | POP
-0095    4 GET_GLOBAL          3 'c'
-0097    | DUP
-0098    | GET_FIELD_OFFSET    0 (index)
-0100    | GET_INDIRECT
-0101    | CONSTANT            5 '1'
-0103    | SWAP
-0104    | GET_ELEMENT_ADDRESS    1 (dims)
-0106    | GET_INDIRECT
-0107    | PROC_CALL_INDIRECT (args=1)
-0109    0 HALT
+--- Procedure child.speak (at 0047) ---
+0047    | GET_LOCAL           0 (slot)
+0049    | CALL_USER_PROC       9 'base.speak' @0023 (1 args)
+0053    | RETURN
+0054    0 CONSTANT           10 'Value type ARRAY'
+0056    | DEFINE_GLOBAL    NameIdx:11  'child_vtable' Type:ARRAY Dims:1 [0..1] of INTEGER ('integer')
+0066    | SET_GLOBAL         11 'child_vtable'
+0068    | CONSTANT           14 'Value type ARRAY'
+0070    | DEFINE_GLOBAL    NameIdx:15  'base_vtable' Type:ARRAY Dims:1 [0..1] of INTEGER ('integer')
+0080    | SET_GLOBAL         15 'base_vtable'
+0082    | GET_GLOBAL          3 'c'
+0084    | DUP
+0085    | GET_FIELD_OFFSET    0 (index)
+0087    | GET_GLOBAL_ADDRESS   11 'child_vtable'
+0089    | SET_INDIRECT
+0090    | POP
+0091    4 GET_GLOBAL          3 'c'
+0093    | DUP
+0094    | GET_FIELD_OFFSET    0 (index)
+0096    | GET_INDIRECT
+0097    | CONSTANT            5 '1'
+0099    | SWAP
+0100    | GET_ELEMENT_ADDRESS    1 (dims)
+0102    | GET_INDIRECT
+0103    | PROC_CALL_INDIRECT (args=1)
+0105    0 HALT
 == End Disassembly: Tests/rea/super_method.rea ==
 
 Constants (16):\n  0000: STR   "myself"

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -1874,9 +1874,8 @@ static void compileLValue(AST* node, BytecodeChunk* chunk, int current_line_appr
                     compileRValue(node->children[i], chunk, getLine(node->children[i]));
                 }
                 int ctorNameIdx = addStringConstant(chunk, lowerClassName);
-                writeBytecodeChunk(chunk, CALL, line);
+                writeBytecodeChunk(chunk, CALL_USER_PROC, line);
                 emitShort(chunk, (uint16_t)ctorNameIdx, line);
-                emitShort(chunk, 0xFFFF, line);
                 writeBytecodeChunk(chunk, (uint8_t)(node->child_count + 1), line);
             }
             global_init_new_depth--;
@@ -3801,14 +3800,8 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
                 }
             } else if (proc_symbol) { // If a symbol was found (either defined or forward-declared)
                 int nameIndex = addStringConstant(chunk, calleeName);
-                writeBytecodeChunk(chunk, CALL, line);
+                writeBytecodeChunk(chunk, CALL_USER_PROC, line);
                 emitShort(chunk, (uint16_t)nameIndex, line);
-
-                if (proc_symbol->is_defined) {
-                    emitShort(chunk, (uint16_t)proc_symbol->bytecode_address, line);
-                } else {
-                    emitShort(chunk, 0xFFFF, line);
-                }
                 writeBytecodeChunk(chunk, (uint8_t)call_arg_count, line);
 
                 // This logic for user-defined functions is already correct.
@@ -3951,9 +3944,8 @@ static void compileRValue(AST* node, BytecodeChunk* chunk, int current_line_appr
                     compileRValue(node->children[i], chunk, getLine(node->children[i]));
                 }
                 int ctorNameIdx = addStringConstant(chunk, lowerClassName);
-                writeBytecodeChunk(chunk, CALL, line);
+                writeBytecodeChunk(chunk, CALL_USER_PROC, line);
                 emitShort(chunk, (uint16_t)ctorNameIdx, line);
-                emitShort(chunk, 0xFFFF, line);
                 writeBytecodeChunk(chunk, (uint8_t)(node->child_count + 1), line);
             }
             global_init_new_depth--;
@@ -4781,14 +4773,8 @@ static void compileRValue(AST* node, BytecodeChunk* chunk, int current_line_appr
                         emitConstant(chunk, addNilConstant(chunk), line);
                     } else {
                         int nameIndex = addStringConstant(chunk, functionName);
-                        writeBytecodeChunk(chunk, CALL, line);
+                        writeBytecodeChunk(chunk, CALL_USER_PROC, line);
                         emitShort(chunk, (uint16_t)nameIndex, line);
-
-                        if (func_symbol->is_defined) {
-                            emitShort(chunk, (uint16_t)func_symbol->bytecode_address, line);
-                        } else {
-                            emitShort(chunk, 0xFFFF, line);
-                        }
                         writeBytecodeChunk(chunk, (uint8_t)call_arg_count, line);
                     }
                 } else {


### PR DESCRIPTION
## Summary
- update the CLike frontend to emit CALL_USER_PROC for direct user-defined calls, including thread spawn wrappers, and flag unresolved procedures
- adjust the generated call to main to rely on procedure table lookups instead of embedding addresses
- refresh the CLike and Rea test disassemblies for the new opcode layout and offset changes

## Testing
- `Tests/run_clike_tests.sh`
- `Tests/run_rea_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68cd9aef5ba8832aba45e5ca1cf537ee