### PR TITLE
Ensure Pascal cache invalidates when units change and support no-cache test runs

### DIFF
--- a/Tests/run_clike_tests.sh
+++ b/Tests/run_clike_tests.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 CLIKE_BIN="$ROOT_DIR/build/bin/clike"
+CLIKE_ARGS=(--no-cache)
 RUNNER_PY="$ROOT_DIR/Tests/tools/run_with_timeout.py"
 TEST_TIMEOUT="${TEST_TIMEOUT:-25}"
 
@@ -51,7 +52,7 @@ for src in "$SCRIPT_DIR"/clike/*.cl; do
     disasm_stdout=$(mktemp)
     disasm_stderr=$(mktemp)
     set +e
-    python3 "$RUNNER_PY" --timeout "$TEST_TIMEOUT" "$CLIKE_BIN" --dump-bytecode-only "$src" \
+    python3 "$RUNNER_PY" --timeout "$TEST_TIMEOUT" "$CLIKE_BIN" "${CLIKE_ARGS[@]}" --dump-bytecode-only "$src" \
       > "$disasm_stdout" 2> "$disasm_stderr"
     disasm_status=$?
     set -e
@@ -94,9 +95,9 @@ for src in "$SCRIPT_DIR"/clike/*.cl; do
 
   set +e
   if [ -f "$in_file" ]; then
-    python3 "$RUNNER_PY" --timeout "$TEST_TIMEOUT" "$CLIKE_BIN" "$src" < "$in_file" > "$actual_out" 2> "$actual_err"
+    python3 "$RUNNER_PY" --timeout "$TEST_TIMEOUT" "$CLIKE_BIN" "${CLIKE_ARGS[@]}" "$src" < "$in_file" > "$actual_out" 2> "$actual_err"
   else
-    python3 "$RUNNER_PY" --timeout "$TEST_TIMEOUT" "$CLIKE_BIN" "$src" > "$actual_out" 2> "$actual_err"
+    python3 "$RUNNER_PY" --timeout "$TEST_TIMEOUT" "$CLIKE_BIN" "${CLIKE_ARGS[@]}" "$src" > "$actual_out" 2> "$actual_err"
   fi
   run_status=$?
   set -e

--- a/Tests/run_json2bc_tests.sh
+++ b/Tests/run_json2bc_tests.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 CLIKE_BIN="$ROOT_DIR/build/bin/clike"
+CLIKE_ARGS=(--no-cache)
 JSON2BC_BIN="$ROOT_DIR/build/bin/pscaljson2bc"
 PSCALVM_BIN="$ROOT_DIR/build/bin/pscalvm"
 
@@ -39,7 +40,7 @@ for src in "$SCRIPT_DIR"/json2bc/*.cl; do
   echo "---- json2bc:$test_name ----"
   set +e
   # Pipe AST JSON from clike to pscaljson2bc, then run the VM
-  "$CLIKE_BIN" --dump-ast-json "$src" | "$JSON2BC_BIN" -o "$tmp_bc" > "$actual_err" 2>&1
+  "$CLIKE_BIN" "${CLIKE_ARGS[@]}" --dump-ast-json "$src" | "$JSON2BC_BIN" -o "$tmp_bc" > "$actual_err" 2>&1
   run_status=$?
   if [ $run_status -ne 0 ]; then
     echo "json2bc compile failed for $test_name" >&2

--- a/Tests/run_pascal_tests.sh
+++ b/Tests/run_pascal_tests.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 PASCAL_BIN="$ROOT_DIR/build/bin/pascal"
+PASCAL_ARGS=(--no-cache)
 
 if [ ! -x "$PASCAL_BIN" ]; then
   echo "pascal binary not found at $PASCAL_BIN" >&2
@@ -75,7 +76,7 @@ for src in "$SCRIPT_DIR"/Pascal/*; do
     disasm_stdout=$(mktemp)
     disasm_stderr=$(mktemp)
     set +e
-    (cd "$SCRIPT_DIR" && "$PASCAL_BIN" --dump-bytecode-only "Pascal/$test_name") \
+    (cd "$SCRIPT_DIR" && "$PASCAL_BIN" "${PASCAL_ARGS[@]}" --dump-bytecode-only "Pascal/$test_name") \
       > "$disasm_stdout" 2> "$disasm_stderr"
     disasm_status=$?
     set -e
@@ -93,11 +94,11 @@ for src in "$SCRIPT_DIR"/Pascal/*; do
 
   set +e
   if [ "$test_name" = "SDLFeaturesTest" ]; then
-    (cd "$SCRIPT_DIR" && printf 'Q\n' | "$PASCAL_BIN" "Pascal/$test_name" > "$actual_out" 2> "$actual_err")
+    (cd "$SCRIPT_DIR" && printf 'Q\n' | "$PASCAL_BIN" "${PASCAL_ARGS[@]}" "Pascal/$test_name" > "$actual_out" 2> "$actual_err")
   elif [ -f "$in_file" ]; then
-    (cd "$SCRIPT_DIR" && "$PASCAL_BIN" "Pascal/$test_name" < "$in_file" > "$actual_out" 2> "$actual_err")
+    (cd "$SCRIPT_DIR" && "$PASCAL_BIN" "${PASCAL_ARGS[@]}" "Pascal/$test_name" < "$in_file" > "$actual_out" 2> "$actual_err")
   else
-    (cd "$SCRIPT_DIR" && "$PASCAL_BIN" "Pascal/$test_name" > "$actual_out" 2> "$actual_err")
+    (cd "$SCRIPT_DIR" && "$PASCAL_BIN" "${PASCAL_ARGS[@]}" "Pascal/$test_name" > "$actual_out" 2> "$actual_err")
   fi
   run_status=$?
   set -e

--- a/src/Pascal/parser.h
+++ b/src/Pascal/parser.h
@@ -4,6 +4,7 @@
 #include "types.h"
 #include "lexer.h"
 #include "ast/ast.h"
+#include "core/list.h"
 #include <stdbool.h>
 #include "compiler/bytecode.h"
 
@@ -11,6 +12,7 @@ typedef struct {
     Lexer *lexer;
     Token *current_token;
     const char *current_unit_name_context;
+    List *dependency_paths;
 } Parser;
 
 AST *parsePointerType(Parser *parser);

--- a/src/clike/main.c
+++ b/src/clike/main.c
@@ -35,8 +35,9 @@ static const char *CLIKE_USAGE =
     "   Options:\n"
     "     --dump-ast-json             Dump AST to JSON and exit.\n"
     "     --dump-bytecode             Dump compiled bytecode before execution.\n"
-"     --dump-bytecode-only       Dump compiled bytecode and exit (no execution).\n"
-"     --vm-trace-head=N          Trace first N VM instructions (also enabled by 'trace on' in source).\n";
+    "     --dump-bytecode-only        Dump compiled bytecode and exit (no execution).\n"
+    "     --no-cache                  Compile fresh (ignore cached bytecode).\n"
+    "     --vm-trace-head=N           Trace first N VM instructions (also enabled by 'trace on' in source).\n";
 
 static char* resolveImportPath(const char* orig_path) {
     FILE *f = fopen(orig_path, "rb");
@@ -69,6 +70,7 @@ int main(int argc, char **argv) {
     int dump_bytecode_flag = 0;
     int dump_bytecode_only_flag = 0;
     int vm_trace_head = 0;
+    int no_cache_flag = 0;
     const char *path = NULL;
     int clike_params_start = 0;
 
@@ -85,6 +87,8 @@ int main(int argc, char **argv) {
         } else if (strcmp(argv[i], "--dump-bytecode-only") == 0) {
             dump_bytecode_flag = 1;
             dump_bytecode_only_flag = 1;
+        } else if (strcmp(argv[i], "--no-cache") == 0) {
+            no_cache_flag = 1;
         } else if (strncmp(argv[i], "--vm-trace-head=", 16) == 0) {
             vm_trace_head = atoi(argv[i] + 16);
         } else if (argv[i][0] == '-') {
@@ -203,7 +207,10 @@ int main(int argc, char **argv) {
     }
     BytecodeChunk chunk;
     initBytecodeChunk(&chunk);
-    bool used_cache = loadBytecodeFromCache(path, argv[0], (const char**)dep_paths, clike_import_count, &chunk);
+    bool used_cache = false;
+    if (!no_cache_flag) {
+        used_cache = loadBytecodeFromCache(path, argv[0], (const char**)dep_paths, clike_import_count, &chunk);
+    }
     if (dep_paths) {
         for (int i = 0; i < clike_import_count; ++i) free(dep_paths[i]);
         free(dep_paths);

--- a/src/rea/main.c
+++ b/src/rea/main.c
@@ -143,6 +143,7 @@ static void processUnitList(List* unit_list, BytecodeChunk* chunk) {
         nested_parser_instance.lexer = &nested_lexer;
         nested_parser_instance.current_token = getNextToken(&nested_lexer);
         nested_parser_instance.current_unit_name_context = lower_used_unit_name;
+        nested_parser_instance.dependency_paths = NULL;
 
         AST *parsed_unit_ast = unitParser(&nested_parser_instance, 1, lower_used_unit_name, chunk);
 


### PR DESCRIPTION
## Summary
- collect Pascal unit file dependencies while parsing and hand them to the cache loader so cached bytecode rebuilds after unit edits
- propagate the dependency tracking through nested unit parsing and initialize the new parser field for Rea’s Pascal importer
- add a --no-cache option to the Pascal and CLike front ends and run the Pascal, CLike, and json2bc tests without reusing cached bytecode

## Testing
- Tests/run_all_tests

------
https://chatgpt.com/codex/tasks/task_e_68cede29f250832a9361065cd360ec79