### PR TITLE
Ensure extended builtins register compiler metadata

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -480,9 +480,19 @@ static void initBuiltinRegistryMutex(void) {
     pthread_mutexattr_destroy(&attr);
 }
 
-void registerVmBuiltin(const char *name, VmBuiltinFn handler) {
+void registerVmBuiltin(const char *name, VmBuiltinFn handler,
+        BuiltinRoutineType type, const char *display_name) {
     if (!name || !handler) return;
     pthread_once(&builtin_registry_once, initBuiltinRegistryMutex);
+
+    if (type == BUILTIN_TYPE_FUNCTION || type == BUILTIN_TYPE_PROCEDURE) {
+        const char *reg_name = display_name ? display_name : name;
+        ASTNodeType declType = (type == BUILTIN_TYPE_FUNCTION)
+                                   ? AST_FUNCTION_DECL
+                                   : AST_PROCEDURE_DECL;
+        registerBuiltinFunction(reg_name, declType, NULL);
+    }
+
     pthread_mutex_lock(&builtin_registry_mutex);
     VmBuiltinMapping *new_table = realloc(extra_vm_builtins,
         sizeof(VmBuiltinMapping) * (num_extra_vm_builtins + 1));
@@ -4089,11 +4099,11 @@ void registerAllBuiltins(void) {
     /* Allow externally linked modules to add more builtins. */
     registerExtendedBuiltins();
     /* CLike-style cast helper synonyms to avoid keyword collisions */
-    registerVmBuiltin("toint",    vmBuiltinToInt);
-    registerVmBuiltin("todouble", vmBuiltinToDouble);
-    registerVmBuiltin("tofloat",  vmBuiltinToFloat);
-    registerVmBuiltin("tochar",   vmBuiltinToChar);
-    registerVmBuiltin("tobool",   vmBuiltinToBool);
-    registerVmBuiltin("tobyte",   vmBuiltinToByte);
+    registerVmBuiltin("toint",    vmBuiltinToInt,    BUILTIN_TYPE_FUNCTION, NULL);
+    registerVmBuiltin("todouble", vmBuiltinToDouble, BUILTIN_TYPE_FUNCTION, NULL);
+    registerVmBuiltin("tofloat",  vmBuiltinToFloat,  BUILTIN_TYPE_FUNCTION, NULL);
+    registerVmBuiltin("tochar",   vmBuiltinToChar,   BUILTIN_TYPE_FUNCTION, NULL);
+    registerVmBuiltin("tobool",   vmBuiltinToBool,   BUILTIN_TYPE_FUNCTION, NULL);
+    registerVmBuiltin("tobyte",   vmBuiltinToByte,   BUILTIN_TYPE_FUNCTION, NULL);
     pthread_mutex_unlock(&builtin_registry_mutex);
 }

--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -9,6 +9,12 @@ struct VM_s;
 
 typedef Value (*VmBuiltinFn)(struct VM_s* vm, int arg_count, Value* args);
 
+typedef enum {
+    BUILTIN_TYPE_NONE,
+    BUILTIN_TYPE_PROCEDURE,
+    BUILTIN_TYPE_FUNCTION
+} BuiltinRoutineType;
+
 typedef struct {
     const char* name;
     VmBuiltinFn handler;
@@ -17,7 +23,8 @@ typedef struct {
 VmBuiltinFn getVmBuiltinHandler(const char* name);
 VmBuiltinFn getVmBuiltinHandlerById(int id);
 const char* getVmBuiltinNameById(int id);
-void registerVmBuiltin(const char *name, VmBuiltinFn handler);
+void registerVmBuiltin(const char *vm_name, VmBuiltinFn handler,
+                       BuiltinRoutineType type, const char *display_name);
 
 /* Optional hook for externally linked built-ins.  The weak
  * definition in builtin.c does nothing unless overridden. */
@@ -155,12 +162,6 @@ Value vmBuiltinDosGettime(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinDosGetfattr(struct VM_s* vm, int arg_count, Value* args);
 
 int getBuiltinIDForCompiler(const char *name);
-
-typedef enum {
-    BUILTIN_TYPE_NONE,
-    BUILTIN_TYPE_PROCEDURE,
-    BUILTIN_TYPE_FUNCTION
-} BuiltinRoutineType;
 
 void registerBuiltinFunction(const char *name, ASTNodeType declType, const char* unit_context_name_param_for_addproc);
 int isBuiltin(const char *name);

--- a/src/ext_builtins/math/chudnovsky.c
+++ b/src/ext_builtins/math/chudnovsky.c
@@ -33,6 +33,6 @@ static Value vmBuiltinChudnovsky(struct VM_s* vm, int arg_count, Value* args) {
 }
 
 void registerChudnovskyBuiltin(void) {
-    registerBuiltinFunction("Chudnovsky", AST_FUNCTION_DECL, NULL);
-    registerVmBuiltin("chudnovsky", vmBuiltinChudnovsky);
+    registerVmBuiltin("chudnovsky", vmBuiltinChudnovsky,
+                      BUILTIN_TYPE_FUNCTION, "Chudnovsky");
 }

--- a/src/ext_builtins/math/factorial.c
+++ b/src/ext_builtins/math/factorial.c
@@ -23,6 +23,6 @@ static Value vmBuiltinFactorial(struct VM_s* vm, int arg_count, Value* args) {
 }
 
 void registerFactorialBuiltin(void) {
-    registerBuiltinFunction("Factorial", AST_FUNCTION_DECL, NULL);
-    registerVmBuiltin("factorial", vmBuiltinFactorial);
+    registerVmBuiltin("factorial", vmBuiltinFactorial,
+                      BUILTIN_TYPE_FUNCTION, "Factorial");
 }

--- a/src/ext_builtins/math/fibonacci.c
+++ b/src/ext_builtins/math/fibonacci.c
@@ -55,6 +55,6 @@ static Value vmBuiltinFibonacci(struct VM_s* vm, int arg_count, Value* args) {
 }
 
 void registerFibonacciBuiltin(void) {
-    registerBuiltinFunction("Fibonacci", AST_FUNCTION_DECL, NULL);
-    registerVmBuiltin("fibonacci", vmBuiltinFibonacci);
+    registerVmBuiltin("fibonacci", vmBuiltinFibonacci,
+                      BUILTIN_TYPE_FUNCTION, "Fibonacci");
 }

--- a/src/ext_builtins/math/mandelbrot.c
+++ b/src/ext_builtins/math/mandelbrot.c
@@ -80,7 +80,7 @@ static Value vmBuiltinMandelbrotRow(struct VM_s* vm, int arg_count, Value* args)
 }
 
 void registerMandelbrotRowBuiltin(void) {
-    registerBuiltinFunction("MandelbrotRow", AST_PROCEDURE_DECL, NULL);
-    registerVmBuiltin("mandelbrotrow", vmBuiltinMandelbrotRow);
+    registerVmBuiltin("mandelbrotrow", vmBuiltinMandelbrotRow,
+                      BUILTIN_TYPE_PROCEDURE, "MandelbrotRow");
 }
 

--- a/src/ext_builtins/query_builtin.c
+++ b/src/ext_builtins/query_builtin.c
@@ -19,6 +19,6 @@ static Value vmBuiltinHasExtBuiltin(struct VM_s *vm, int arg_count,
 }
 
 void registerHasExtBuiltin(void) {
-  registerBuiltinFunction("HasExtBuiltin", AST_FUNCTION_DECL, NULL);
-  registerVmBuiltin("hasextbuiltin", vmBuiltinHasExtBuiltin);
+  registerVmBuiltin("hasextbuiltin", vmBuiltinHasExtBuiltin,
+                    BUILTIN_TYPE_FUNCTION, "HasExtBuiltin");
 }

--- a/src/ext_builtins/strings/atoi.c
+++ b/src/ext_builtins/strings/atoi.c
@@ -20,7 +20,7 @@ static Value vmBuiltinAtoi(struct VM_s* vm, int arg_count, Value* args) {
 }
 
 void registerAtoiBuiltin(void) {
-    registerBuiltinFunction("Atoi", AST_FUNCTION_DECL, NULL);
-    registerVmBuiltin("atoi", vmBuiltinAtoi);
+    registerVmBuiltin("atoi", vmBuiltinAtoi,
+                      BUILTIN_TYPE_FUNCTION, "Atoi");
 }
 

--- a/src/ext_builtins/system/fileexists.c
+++ b/src/ext_builtins/system/fileexists.c
@@ -25,7 +25,7 @@ static Value vmBuiltinFileExists(struct VM_s* vm, int arg_count, Value* args) {
 }
 
 void registerFileExistsBuiltin(void) {
-    registerBuiltinFunction("FileExists", AST_FUNCTION_DECL, NULL);
-    registerVmBuiltin("fileexists", vmBuiltinFileExists);
+    registerVmBuiltin("fileexists", vmBuiltinFileExists,
+                      BUILTIN_TYPE_FUNCTION, "FileExists");
 }
 

--- a/src/ext_builtins/system/getpid.c
+++ b/src/ext_builtins/system/getpid.c
@@ -8,7 +8,7 @@ static Value vmBuiltinGetPid(struct VM_s* vm, int arg_count, Value* args) {
 }
 
 void registerGetPidBuiltin(void) {
-    registerBuiltinFunction("GetPid", AST_FUNCTION_DECL, NULL);
-    registerVmBuiltin("getpid", vmBuiltinGetPid);
+    registerVmBuiltin("getpid", vmBuiltinGetPid,
+                      BUILTIN_TYPE_FUNCTION, "GetPid");
 }
 

--- a/src/ext_builtins/system/swap.c
+++ b/src/ext_builtins/system/swap.c
@@ -28,7 +28,7 @@ static Value vmBuiltinSwap(struct VM_s* vm, int arg_count, Value* args) {
 }
 
 void registerSwapBuiltin(void) {
-    registerBuiltinFunction("Swap", AST_PROCEDURE_DECL, NULL);
-    registerVmBuiltin("swap", vmBuiltinSwap);
+    registerVmBuiltin("swap", vmBuiltinSwap,
+                      BUILTIN_TYPE_PROCEDURE, "Swap");
 }
 


### PR DESCRIPTION
## Summary
- update `registerVmBuiltin` so registering a VM builtin also records its compile-time signature
- switch all extended builtin registration helpers, including MandelbrotRow, to the new API so their types stay in sync

## Testing
- cmake --build build
- build/bin/rea Tests/rea/mandelbrotrow.rea
- cmake --build build_nomath --target rea

------
https://chatgpt.com/codex/tasks/task_e_68cecad36ef8832a8dd5621fab630761