### PR TITLE
Adjust SDL landscape controls and size

### DIFF
--- a/Examples/rea/sdl_landscape
+++ b/Examples/rea/sdl_landscape
@@ -5,7 +5,7 @@
 
 const int WindowWidth = 1280;
 const int WindowHeight = 720;
-const int TerrainSize = 128;
+const int TerrainSize = 256;
 const int VertexStride = TerrainSize + 1;
 const int VertexCount = VertexStride * VertexStride;
 const float TileScale = 1.2;
@@ -400,8 +400,8 @@ class LandscapeDemo {
       }
     }
 
-    bool forward = IsKeyDown(ScanCodeW);
-    bool backward = IsKeyDown(ScanCodeS);
+    bool forward = IsKeyDown(ScanCodeS);
+    bool backward = IsKeyDown(ScanCodeW);
 
     float moveForward = 0.0;
     if (forward) moveForward = moveForward + 1.0;


### PR DESCRIPTION
## Summary
- double the terrain grid resolution for the SDL landscape demo to expand the map in both axes
- swap the forward/backward key handling so the W and S keys trade behaviors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf58a1bfd8832aa524ed8bafd390b9