### PR TITLE
Update disassembly expectations for write builtin id

### DIFF
--- a/Tests/Pascal/ShortCircuitTest.disasm
+++ b/Tests/Pascal/ShortCircuitTest.disasm
@@ -14,7 +14,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 --- Function rhs1 (at 0035) ---
 0035    5 CONSTANT            9 '1'
 0037    | CONSTANT           10 'R1'
-0039    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0039    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0045    6 CONSTANT           12 'true'
 0047    | SET_LOCAL           0 (slot)
 0049    3 GET_LOCAL           0 (slot)
@@ -24,7 +24,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 --- Function rhs0 (at 0055) ---
 0055   11 CONSTANT            9 '1'
 0057    | CONSTANT           13 'R0'
-0059    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0059    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0065   12 CONSTANT           14 'false'
 0067    | SET_LOCAL           0 (slot)
 0069    9 GET_LOCAL           0 (slot)
@@ -38,11 +38,11 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0087    | JUMP_IF_FALSE      13 (to 0103)
 0090    | CONSTANT            9 '1'
 0092    | CONSTANT           18 'A triggered'
-0094    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0094    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0100    | JUMP               10 (to 0113)
 0103    | CONSTANT            9 '1'
 0105    | CONSTANT           19 'A skipped'
-0107    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0107    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0113   19 CONSTANT           20 'true'
 0115    | JUMP_IF_FALSE       5 (to 0123)
 0118    | CONSTANT           21 'true'
@@ -52,11 +52,11 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0128    | JUMP_IF_FALSE      13 (to 0144)
 0131    | CONSTANT            9 '1'
 0133    | CONSTANT           22 'B taken'
-0135    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0135    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0141    | JUMP               10 (to 0154)
 0144    | CONSTANT            9 '1'
 0146    | CONSTANT           23 'B skipped'
-0148    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0148    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0154   21 CONSTANT           24 'false'
 0156    | JUMP_IF_FALSE       8 (to 0167)
 0159    | CALL_USER_PROC      16 'rhs1' @0035 (0 args)
@@ -108,7 +108,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0273    | CONSTANT           37 ' '
 0275    | GET_GLOBAL          8 'r4'
 0277    | CALL_BUILTIN        36 'ord' (1 args)
-0281    | CALL_BUILTIN_PROC   176 'write' (11 args)
+0281    | CALL_BUILTIN_PROC   123 'write' (11 args)
 0287    1 HALT
 == End Disassembly: Pascal/ShortCircuitTest ==
 

--- a/Tests/Pascal/UserProcCallTest.disasm
+++ b/Tests/Pascal/UserProcCallTest.disasm
@@ -21,13 +21,13 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0038   13 CONSTANT            4 '1'
 0040    | CONSTANT            9 'value='
 0042    | GET_LOCAL           0 (slot)
-0044    | CALL_BUILTIN_PROC   176 'write' (3 args)
+0044    | CALL_BUILTIN_PROC   123 'write' (3 args)
 0050   11 RETURN
 0051   20 CONSTANT            4 '1'
 0053    | CONSTANT           11 'double='
 0055    | CONSTANT           12 '5'
 0057    | CALL_USER_PROC      13 'doubleit' @0025 (1 args)
-0061    | CALL_BUILTIN_PROC   176 'write' (3 args)
+0061    | CALL_BUILTIN_PROC   123 'write' (3 args)
 0067   21 CONSTANT            5 '3'
 0069    | GET_GLOBAL_ADDRESS    3 'data'
 0071    | GET_ELEMENT_ADDRESS_CONST          0 (flat offset)

--- a/Tests/clike/ShortCircuit.disasm
+++ b/Tests/clike/ShortCircuit.disasm
@@ -8,7 +8,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 --- Routine rhs1 (at 0005) ---
 0005    1 CONSTANT            1 '0'
 0007    | CONSTANT            2 'R1\n'
-0009    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0009    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0015    | CONSTANT            1 '0'
 0017    | POP
 0018    | CONSTANT            4 '1'
@@ -18,7 +18,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 --- Routine rhs0 (at 0022) ---
 0022    2 CONSTANT            1 '0'
 0024    | CONSTANT            5 'R0\n'
-0026    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0026    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0032    | CONSTANT            1 '0'
 0034    | POP
 0035    | CONSTANT            1 '0'
@@ -35,7 +35,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0054    6 JUMP_IF_FALSE      13 (to 0070)
 0057    5 CONSTANT            1 '0'
 0059    | CONSTANT            8 'A\n'
-0061    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0061    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0067    | CONSTANT            1 '0'
 0069    6 POP
 0070    | CONSTANT            4 '1'
@@ -47,7 +47,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0085    7 JUMP_IF_FALSE      13 (to 0101)
 0088    6 CONSTANT            1 '0'
 0090    | CONSTANT           10 'B\n'
-0092    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0092    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0098    | CONSTANT            1 '0'
 0100    7 POP
 0101    | CONSTANT            4 '1'
@@ -59,7 +59,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0116    8 JUMP_IF_FALSE      13 (to 0132)
 0119    7 CONSTANT            1 '0'
 0121    | CONSTANT           12 'C\n'
-0123    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0123    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0129    | CONSTANT            1 '0'
 0131    8 POP
 0132    | CONSTANT            1 '0'
@@ -71,7 +71,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0147    9 JUMP_IF_FALSE      13 (to 0163)
 0150    8 CONSTANT            1 '0'
 0152    | CONSTANT           15 'D\n'
-0154    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0154    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0160    | CONSTANT            1 '0'
 0162    9 POP
 0163    | CONSTANT            1 '0'
@@ -84,7 +84,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0177    9 CONSTANT           17 ' '
 0179    0 CONSTANT            4 '1'
 0181    9 CONSTANT           18 '\n'
-0183    | CALL_BUILTIN_PROC   176 'write' (10 args)
+0183    | CALL_BUILTIN_PROC   123 'write' (10 args)
 0189    | CONSTANT            1 '0'
 0191   10 POP
 0192    | CONSTANT            1 '0'

--- a/Tests/rea/class_instantiation.err
+++ b/Tests/rea/class_instantiation.err
@@ -9,7 +9,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0014    | SET_GLOBAL          3 'd'
 0016    3 CONSTANT            5 '1'
 0018    | CONSTANT            5 '1'
-0020    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0020    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0026    0 HALT
 == End Disassembly: Tests/rea/class_instantiation.rea ==
 

--- a/Tests/rea/printf_format.err
+++ b/Tests/rea/printf_format.err
@@ -12,7 +12,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0018    | CONSTANT            7 '1.234560'
 0020    | FORMAT_VALUE     width:0 prec:2
 0023    | CONSTANT            8 '\n'
-0025    | CALL_BUILTIN_PROC   176 'write' (6 args)
+0025    | CALL_BUILTIN_PROC   123 'write' (6 args)
 0031    0 HALT
 == End Disassembly: Tests/rea/printf_format.rea ==
 

--- a/Tests/rea/short_circuit.disasm
+++ b/Tests/rea/short_circuit.disasm
@@ -49,7 +49,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 --- Function rhs_true (at 0120) ---
 0120    2 CONSTANT           21 '1'
 0122    | CONSTANT           22 'R1'
-0124    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0124    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0130    3 CONSTANT           24 'true'
 0132    | RETURN
 0133    1 GET_LOCAL           0 (slot)
@@ -59,7 +59,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 --- Function rhs_false (at 0139) ---
 0139    7 CONSTANT           21 '1'
 0141    | CONSTANT           25 'R0'
-0143    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0143    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0149    8 CONSTANT           26 'false'
 0151    | RETURN
 0152    6 GET_LOCAL           0 (slot)
@@ -73,11 +73,11 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0170    | JUMP_IF_FALSE      13 (to 0186)
 0173   12 CONSTANT           21 '1'
 0175    | CONSTANT           29 'A hit'
-0177    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0177    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0183   11 JUMP               10 (to 0196)
 0186   14 CONSTANT           21 '1'
 0188    | CONSTANT           30 'A skip'
-0190    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0190    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0196   17 CONSTANT           31 'true'
 0198    | JUMP_IF_FALSE       5 (to 0206)
 0201    | CONSTANT           32 'true'
@@ -87,11 +87,11 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0211    | JUMP_IF_FALSE      13 (to 0227)
 0214   18 CONSTANT           21 '1'
 0216    | CONSTANT           33 'B hit'
-0218    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0218    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0224   17 JUMP               10 (to 0237)
 0227   20 CONSTANT           21 '1'
 0229    | CONSTANT           34 'B skip'
-0231    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0231    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0237   29 CONSTANT           21 '1'
 0239    | CONSTANT           35 'vals:'
 0241    | GET_GLOBAL          3 'r0'
@@ -103,7 +103,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0253    | GET_GLOBAL         14 'r3'
 0255    | CONSTANT           36 ' '
 0257    | GET_GLOBAL         18 'r4'
-0259    | CALL_BUILTIN_PROC   176 'write' (11 args)
+0259    | CALL_BUILTIN_PROC   123 'write' (11 args)
 0265    0 HALT
 == End Disassembly: Tests/rea/short_circuit.rea ==
 

--- a/Tests/rea/super_constructor.err
+++ b/Tests/rea/super_constructor.err
@@ -29,7 +29,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0047    4 CONSTANT            8 '1'
 0049    | GET_GLOBAL          3 'c'
 0051    | LOAD_FIELD_VALUE    1 (index)
-0053    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0053    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0059    0 HALT
 == End Disassembly: Tests/rea/super_constructor.rea ==
 

--- a/Tests/rea/super_method.err
+++ b/Tests/rea/super_method.err
@@ -16,7 +16,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 --- Procedure base.speak (at 0023) ---
 0023    | CONSTANT            5 '1'
 0025    | CONSTANT            6 'base'
-0027    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0027    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0033    | RETURN
 0034    2 JUMP                7 (to 0044)
 

--- a/Tests/rea/switch_stmt.err
+++ b/Tests/rea/switch_stmt.err
@@ -15,7 +15,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0025    | POP
 0026    4 CONSTANT            6 '1'
 0028    | CONSTANT            6 '1'
-0030    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0030    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0036    2 JUMP               32 (to 0071)
 0039    | DUP
 0040    6 CONSTANT            5 '2'
@@ -24,12 +24,12 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0046    | POP
 0047    7 CONSTANT            6 '1'
 0049    | CONSTANT            5 '2'
-0051    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0051    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0057    2 JUMP               11 (to 0071)
 0060    | POP
 0061   10 CONSTANT            6 '1'
 0063    | CONSTANT            8 '3'
-0065    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0065    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0071    0 HALT
 == End Disassembly: Tests/rea/switch_stmt.rea ==
 

--- a/Tests/rea/write_sugar.err
+++ b/Tests/rea/write_sugar.err
@@ -7,10 +7,10 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0007    1 CONSTANT            3 '1'
 0009    | CONSTANT            4 'A'
 0011    | CONSTANT            3 '1'
-0013    | CALL_BUILTIN_PROC   176 'write' (3 args)
+0013    | CALL_BUILTIN_PROC   123 'write' (3 args)
 0019    2 CONSTANT            6 '0'
 0021    | CONSTANT            7 'B'
-0023    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0023    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0029    0 HALT
 == End Disassembly: Tests/rea/write_sugar.rea ==
 

--- a/Tests/rea/writeln_format.err
+++ b/Tests/rea/writeln_format.err
@@ -7,7 +7,7 @@ Offset Line Opcode           Operand  Value / Target (Args)
 0007    1 CONSTANT            3 '1'
 0009    | CONSTANT            4 '3.141590'
 0011    | FORMAT_VALUE     width:0 prec:2
-0014    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0014    | CALL_BUILTIN_PROC   123 'write' (2 args)
 0020    0 HALT
 == End Disassembly: Tests/rea/writeln_format.rea ==
 


### PR DESCRIPTION
## Summary
- update Pascal, CLike, and Rea disassembly fixtures to expect the restored builtin id for `write`
- ensure Rea bytecode expectation files include the standard compile header line

## Testing
- ./run_all_tests

------
https://chatgpt.com/codex/tasks/task_e_68ce9ff94444832a8b726740d25048c7