### PR TITLE
Speed up regression test scripts

### DIFF
--- a/Tests/clike/HttpServerCases.net
+++ b/Tests/clike/HttpServerCases.net
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import os
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 class Handler(BaseHTTPRequestHandler):
@@ -19,4 +20,12 @@ class Handler(BaseHTTPRequestHandler):
         pass
 
 if __name__ == '__main__':
-    HTTPServer(('127.0.0.1', 8081), Handler).serve_forever()
+    ready_file = os.environ.get('PSCAL_NET_READY_FILE')
+    server = HTTPServer(('127.0.0.1', 8081), Handler)
+    if ready_file:
+        try:
+            with open(ready_file, 'w', encoding='utf-8') as f:
+                f.write('ready\n')
+        except OSError:
+            pass
+    server.serve_forever()


### PR DESCRIPTION
## Summary
- add a reusable `shift_mtime` helper in the Pascal, Rea, and CLike regression harnesses so cache timestamp checks no longer rely on multi-second sleeps
- update the CLike network test harness to wait on a readiness file and terminate servers via polling instead of fixed delays
- teach `HttpServerCases.net` to create the readiness marker expected by the harness

## Testing
- Tests/run_pascal_tests.sh
- Tests/run_rea_tests.sh
- RUN_NET_TESTS=1 Tests/run_clike_tests.sh

------
https://chatgpt.com/codex/tasks/task_e_68ceeb045af4832a8bbdc189efef2f30