### PR TITLE
Add hangman5 regression test for vtable emission

### DIFF
--- a/Tests/rea/constructor_init.err
+++ b/Tests/rea/constructor_init.err
@@ -4,21 +4,21 @@ Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
 0000    0 CONSTANT            1 'nil'
 0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
-0007    2 DEFINE_GLOBAL    NameIdx:3   'p' Type:POINTER ('Point')
-0012    | ALLOC_OBJECT        2 (fields)
-0014    | DUP
-0015    | CONSTANT            5 '5'
-0017    | CALL_USER_PROC       6 'point' @0026 (2 args)
-0021    | SET_GLOBAL          3 'p'
-0023    1 JUMP                9 (to 0035)
+0007    1 JUMP                9 (to 0019)
 
---- Procedure point.point (at 0026) ---
-0026    | GET_LOCAL           1 (slot)
-0028    | GET_LOCAL           0 (slot)
-0030    | GET_FIELD_OFFSET    1 (index)
-0032    | SWAP
-0033    | SET_INDIRECT
-0034    | RETURN
+--- Procedure point.point (at 0010) ---
+0010    | GET_LOCAL           1 (slot)
+0012    | GET_LOCAL           0 (slot)
+0014    | GET_FIELD_OFFSET    1 (index)
+0016    | SWAP
+0017    | SET_INDIRECT
+0018    | RETURN
+0019    2 DEFINE_GLOBAL    NameIdx:3   'p' Type:POINTER ('Point')
+0024    | ALLOC_OBJECT        2 (fields)
+0026    | DUP
+0027    | CONSTANT            5 '5'
+0029    | CALL_USER_PROC       6 'point' @0010 (2 args)
+0033    | SET_GLOBAL          3 'p'
 0035    0 HALT
 == End Disassembly: Tests/rea/constructor_init.rea ==
 

--- a/Tests/rea/myself_keyword.err
+++ b/Tests/rea/myself_keyword.err
@@ -4,39 +4,39 @@ Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
 0000    0 CONSTANT            1 'nil'
 0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
-0007    8 DEFINE_GLOBAL    NameIdx:3   'd' Type:POINTER ('Dummy')
-0012    | ALLOC_OBJECT        3 (fields)
-0014    | SET_GLOBAL          3 'd'
-0016    3 JUMP               23 (to 0042)
+0007    3 JUMP               23 (to 0033)
 
---- Procedure dummy.test (at 0019) ---
-0019    4 GET_LOCAL           0 (slot)
-0021    | LOAD_FIELD_VALUE    2 (index)
-0023    | CONSTANT            5 '0'
-0025    | EQUAL
-0026    | SET_LOCAL           1 (slot)
-0028    5 GET_LOCAL           1 (slot)
-0030    | JUMP_IF_FALSE       8 (to 0041)
-0033    | CONSTANT            6 '1'
-0035    | GET_LOCAL           0 (slot)
-0037    | GET_FIELD_OFFSET    2 (index)
-0039    | SWAP
-0040    | SET_INDIRECT
-0041    3 RETURN
-0042    0 CONSTANT            7 'Value type ARRAY'
-0044    | DEFINE_GLOBAL    NameIdx:8   'dummy_vtable' Type:ARRAY Dims:1 [0..0] of INTEGER ('integer')
-0054    | SET_GLOBAL          8 'dummy_vtable'
-0056    | GET_GLOBAL          3 'd'
+--- Procedure dummy.test (at 0010) ---
+0010    4 GET_LOCAL           0 (slot)
+0012    | LOAD_FIELD_VALUE    2 (index)
+0014    | CONSTANT            3 '0'
+0016    | EQUAL
+0017    | SET_LOCAL           1 (slot)
+0019    5 GET_LOCAL           1 (slot)
+0021    | JUMP_IF_FALSE       8 (to 0032)
+0024    | CONSTANT            4 '1'
+0026    | GET_LOCAL           0 (slot)
+0028    | GET_FIELD_OFFSET    2 (index)
+0030    | SWAP
+0031    | SET_INDIRECT
+0032    3 RETURN
+0033    0 CONSTANT            5 'Value type ARRAY'
+0035    | DEFINE_GLOBAL    NameIdx:6   'dummy_vtable' Type:ARRAY Dims:1 [0..0] of INTEGER ('integer')
+0045    | SET_GLOBAL          6 'dummy_vtable'
+0047    8 DEFINE_GLOBAL    NameIdx:8   'd' Type:POINTER ('Dummy')
+0052    | ALLOC_OBJECT        3 (fields)
+0054    | SET_GLOBAL          8 'd'
+0056    0 GET_GLOBAL          8 'd'
 0058    | DUP
 0059    | GET_FIELD_OFFSET    0 (index)
-0061    | GET_GLOBAL_ADDRESS    8 'dummy_vtable'
+0061    | GET_GLOBAL_ADDRESS    6 'dummy_vtable'
 0063    | SET_INDIRECT
 0064    | POP
-0065    9 GET_GLOBAL          3 'd'
+0065    9 GET_GLOBAL          8 'd'
 0067    | DUP
 0068    | GET_FIELD_OFFSET    0 (index)
 0070    | GET_INDIRECT
-0071    | CONSTANT            5 '0'
+0071    | CONSTANT            3 '0'
 0073    | SWAP
 0074    | GET_ELEMENT_ADDRESS    1 (dims)
 0076    | GET_INDIRECT
@@ -47,11 +47,11 @@ Offset Line Opcode           Operand  Value / Target (Args)
 Constants (10):\n  0000: STR   "myself"
   0001: NIL
   0002: STR   ""
-  0003: STR   "d"
-  0004: STR   "Dummy"
-  0005: INT   0
-  0006: INT   1
-  0007: Value type ARRAY
-  0008: STR   "dummy_vtable"
-  0009: STR   "integer"
+  0003: INT   0
+  0004: INT   1
+  0005: Value type ARRAY
+  0006: STR   "dummy_vtable"
+  0007: STR   "integer"
+  0008: STR   "d"
+  0009: STR   "Dummy"
 

--- a/Tests/rea/short_circuit.disasm
+++ b/Tests/rea/short_circuit.disasm
@@ -4,105 +4,105 @@ Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
 0000    0 CONSTANT            1 'nil'
 0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
-0007   23 DEFINE_GLOBAL    NameIdx:3   'r0' Type:BOOLEAN ('bool')
-0012    | CONSTANT            5 'false'
-0014    | JUMP_IF_FALSE       8 (to 0025)
-0017    | CALL_USER_PROC       6 'rhs_true' @0120 (0 args)
-0021    | TO_BOOL
-0022    | JUMP                2 (to 0027)
-0025    | CONSTANT            7 'false'
-0027    | SET_GLOBAL          3 'r0'
-0029   24 DEFINE_GLOBAL    NameIdx:8   'r1' Type:BOOLEAN ('bool')
-0034    | CONSTANT            9 'true'
-0036    | JUMP_IF_FALSE       5 (to 0044)
-0039    | CONSTANT           10 'true'
-0041    | JUMP                5 (to 0049)
-0044    | CALL_USER_PROC       6 'rhs_true' @0120 (0 args)
-0048    | TO_BOOL
-0049    | SET_GLOBAL          8 'r1'
-0051   25 DEFINE_GLOBAL    NameIdx:11  'r2' Type:BOOLEAN ('bool')
-0056    | CONSTANT           12 'true'
-0058    | JUMP_IF_FALSE       8 (to 0069)
-0061    | CALL_USER_PROC       6 'rhs_true' @0120 (0 args)
-0065    | TO_BOOL
-0066    | JUMP                2 (to 0071)
-0069    | CONSTANT           13 'false'
-0071    | SET_GLOBAL         11 'r2'
-0073   26 DEFINE_GLOBAL    NameIdx:14  'r3' Type:BOOLEAN ('bool')
-0078    | CONSTANT           15 'false'
-0080    | JUMP_IF_FALSE       5 (to 0088)
-0083    | CONSTANT           16 'true'
-0085    | JUMP                5 (to 0093)
-0088    | CALL_USER_PROC      17 'rhs_false' @0139 (0 args)
-0092    | TO_BOOL
-0093    | SET_GLOBAL         14 'r3'
-0095   27 DEFINE_GLOBAL    NameIdx:18  'r4' Type:BOOLEAN ('bool')
-0100    | CONSTANT           19 'false'
-0102    | JUMP_IF_FALSE       5 (to 0110)
-0105    | CONSTANT           20 'true'
-0107    | JUMP                5 (to 0115)
-0110    | CALL_USER_PROC       6 'rhs_true' @0120 (0 args)
-0114    | TO_BOOL
-0115    | SET_GLOBAL         18 'r4'
-0117    1 JUMP               16 (to 0136)
+0007    1 JUMP               16 (to 0026)
 
---- Function rhs_true (at 0120) ---
-0120    2 CONSTANT           21 '1'
-0122    | CONSTANT           22 'R1'
-0124    | CALL_BUILTIN_PROC   176 'write' (2 args)
-0130    3 CONSTANT           24 'true'
-0132    | RETURN
-0133    1 GET_LOCAL           0 (slot)
-0135    | RETURN
-0136    6 JUMP               16 (to 0155)
+--- Function rhs_true (at 0010) ---
+0010    2 CONSTANT            3 '1'
+0012    | CONSTANT            4 'R1'
+0014    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0020    3 CONSTANT            6 'true'
+0022    | RETURN
+0023    1 GET_LOCAL           0 (slot)
+0025    | RETURN
+0026    6 JUMP               16 (to 0045)
 
---- Function rhs_false (at 0139) ---
-0139    7 CONSTANT           21 '1'
-0141    | CONSTANT           25 'R0'
-0143    | CALL_BUILTIN_PROC   176 'write' (2 args)
-0149    8 CONSTANT           26 'false'
-0151    | RETURN
-0152    6 GET_LOCAL           0 (slot)
-0154    | RETURN
+--- Function rhs_false (at 0029) ---
+0029    7 CONSTANT            3 '1'
+0031    | CONSTANT            7 'R0'
+0033    | CALL_BUILTIN_PROC   176 'write' (2 args)
+0039    8 CONSTANT            8 'false'
+0041    | RETURN
+0042    6 GET_LOCAL           0 (slot)
+0044    | RETURN
+0045   23 DEFINE_GLOBAL    NameIdx:9   'r0' Type:BOOLEAN ('bool')
+0050    | CONSTANT           11 'false'
+0052    | JUMP_IF_FALSE       8 (to 0063)
+0055    | CALL_USER_PROC      12 'rhs_true' @0010 (0 args)
+0059    | TO_BOOL
+0060    | JUMP                2 (to 0065)
+0063    | CONSTANT           13 'false'
+0065    | SET_GLOBAL          9 'r0'
+0067   24 DEFINE_GLOBAL    NameIdx:14  'r1' Type:BOOLEAN ('bool')
+0072    | CONSTANT           15 'true'
+0074    | JUMP_IF_FALSE       5 (to 0082)
+0077    | CONSTANT           16 'true'
+0079    | JUMP                5 (to 0087)
+0082    | CALL_USER_PROC      12 'rhs_true' @0010 (0 args)
+0086    | TO_BOOL
+0087    | SET_GLOBAL         14 'r1'
+0089   25 DEFINE_GLOBAL    NameIdx:17  'r2' Type:BOOLEAN ('bool')
+0094    | CONSTANT           18 'true'
+0096    | JUMP_IF_FALSE       8 (to 0107)
+0099    | CALL_USER_PROC      12 'rhs_true' @0010 (0 args)
+0103    | TO_BOOL
+0104    | JUMP                2 (to 0109)
+0107    | CONSTANT           19 'false'
+0109    | SET_GLOBAL         17 'r2'
+0111   26 DEFINE_GLOBAL    NameIdx:20  'r3' Type:BOOLEAN ('bool')
+0116    | CONSTANT           21 'false'
+0118    | JUMP_IF_FALSE       5 (to 0126)
+0121    | CONSTANT           22 'true'
+0123    | JUMP                5 (to 0131)
+0126    | CALL_USER_PROC      23 'rhs_false' @0029 (0 args)
+0130    | TO_BOOL
+0131    | SET_GLOBAL         20 'r3'
+0133   27 DEFINE_GLOBAL    NameIdx:24  'r4' Type:BOOLEAN ('bool')
+0138    | CONSTANT           25 'false'
+0140    | JUMP_IF_FALSE       5 (to 0148)
+0143    | CONSTANT           26 'true'
+0145    | JUMP                5 (to 0153)
+0148    | CALL_USER_PROC      12 'rhs_true' @0010 (0 args)
+0152    | TO_BOOL
+0153    | SET_GLOBAL         24 'r4'
 0155   11 CONSTANT           27 'false'
 0157    | JUMP_IF_FALSE       8 (to 0168)
-0160    | CALL_USER_PROC       6 'rhs_true' @0120 (0 args)
+0160    | CALL_USER_PROC      12 'rhs_true' @0010 (0 args)
 0164    | TO_BOOL
 0165    | JUMP                2 (to 0170)
 0168    | CONSTANT           28 'false'
 0170    | JUMP_IF_FALSE      13 (to 0186)
-0173   12 CONSTANT           21 '1'
+0173   12 CONSTANT            3 '1'
 0175    | CONSTANT           29 'A hit'
 0177    | CALL_BUILTIN_PROC   176 'write' (2 args)
 0183   11 JUMP               10 (to 0196)
-0186   14 CONSTANT           21 '1'
+0186   14 CONSTANT            3 '1'
 0188    | CONSTANT           30 'A skip'
 0190    | CALL_BUILTIN_PROC   176 'write' (2 args)
 0196   17 CONSTANT           31 'true'
 0198    | JUMP_IF_FALSE       5 (to 0206)
 0201    | CONSTANT           32 'true'
 0203    | JUMP                5 (to 0211)
-0206    | CALL_USER_PROC       6 'rhs_true' @0120 (0 args)
+0206    | CALL_USER_PROC      12 'rhs_true' @0010 (0 args)
 0210    | TO_BOOL
 0211    | JUMP_IF_FALSE      13 (to 0227)
-0214   18 CONSTANT           21 '1'
+0214   18 CONSTANT            3 '1'
 0216    | CONSTANT           33 'B hit'
 0218    | CALL_BUILTIN_PROC   176 'write' (2 args)
 0224   17 JUMP               10 (to 0237)
-0227   20 CONSTANT           21 '1'
+0227   20 CONSTANT            3 '1'
 0229    | CONSTANT           34 'B skip'
 0231    | CALL_BUILTIN_PROC   176 'write' (2 args)
-0237   29 CONSTANT           21 '1'
+0237   29 CONSTANT            3 '1'
 0239    | CONSTANT           35 'vals:'
-0241    | GET_GLOBAL          3 'r0'
+0241    | GET_GLOBAL          9 'r0'
 0243    | CONSTANT           36 ' '
-0245    | GET_GLOBAL          8 'r1'
+0245    | GET_GLOBAL         14 'r1'
 0247    | CONSTANT           36 ' '
-0249    | GET_GLOBAL         11 'r2'
+0249    | GET_GLOBAL         17 'r2'
 0251    | CONSTANT           36 ' '
-0253    | GET_GLOBAL         14 'r3'
+0253    | GET_GLOBAL         20 'r3'
 0255    | CONSTANT           36 ' '
-0257    | GET_GLOBAL         18 'r4'
+0257    | GET_GLOBAL         24 'r4'
 0259    | CALL_BUILTIN_PROC   176 'write' (11 args)
 0265    0 HALT
 == End Disassembly: Tests/rea/short_circuit.rea ==
@@ -110,30 +110,30 @@ Offset Line Opcode           Operand  Value / Target (Args)
 Constants (37):\n  0000: STR   "myself"
   0001: NIL
   0002: STR   ""
-  0003: STR   "r0"
-  0004: STR   "bool"
-  0005: BOOL  false
-  0006: STR   "rhs_true"
-  0007: BOOL  false
-  0008: STR   "r1"
-  0009: BOOL  true
-  0010: BOOL  true
-  0011: STR   "r2"
-  0012: BOOL  true
+  0003: INT   1
+  0004: STR   "R1"
+  0005: STR   "write"
+  0006: BOOL  true
+  0007: STR   "R0"
+  0008: BOOL  false
+  0009: STR   "r0"
+  0010: STR   "bool"
+  0011: BOOL  false
+  0012: STR   "rhs_true"
   0013: BOOL  false
-  0014: STR   "r3"
-  0015: BOOL  false
+  0014: STR   "r1"
+  0015: BOOL  true
   0016: BOOL  true
-  0017: STR   "rhs_false"
-  0018: STR   "r4"
+  0017: STR   "r2"
+  0018: BOOL  true
   0019: BOOL  false
-  0020: BOOL  true
-  0021: INT   1
-  0022: STR   "R1"
-  0023: STR   "write"
-  0024: BOOL  true
-  0025: STR   "R0"
-  0026: BOOL  false
+  0020: STR   "r3"
+  0021: BOOL  false
+  0022: BOOL  true
+  0023: STR   "rhs_false"
+  0024: STR   "r4"
+  0025: BOOL  false
+  0026: BOOL  true
   0027: BOOL  false
   0028: BOOL  false
   0029: STR   "A hit"

--- a/Tests/rea/super_constructor.err
+++ b/Tests/rea/super_constructor.err
@@ -4,30 +4,30 @@ Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
 0000    0 CONSTANT            1 'nil'
 0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
-0007    3 DEFINE_GLOBAL    NameIdx:3   'c' Type:POINTER ('Child')
-0012    | ALLOC_OBJECT        3 (fields)
-0014    | DUP
-0015    | CONSTANT            5 '42'
-0017    | CALL_USER_PROC       6 'child' @0038 (2 args)
-0021    | SET_GLOBAL          3 'c'
-0023    1 JUMP                9 (to 0035)
+0007    1 JUMP                9 (to 0019)
 
---- Procedure base.base (at 0026) ---
-0026    | GET_LOCAL           1 (slot)
-0028    | GET_LOCAL           0 (slot)
-0030    | GET_FIELD_OFFSET    1 (index)
-0032    | SWAP
-0033    | SET_INDIRECT
-0034    | RETURN
-0035    2 JUMP                9 (to 0047)
+--- Procedure base.base (at 0010) ---
+0010    | GET_LOCAL           1 (slot)
+0012    | GET_LOCAL           0 (slot)
+0014    | GET_FIELD_OFFSET    1 (index)
+0016    | SWAP
+0017    | SET_INDIRECT
+0018    | RETURN
+0019    2 JUMP                9 (to 0031)
 
---- Procedure child.child (at 0038) ---
-0038    | GET_LOCAL           0 (slot)
-0040    | GET_LOCAL           1 (slot)
-0042    | CALL_USER_PROC       7 'base.base' @0026 (2 args)
-0046    | RETURN
+--- Procedure child.child (at 0022) ---
+0022    | GET_LOCAL           0 (slot)
+0024    | GET_LOCAL           1 (slot)
+0026    | CALL_USER_PROC       3 'base.base' @0010 (2 args)
+0030    | RETURN
+0031    3 DEFINE_GLOBAL    NameIdx:4   'c' Type:POINTER ('Child')
+0036    | ALLOC_OBJECT        3 (fields)
+0038    | DUP
+0039    | CONSTANT            6 '42'
+0041    | CALL_USER_PROC       7 'child' @0022 (2 args)
+0045    | SET_GLOBAL          4 'c'
 0047    4 CONSTANT            8 '1'
-0049    | GET_GLOBAL          3 'c'
+0049    | GET_GLOBAL          4 'c'
 0051    | LOAD_FIELD_VALUE    1 (index)
 0053    | CALL_BUILTIN_PROC   176 'write' (2 args)
 0059    0 HALT
@@ -36,11 +36,11 @@ Offset Line Opcode           Operand  Value / Target (Args)
 Constants (10):\n  0000: STR   "myself"
   0001: NIL
   0002: STR   ""
-  0003: STR   "c"
-  0004: STR   "Child"
-  0005: INT   42
-  0006: STR   "child"
-  0007: STR   "base.base"
+  0003: STR   "base.base"
+  0004: STR   "c"
+  0005: STR   "Child"
+  0006: INT   42
+  0007: STR   "child"
   0008: INT   1
   0009: STR   "write"
 

--- a/Tests/rea/super_method.err
+++ b/Tests/rea/super_method.err
@@ -4,51 +4,51 @@ Offset Line Opcode           Operand  Value / Target (Args)
 ------ ---- ---------------- -------- --------------------------
 0000    0 CONSTANT            1 'nil'
 0002    | DEFINE_GLOBAL    NameIdx:0   'myself' Type:POINTER ('')
-0007    3 DEFINE_GLOBAL    NameIdx:3   'c' Type:POINTER ('Child')
-0012    | ALLOC_OBJECT        3 (fields)
-0014    | DUP
-0015    | CALL_USER_PROC       5 'child' @0042 (1 args)
-0019    | SET_GLOBAL          3 'c'
-0021    1 JUMP                1 (to 0025)
+0007    1 JUMP                1 (to 0011)
 
---- Procedure base.base (at 0024) ---
+--- Procedure base.base (at 0010) ---
+0010    | RETURN
+0011    | JUMP               11 (to 0025)
+
+--- Procedure base.speak (at 0014) ---
+0014    | CONSTANT            3 '1'
+0016    | CONSTANT            4 'base'
+0018    | CALL_BUILTIN_PROC   176 'write' (2 args)
 0024    | RETURN
-0025    | JUMP               11 (to 0039)
+0025    2 JUMP                7 (to 0035)
 
---- Procedure base.speak (at 0028) ---
-0028    | CONSTANT            6 '1'
-0030    | CONSTANT            7 'base'
-0032    | CALL_BUILTIN_PROC   176 'write' (2 args)
-0038    | RETURN
-0039    2 JUMP                7 (to 0049)
+--- Procedure child.child (at 0028) ---
+0028    | GET_LOCAL           0 (slot)
+0030    | CALL_USER_PROC       6 'base.base' @0010 (1 args)
+0034    | RETURN
+0035    | JUMP                7 (to 0045)
 
---- Procedure child.child (at 0042) ---
-0042    | GET_LOCAL           0 (slot)
-0044    | CALL_USER_PROC       9 'base.base' @0024 (1 args)
-0048    | RETURN
-0049    | JUMP                7 (to 0059)
-
---- Procedure child.speak (at 0052) ---
-0052    | GET_LOCAL           0 (slot)
-0054    | CALL_USER_PROC      10 'base.speak' @0028 (1 args)
-0058    | RETURN
-0059    0 CONSTANT           11 'Value type ARRAY'
-0061    | DEFINE_GLOBAL    NameIdx:12  'child_vtable' Type:ARRAY Dims:1 [0..1] of INTEGER ('integer')
-0071    | SET_GLOBAL         12 'child_vtable'
-0073    | CONSTANT           15 'Value type ARRAY'
-0075    | DEFINE_GLOBAL    NameIdx:16  'base_vtable' Type:ARRAY Dims:1 [0..1] of INTEGER ('integer')
-0085    | SET_GLOBAL         16 'base_vtable'
-0087    | GET_GLOBAL          3 'c'
+--- Procedure child.speak (at 0038) ---
+0038    | GET_LOCAL           0 (slot)
+0040    | CALL_USER_PROC       7 'base.speak' @0014 (1 args)
+0044    | RETURN
+0045    0 CONSTANT            8 'Value type ARRAY'
+0047    | DEFINE_GLOBAL    NameIdx:9   'child_vtable' Type:ARRAY Dims:1 [0..1] of INTEGER ('integer')
+0057    | SET_GLOBAL          9 'child_vtable'
+0059    | CONSTANT           12 'Value type ARRAY'
+0061    | DEFINE_GLOBAL    NameIdx:13  'base_vtable' Type:ARRAY Dims:1 [0..1] of INTEGER ('integer')
+0071    | SET_GLOBAL         13 'base_vtable'
+0073    3 DEFINE_GLOBAL    NameIdx:14  'c' Type:POINTER ('Child')
+0078    | ALLOC_OBJECT        3 (fields)
+0080    | DUP
+0081    | CALL_USER_PROC      16 'child' @0028 (1 args)
+0085    | SET_GLOBAL         14 'c'
+0087    0 GET_GLOBAL         14 'c'
 0089    | DUP
 0090    | GET_FIELD_OFFSET    0 (index)
-0092    | GET_GLOBAL_ADDRESS   12 'child_vtable'
+0092    | GET_GLOBAL_ADDRESS    9 'child_vtable'
 0094    | SET_INDIRECT
 0095    | POP
-0096    4 GET_GLOBAL          3 'c'
+0096    4 GET_GLOBAL         14 'c'
 0098    | DUP
 0099    | GET_FIELD_OFFSET    0 (index)
 0101    | GET_INDIRECT
-0102    | CONSTANT            6 '1'
+0102    | CONSTANT            3 '1'
 0104    | SWAP
 0105    | GET_ELEMENT_ADDRESS    1 (dims)
 0107    | GET_INDIRECT
@@ -59,18 +59,18 @@ Offset Line Opcode           Operand  Value / Target (Args)
 Constants (17):\n  0000: STR   "myself"
   0001: NIL
   0002: STR   ""
-  0003: STR   "c"
-  0004: STR   "Child"
-  0005: STR   "child"
-  0006: INT   1
-  0007: STR   "base"
-  0008: STR   "write"
-  0009: STR   "base.base"
-  0010: STR   "base.speak"
-  0011: Value type ARRAY
-  0012: STR   "child_vtable"
-  0013: INT   0
-  0014: STR   "integer"
-  0015: Value type ARRAY
-  0016: STR   "base_vtable"
+  0003: INT   1
+  0004: STR   "base"
+  0005: STR   "write"
+  0006: STR   "base.base"
+  0007: STR   "base.speak"
+  0008: Value type ARRAY
+  0009: STR   "child_vtable"
+  0010: INT   0
+  0011: STR   "integer"
+  0012: Value type ARRAY
+  0013: STR   "base_vtable"
+  0014: STR   "c"
+  0015: STR   "Child"
+  0016: STR   "child"
 


### PR DESCRIPTION
## Summary
- extend the Rea frontend test runner to compile the hangman5 example with `--no-cache`
- verify the compiled disassembly still defines `wordrepository_vtable` before the global HangmanGame constructor executes

## Testing
- Tests/run_rea_tests.sh

------
https://chatgpt.com/codex/tasks/task_e_68d024c58500832a95824cf52f3128b2