### PR TITLE
Fix Rea method call type retention

### DIFF
--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -1042,10 +1042,12 @@ void freeProcedureTable(void) {
                 freeAST(current_sym->type_def);
                 current_sym->type_def = NULL;
             }
-            
-            // Note: current_sym->value should be NULL for procedure/function symbols
-            // as they don't have a "value" in the variable sense. If it could be non-NULL,
-            // it would need freeing: if (current_sym->value) { freeValue(current_sym->value); free(current_sym->value); }
+
+            if (current_sym->value) {
+                freeValue(current_sym->value);
+                free(current_sym->value);
+                current_sym->value = NULL;
+            }
 
             free(current_sym); // Free the Symbol struct itself
             


### PR DESCRIPTION
## Summary
- retain the original Rea method AST on the procedure table entry so forward references keep full type metadata
- refresh procedure table copies after semantic analysis to mirror annotated method bodies
- free any stored method metadata when releasing the procedure table

## Testing
- build/bin/rea --dump-bytecode-only --no-cache Examples/rea/sdl_landscape

------
https://chatgpt.com/codex/tasks/task_e_68cf79b77abc832a88f5c3312ff563ab