### PR TITLE
Restore legacy write builtin id

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -382,7 +382,7 @@ static const VmBuiltinMapping vmBuiltinDispatchTable[] = {
 #ifdef SDL
     {"putpixel", vmBuiltinPutpixel},
 #endif
-    {"quitrequested", vmBuiltinQuitrequested},
+    {"write", vmBuiltinWrite}, // Preserve legacy builtin id for write
 #ifdef SDL
     {"quitsoundsystem", vmBuiltinQuitsoundsystem},
     {"quittextsystem", vmBuiltinQuittextsystem},
@@ -460,7 +460,7 @@ static const VmBuiltinMapping vmBuiltinDispatchTable[] = {
     {"wherex", vmBuiltinWherex},
     {"wherey", vmBuiltinWherey},
     {"window", vmBuiltinWindow},
-    {"write", vmBuiltinWrite},
+    {"quitrequested", vmBuiltinQuitrequested},
     {"to be filled", NULL}
 };
 


### PR DESCRIPTION
## Summary
- restore the write built-in to its legacy numeric identifier by swapping its entry with quitrequested
- keep Pascal bytecode regressions expecting CALL_BUILTIN_PROC 176 unchanged

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce98bec114832a909a8addfd411367