### PR TITLE
Add direct field/element load opcodes and update tests

### DIFF
--- a/Docs/pscal_vm_overview.md
+++ b/Docs/pscal_vm_overview.md
@@ -206,9 +206,18 @@ This sequence uses `JUMP_IF_FALSE` to exit the loop and `JUMP` to repeat.
 * **`GET_FIELD_ADDRESS`** / **`GET_FIELD_ADDRESS16`**:
     * **Operands:** Constant index for the field's name.
     * **Action:** Pops a record or a pointer to a record from the stack and pushes a pointer to the specified field's `Value` struct.
+* **`LOAD_FIELD_VALUE`** / **`LOAD_FIELD_VALUE16`**:
+    * **Operands:** Field offset (1-byte or 2-byte).
+    * **Action:** Pops a record or pointer to a record (including chained pointers), resolves the field by offset—respecting hidden vtable slots—and pushes a copy of the field's value onto the stack.
+* **`LOAD_FIELD_VALUE_BY_NAME`** / **`LOAD_FIELD_VALUE_BY_NAME16`**:
+    * **Operands:** Constant index of the field name (1-byte or 2-byte).
+    * **Action:** Pops a record or pointer to a record, locates the named field, and pushes a copy of its value. Emits a runtime error if the field does not exist.
 * **`GET_ELEMENT_ADDRESS`**:
     * **Operands:** 1-byte dimension count.
     * **Action:** Pops an array or pointer to an array, and then pops the indices for each dimension. Pushes a pointer to the specified element's `Value` struct.
+* **`LOAD_ELEMENT_VALUE`**:
+    * **Operands:** 1-byte dimension count.
+    * **Action:** Pops an array (or pointer to an array) and the indices for each dimension, checks bounds, and pushes a copy of the addressed element's value. Handles Pascal strings specially so that `s[0]` yields the length and `s[i]` yields the character value.
 * **`GET_CHAR_ADDRESS`**:
     * **Operands:** None.
     * **Action:** Pops an index and a pointer to a string. Pushes a pointer to the character at that index within the string.

--- a/Tests/Pascal/UserProcCallTest.disasm
+++ b/Tests/Pascal/UserProcCallTest.disasm
@@ -51,18 +51,17 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0101    | GET_GLOBAL          7 'i'
 0103    | CONSTANT            5 '3'
 0105    | LESS_EQUAL
-0106    | JUMP_IF_FALSE      21 (to 0130)
+0106    | JUMP_IF_FALSE      20 (to 0129)
 0109   25 GET_GLOBAL          7 'i'
 0111    | GET_GLOBAL_ADDRESS    3 'data'
-0113    | GET_ELEMENT_ADDRESS    1 (dims)
-0115    | GET_INDIRECT
-0116    | CALL_USER_PROC      15 'printvalue' @0038 (1 args)
-0120   24 GET_GLOBAL          7 'i'
-0122    | CONSTANT            4 '1'
-0124    | ADD
-0125    | SET_GLOBAL          7 'i'
-0127    | JUMP              -29 (to 0101)
-0130    1 HALT
+0113    | LOAD_ELEMENT_VALUE    1 (dims)
+0115    | CALL_USER_PROC      15 'printvalue' @0038 (1 args)
+0119   24 GET_GLOBAL          7 'i'
+0121    | CONSTANT            4 '1'
+0123    | ADD
+0124    | SET_GLOBAL          7 'i'
+0126    | JUMP              -28 (to 0101)
+0129    1 HALT
 == End Disassembly: Pascal/UserProcCallTest ==
 
 Constants (16):\n  0000: STR   "myself"

--- a/Tests/rea/array_element_read.err
+++ b/Tests/rea/array_element_read.err
@@ -1,0 +1,25 @@
+--- Compiling Main Program AST to Bytecode ---
+== Disassembly: Tests/rea/array_element_read.rea ==
+Offset Line Opcode           Operand  Value / Target (Args)
+------ ---- ---------------- -------- --------------------------
+0000    0 CONSTANT            1 'nil'
+0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
+0007    1 DEFINE_GLOBAL    NameIdx:3   'a' Type:ARRAY Dims:1 [0..2] of INT64 ('int')
+0017    2 DEFINE_GLOBAL    NameIdx:7   'value' Type:INT64 ('int')
+0022    | CONSTANT            8 '1'
+0024    | GET_GLOBAL_ADDRESS    3 'a'
+0026    | LOAD_ELEMENT_VALUE    1 (dims)
+0028    | SET_GLOBAL          7 'value'
+0030    0 HALT
+== End Disassembly: Tests/rea/array_element_read.rea ==
+
+Constants (9):\n  0000: STR   "myself"
+  0001: NIL
+  0002: STR   ""
+  0003: STR   "a"
+  0004: INT   0
+  0005: INT   2
+  0006: STR   "int"
+  0007: STR   "value"
+  0008: INT   1
+

--- a/Tests/rea/array_element_read.rea
+++ b/Tests/rea/array_element_read.rea
@@ -1,0 +1,2 @@
+int a[3];
+int value = a[1];

--- a/Tests/rea/field_access_read.err
+++ b/Tests/rea/field_access_read.err
@@ -7,10 +7,9 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0007    2 DEFINE_GLOBAL    NameIdx:3   'p' Type:POINTER ('Point')
 0012    4 DEFINE_GLOBAL    NameIdx:5   'a' Type:INT64 ('int')
 0017    | GET_GLOBAL          3 'p'
-0019    | GET_FIELD_OFFSET    1 (index)
-0021    | GET_INDIRECT
-0022    | SET_GLOBAL          5 'a'
-0024    0 HALT
+0019    | LOAD_FIELD_VALUE    1 (index)
+0021    | SET_GLOBAL          5 'a'
+0023    0 HALT
 == End Disassembly: Tests/rea/field_access_read.rea ==
 
 Constants (7):\n  0000: STR   "myself"

--- a/Tests/rea/myself_keyword.err
+++ b/Tests/rea/myself_keyword.err
@@ -7,42 +7,41 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0007    8 DEFINE_GLOBAL    NameIdx:3   'd' Type:POINTER ('Dummy')
 0012    | ALLOC_OBJECT        3 (fields)
 0014    | SET_GLOBAL          3 'd'
-0016    3 JUMP               24 (to 0043)
+0016    3 JUMP               23 (to 0042)
 
 --- Procedure dummy.test (at 0019) ---
 0019    4 GET_LOCAL           0 (slot)
-0021    | GET_FIELD_OFFSET    2 (index)
-0023    | GET_INDIRECT
-0024    | CONSTANT            5 '0'
-0026    | EQUAL
-0027    | SET_LOCAL           1 (slot)
-0029    5 GET_LOCAL           1 (slot)
-0031    | JUMP_IF_FALSE       8 (to 0042)
-0034    | CONSTANT            6 '1'
-0036    | GET_LOCAL           0 (slot)
-0038    | GET_FIELD_OFFSET    2 (index)
-0040    | SWAP
-0041    | SET_INDIRECT
-0042    3 RETURN
-0043    0 CONSTANT            7 'Value type ARRAY'
-0045    | DEFINE_GLOBAL    NameIdx:8   'dummy_vtable' Type:ARRAY Dims:1 [0..0] of INTEGER ('integer')
-0055    | SET_GLOBAL          8 'dummy_vtable'
-0057    | GET_GLOBAL          3 'd'
-0059    | DUP
-0060    | GET_FIELD_OFFSET    0 (index)
-0062    | GET_GLOBAL_ADDRESS    8 'dummy_vtable'
-0064    | SET_INDIRECT
-0065    | POP
-0066    9 GET_GLOBAL          3 'd'
-0068    | DUP
-0069    | GET_FIELD_OFFSET    0 (index)
-0071    | GET_INDIRECT
-0072    | CONSTANT            5 '0'
-0074    | SWAP
-0075    | GET_ELEMENT_ADDRESS    1 (dims)
-0077    | GET_INDIRECT
-0078    | PROC_CALL_INDIRECT (args=1)
-0080    0 HALT
+0021    | LOAD_FIELD_VALUE    2 (index)
+0023    | CONSTANT            5 '0'
+0025    | EQUAL
+0026    | SET_LOCAL           1 (slot)
+0028    5 GET_LOCAL           1 (slot)
+0030    | JUMP_IF_FALSE       8 (to 0041)
+0033    | CONSTANT            6 '1'
+0035    | GET_LOCAL           0 (slot)
+0037    | GET_FIELD_OFFSET    2 (index)
+0039    | SWAP
+0040    | SET_INDIRECT
+0041    3 RETURN
+0042    0 CONSTANT            7 'Value type ARRAY'
+0044    | DEFINE_GLOBAL    NameIdx:8   'dummy_vtable' Type:ARRAY Dims:1 [0..0] of INTEGER ('integer')
+0054    | SET_GLOBAL          8 'dummy_vtable'
+0056    | GET_GLOBAL          3 'd'
+0058    | DUP
+0059    | GET_FIELD_OFFSET    0 (index)
+0061    | GET_GLOBAL_ADDRESS    8 'dummy_vtable'
+0063    | SET_INDIRECT
+0064    | POP
+0065    9 GET_GLOBAL          3 'd'
+0067    | DUP
+0068    | GET_FIELD_OFFSET    0 (index)
+0070    | GET_INDIRECT
+0071    | CONSTANT            5 '0'
+0073    | SWAP
+0074    | GET_ELEMENT_ADDRESS    1 (dims)
+0076    | GET_INDIRECT
+0077    | PROC_CALL_INDIRECT (args=1)
+0079    0 HALT
 == End Disassembly: Tests/rea/myself_keyword.rea ==
 
 Constants (10):\n  0000: STR   "myself"

--- a/Tests/rea/super_constructor.err
+++ b/Tests/rea/super_constructor.err
@@ -28,10 +28,9 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0046    | RETURN
 0047    4 CONSTANT            8 '1'
 0049    | GET_GLOBAL          3 'c'
-0051    | GET_FIELD_OFFSET    1 (index)
-0053    | GET_INDIRECT
-0054    | CALL_BUILTIN_PROC   176 'write' (2 args)
-0060    0 HALT
+0051    | LOAD_FIELD_VALUE    1 (index)
+0053    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0059    0 HALT
 == End Disassembly: Tests/rea/super_constructor.rea ==
 
 Constants (10):\n  0000: STR   "myself"

--- a/src/compiler/bytecode.c
+++ b/src/compiler/bytecode.c
@@ -149,8 +149,11 @@ int getInstructionLength(BytecodeChunk* chunk, int offset) {
         case GET_UPVALUE_ADDRESS:
         case GET_FIELD_ADDRESS:
         case GET_FIELD_OFFSET:
+        case LOAD_FIELD_VALUE:
+        case LOAD_FIELD_VALUE_BY_NAME:
         case ALLOC_OBJECT:
         case GET_ELEMENT_ADDRESS:
+        case LOAD_ELEMENT_VALUE:
         case GET_CHAR_ADDRESS:
         case INIT_LOCAL_FILE:
             return 2; // 1-byte opcode + 1-byte operand
@@ -179,6 +182,8 @@ int getInstructionLength(BytecodeChunk* chunk, int offset) {
         case CONSTANT16:
         case GET_FIELD_ADDRESS16:
         case GET_FIELD_OFFSET16:
+        case LOAD_FIELD_VALUE16:
+        case LOAD_FIELD_VALUE_BY_NAME16:
         case ALLOC_OBJECT16:
         case GET_GLOBAL16:
         case SET_GLOBAL16:
@@ -639,6 +644,29 @@ int disassembleInstruction(BytecodeChunk* chunk, int offset, HashTable* procedur
             }
             return offset + 3;
         }
+        case LOAD_FIELD_VALUE_BY_NAME: {
+            uint8_t const_idx = chunk->code[offset + 1];
+            fprintf(stderr, "%-16s %4d ", "LOAD_FIELD_VALUE_BY_NAME", const_idx);
+            if (const_idx < chunk->constants_count &&
+                chunk->constants[const_idx].type == TYPE_STRING) {
+                fprintf(stderr, "'%s'\n", AS_STRING(chunk->constants[const_idx]));
+            } else {
+                fprintf(stderr, "<INVALID FIELD CONST>\n");
+            }
+            return offset + 2;
+        }
+        case LOAD_FIELD_VALUE_BY_NAME16: {
+            uint16_t const_idx = (uint16_t)(chunk->code[offset + 1] << 8) |
+                                 chunk->code[offset + 2];
+            fprintf(stderr, "%-16s %4d ", "LOAD_FIELD_VALUE_BY_NAME16", const_idx);
+            if (const_idx < chunk->constants_count &&
+                chunk->constants[const_idx].type == TYPE_STRING) {
+                fprintf(stderr, "'%s'\n", AS_STRING(chunk->constants[const_idx]));
+            } else {
+                fprintf(stderr, "<INVALID FIELD CONST>\n");
+            }
+            return offset + 3;
+        }
         case ALLOC_OBJECT: {
             uint8_t fields = chunk->code[offset + 1];
             fprintf(stderr, "%-16s %4d (fields)\n", "ALLOC_OBJECT", fields);
@@ -661,9 +689,25 @@ int disassembleInstruction(BytecodeChunk* chunk, int offset, HashTable* procedur
             fprintf(stderr, "%-16s %4d (index)\n", "GET_FIELD_OFFSET16", idx);
             return offset + 3;
         }
+        case LOAD_FIELD_VALUE: {
+            uint8_t idx = chunk->code[offset + 1];
+            fprintf(stderr, "%-16s %4d (index)\n", "LOAD_FIELD_VALUE", idx);
+            return offset + 2;
+        }
+        case LOAD_FIELD_VALUE16: {
+            uint16_t idx = (uint16_t)(chunk->code[offset + 1] << 8) |
+                            chunk->code[offset + 2];
+            fprintf(stderr, "%-16s %4d (index)\n", "LOAD_FIELD_VALUE16", idx);
+            return offset + 3;
+        }
         case GET_ELEMENT_ADDRESS: {
             uint8_t dims = chunk->code[offset + 1];
             fprintf(stderr, "%-16s %4d (dims)\n", "GET_ELEMENT_ADDRESS", dims);
+            return offset + 2;
+        }
+        case LOAD_ELEMENT_VALUE: {
+            uint8_t dims = chunk->code[offset + 1];
+            fprintf(stderr, "%-16s %4d (dims)\n", "LOAD_ELEMENT_VALUE", dims);
             return offset + 2;
         }
         case GET_CHAR_ADDRESS:

--- a/src/compiler/bytecode.h
+++ b/src/compiler/bytecode.h
@@ -74,7 +74,10 @@ typedef enum {
 
     GET_FIELD_ADDRESS,
     GET_FIELD_ADDRESS16,
+    LOAD_FIELD_VALUE_BY_NAME,   // Pops base record/pointer, looks up field by name (1-byte const index) and pushes its value
+    LOAD_FIELD_VALUE_BY_NAME16, // Pops base record/pointer, looks up field by name (2-byte const index) and pushes its value
     GET_ELEMENT_ADDRESS,
+    LOAD_ELEMENT_VALUE,  // Pops array/pointer after its indices and pushes a copy of the addressed element's value
     GET_CHAR_ADDRESS, // NEW: Gets address of char in string for s[i] := 'X'
     SET_INDIRECT,
     GET_INDIRECT,
@@ -93,6 +96,8 @@ typedef enum {
     // field.
     GET_FIELD_OFFSET,   // Operand: 1-byte field index
     GET_FIELD_OFFSET16, // Operand: 2-byte field index
+    LOAD_FIELD_VALUE,   // Pops the base record/pointer and pushes a copy of the field value (1-byte offset)
+    LOAD_FIELD_VALUE16, // Pops the base record/pointer and pushes a copy of the field value (2-byte offset)
 
     // For now, built-ins might be handled specially, or we can add a generic call
     CALL_BUILTIN,  // Placeholder for calling built-in functions

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -1618,6 +1618,105 @@ static bool constIsClassMember(AST* node) {
     return false;
 }
 
+static bool pushFieldBaseAndResolveOffset(AST* node, BytecodeChunk* chunk, int line, int* outFieldOffset) {
+    if (!node || node->type != AST_FIELD_ACCESS) {
+        fprintf(stderr, "L%d: Compiler error: Invalid field access expression.\n", line);
+        compiler_had_error = true;
+        return false;
+    }
+
+    AST* base = node->left;
+    if (!base) {
+        fprintf(stderr, "L%d: Compiler error: Field access missing base expression.\n", line);
+        compiler_had_error = true;
+        return false;
+    }
+
+    if (base->var_type == TYPE_POINTER) {
+        compileRValue(base, chunk, getLine(base));
+    } else {
+        compileLValue(base, chunk, getLine(base));
+    }
+
+    AST* recType = getRecordTypeFromExpr(base);
+    if ((!recType || recType->type != AST_RECORD_TYPE) &&
+        base->type == AST_VARIABLE && base->token && base->token->value &&
+        (strcasecmp(base->token->value, "myself") == 0 ||
+         strcasecmp(base->token->value, "my") == 0)) {
+        if (!recType && current_class_record_type && current_class_record_type->type == AST_RECORD_TYPE) {
+            recType = current_class_record_type;
+        }
+        if ((!recType || recType->type != AST_RECORD_TYPE) &&
+            current_function_compiler && current_function_compiler->function_symbol &&
+            current_function_compiler->function_symbol->name) {
+            const char* fname = current_function_compiler->function_symbol->name;
+            const char* dot = strchr(fname, '.');
+            if (dot) {
+                size_t len = (size_t)(dot - fname);
+                char cls[MAX_SYMBOL_LENGTH];
+                if (len >= sizeof(cls)) len = sizeof(cls) - 1;
+                memcpy(cls, fname, len);
+                cls[len] = '\0';
+                for (size_t i = 0; i < len; i++) cls[i] = (char)tolower(cls[i]);
+                recType = lookupType(cls);
+                recType = resolveTypeAlias(recType);
+                if (recType && recType->type == AST_TYPE_DECL && recType->left) {
+                    recType = recType->left;
+                }
+            }
+        }
+        if (!recType || recType->type != AST_RECORD_TYPE) {
+            recType = findRecordTypeByFieldName(node->token ? node->token->value : NULL);
+        }
+    }
+
+    int fieldOffset = getRecordFieldOffset(recType, node->token ? node->token->value : NULL);
+    if (fieldOffset < 0 && recType && base->type == AST_VARIABLE &&
+        base->token && base->token->value &&
+        (strcasecmp(base->token->value, "myself") == 0 ||
+         strcasecmp(base->token->value, "my") == 0)) {
+        int offset = 0;
+        if (recType->extra && recType->extra->token && recType->extra->token->value) {
+            AST* parent = lookupType(recType->extra->token->value);
+            offset = getRecordFieldCount(parent);
+        }
+        for (int i = 0; fieldOffset < 0 && recType && i < recType->child_count; i++) {
+            AST* decl = recType->children[i];
+            if (!decl) continue;
+            if (decl->type == AST_VAR_DECL) {
+                for (int j = 0; j < decl->child_count; j++) {
+                    AST* var = decl->children[j];
+                    if (var && var->token && node->token && node->token->value &&
+                        strcasecmp(var->token->value, node->token->value) == 0) {
+                        fieldOffset = offset;
+                        break;
+                    }
+                    offset++;
+                }
+            } else if (decl->token) {
+                if (node->token && node->token->value &&
+                    strcasecmp(decl->token->value, node->token->value) == 0) {
+                    fieldOffset = offset;
+                    break;
+                }
+                offset++;
+            }
+        }
+    }
+
+    if (recordTypeHasVTable(recType)) fieldOffset++;
+
+    if (fieldOffset < 0) {
+        fprintf(stderr, "L%d: Compiler error: Unknown field '%s'.\n", line,
+                node->token ? node->token->value : "<null>");
+        compiler_had_error = true;
+        return false;
+    }
+
+    if (outFieldOffset) *outFieldOffset = fieldOffset;
+    return true;
+}
+
 static void compileLValue(AST* node, BytecodeChunk* chunk, int current_line_approx) {
     if (!node) return;
     int line = getLine(node);
@@ -1703,7 +1802,6 @@ static void compileLValue(AST* node, BytecodeChunk* chunk, int current_line_appr
             break;
         }
         case AST_FIELD_ACCESS: {
-            // Constants defined in a record cannot have their address taken.
             if (node->token && node->token->value) {
                 Value* const_ptr = findCompilerConstant(node->token->value);
                 if (const_ptr) {
@@ -1715,84 +1813,8 @@ static void compileLValue(AST* node, BytecodeChunk* chunk, int current_line_appr
                 }
             }
 
-            // Base expression might be a record value or a pointer to a record.
-            if (node->left && node->left->var_type == TYPE_POINTER) {
-                compileRValue(node->left, chunk, getLine(node->left));
-            } else {
-                compileLValue(node->left, chunk, getLine(node->left));
-            }
-
-            AST* recType = getRecordTypeFromExpr(node->left);
-            if ((!recType || recType->type != AST_RECORD_TYPE) &&
-                node->left && node->left->type == AST_VARIABLE &&
-                node->left->token && node->left->token->value &&
-                (strcasecmp(node->left->token->value, "myself") == 0 ||
-                 strcasecmp(node->left->token->value, "my") == 0)) {
-                if (!recType && current_class_record_type && current_class_record_type->type == AST_RECORD_TYPE) {
-                    recType = current_class_record_type;
-                }
-                if ((!recType || recType->type != AST_RECORD_TYPE) &&
-                    current_function_compiler && current_function_compiler->function_symbol &&
-                    current_function_compiler->function_symbol->name) {
-                    const char* fname = current_function_compiler->function_symbol->name;
-                    const char* dot = strchr(fname, '.');
-                    if (dot) {
-                        size_t len = (size_t)(dot - fname);
-                        char cls[MAX_SYMBOL_LENGTH];
-                        if (len >= sizeof(cls)) len = sizeof(cls) - 1;
-                        memcpy(cls, fname, len);
-                        cls[len] = '\0';
-                        for (size_t i = 0; i < len; i++) cls[i] = (char)tolower(cls[i]);
-                        recType = lookupType(cls);
-                        recType = resolveTypeAlias(recType);
-                        if (recType && recType->type == AST_TYPE_DECL && recType->left) {
-                            recType = recType->left;
-                        }
-                    }
-                }
-                if (!recType || recType->type != AST_RECORD_TYPE) {
-                    recType = findRecordTypeByFieldName(node->token ? node->token->value : NULL);
-                }
-            }
-            int fieldOffset = getRecordFieldOffset(recType, node->token ? node->token->value : NULL);
-            if (fieldOffset < 0 && recType && node->left && node->left->type == AST_VARIABLE &&
-                node->left->token && node->left->token->value &&
-                (strcasecmp(node->left->token->value, "myself") == 0 ||
-                 strcasecmp(node->left->token->value, "my") == 0)) {
-                // Fallback: case-insensitive search through class fields
-                int offset = 0;
-                if (recType->extra && recType->extra->token && recType->extra->token->value) {
-                    AST* parent = lookupType(recType->extra->token->value);
-                    offset = getRecordFieldCount(parent);
-                }
-                for (int i = 0; fieldOffset < 0 && i < recType->child_count; i++) {
-                    AST* decl = recType->children[i];
-                    if (!decl) continue;
-                    if (decl->type == AST_VAR_DECL) {
-                        for (int j = 0; j < decl->child_count; j++) {
-                            AST* var = decl->children[j];
-                            if (var && var->token && node->token && node->token->value &&
-                                strcasecmp(var->token->value, node->token->value) == 0) {
-                                fieldOffset = offset;
-                                break;
-                            }
-                            offset++;
-                        }
-                    } else if (decl->token) {
-                        if (node->token && node->token->value &&
-                            strcasecmp(decl->token->value, node->token->value) == 0) {
-                            fieldOffset = offset;
-                            break;
-                        }
-                        offset++;
-                    }
-                }
-            }
-            if (recordTypeHasVTable(recType)) fieldOffset++;
-            if (fieldOffset < 0) {
-                fprintf(stderr, "L%d: Compiler error: Unknown field '%s'.\n", line,
-                        node->token ? node->token->value : "<null>");
-                compiler_had_error = true;
+            int fieldOffset = -1;
+            if (!pushFieldBaseAndResolveOffset(node, chunk, line, &fieldOffset)) {
                 break;
             }
 
@@ -4198,9 +4220,18 @@ static void compileRValue(AST* node, BytecodeChunk* chunk, int current_line_appr
                     break;
                 }
             }
-            // Otherwise, load the field address and then fetch its value.
-            compileLValue(node, chunk, getLine(node));
-            writeBytecodeChunk(chunk, GET_INDIRECT, line);
+            int fieldOffset = -1;
+            if (!pushFieldBaseAndResolveOffset(node, chunk, line, &fieldOffset)) {
+                break;
+            }
+
+            if (fieldOffset <= 0xFF) {
+                writeBytecodeChunk(chunk, LOAD_FIELD_VALUE, line);
+                writeBytecodeChunk(chunk, (uint8_t)fieldOffset, line);
+            } else {
+                writeBytecodeChunk(chunk, LOAD_FIELD_VALUE16, line);
+                emitShort(chunk, (uint16_t)fieldOffset, line);
+            }
             break;
         }
         case AST_ARRAY_ACCESS: {
@@ -4212,9 +4243,12 @@ static void compileRValue(AST* node, BytecodeChunk* chunk, int current_line_appr
                 break;
             }
 
-            // Default behavior for actual arrays: get address, then get value.
-            compileLValue(node, chunk, getLine(node));
-            writeBytecodeChunk(chunk, GET_INDIRECT, line);
+            for (int i = 0; i < node->child_count; i++) {
+                compileRValue(node->children[i], chunk, getLine(node->children[i]));
+            }
+            compileLValue(node->left, chunk, getLine(node->left));
+            writeBytecodeChunk(chunk, LOAD_ELEMENT_VALUE, line);
+            writeBytecodeChunk(chunk, (uint8_t)node->child_count, line);
             break;
         }
         case AST_ASSIGN: {


### PR DESCRIPTION
## Summary
- document and expose new LOAD_FIELD_VALUE* and LOAD_ELEMENT_VALUE opcodes
- teach the VM, compiler, and disassembler to emit/use the direct value loads for fields and array elements
- refresh Pascal/REA fixtures and add array_element_read regression to cover the new bytecode

## Testing
- Tests/run_pascal_tests.sh
- Tests/run_rea_tests.sh

------
https://chatgpt.com/codex/tasks/task_e_68cdca842d50832aa541e76e837f525d