### PR TITLE
Add release notes for v2.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v2.21 – 2025-09-21
+
+Enhancements
+- Bytecode & VM: Added `TO_BOOL`, direct field/array load opcodes (including constant-index forms), and `CALL_BUILTIN_PROC`/`CALL_USER_PROC` so builtin and user procedures carry stable identifiers regardless of SDL support.
+- Languages: Pascal/CLike emit the VM's XOR opcode with constant folding, Rea adds `nil`, and Pascal gained an `override builtin` directive plus ASCII-safe identifier lexing.
+- CLI & Docs: Pascal, CLike, and Rea accept `--no-cache`; documentation covers the new builtin-call flow; a comprehensive `PerformanceBenchmark` example exercises the VM.
+
+Stability and correctness
+- Deferred global initializers until after vtables are emitted, ensuring zero-argument `new` calls and nested `CALL_USER_PROC` invocations wire constructors in source order.
+- Pascal cached-bytecode detection no longer depends on `memmem`, musl builds tokenize identifiers reliably, and direct-load bytecode keeps cached locals metadata intact.
+- Rea preserves method metadata across recompiles, fixes call-frame slot allocation, and regression tests verify the Hangman5 vtable appears before its global constructor.
+- Mutex registries are shared by spawned threads and `INC_LOCAL`/`DEC_LOCAL` now adjust real and enum locals without type errors.
+
+Developer experience
+- Regression runners invoke every front end with `--no-cache`, normalize case-sensitive paths on macOS, and disassemble Hangman5 to guard vtable ordering.
+- The build system probes for AddressSanitizer support before enabling `dascal` instrumentation.
+
+Fixed
+- Prevented console color resets from forcing black backgrounds and restored WordRepository's vtable emission ahead of global constructors.
+
+
+
 ## v2.2 – 2025-09-18
 
 Enhancements

--- a/RELEASE_NOTES_v2.21.md
+++ b/RELEASE_NOTES_v2.21.md
@@ -1,0 +1,61 @@
+# Pscal v2.21
+
+Date: 2025-09-21
+
+## Highlights
+- Bytecode & VM: Dedicated `TO_BOOL`, direct field/array load instructions, and explicit builtin/user procedure call opcodes make truthiness and dispatch consistent across front ends.
+- Language front ends: Pascal, CLike, and Rea gain XOR expressions, Rea adds a `nil` literal, and Pascal introduces an `override builtin` directive for intentional overrides.
+- Tooling & Tests: All compilers understand `--no-cache`, regression scripts run cache-free, and a new Pascal PerformanceBenchmark program exercises the VM.
+- Reliability: Deferred global initializer handling keeps constructors, vtables, and mutex registries ordered correctly even under nested `new` calls and spawned threads.
+
+## New
+- Bytecode & VM
+  - Added `TO_BOOL` to normalize truthiness without extra `NOT` sequences.
+  - Introduced `LOAD_FIELD_VALUE`, `LOAD_FIELD_VALUE16`, `LOAD_ELEMENT_VALUE`, and `LOAD_ELEMENT_VALUE_CONST` so the VM can fetch record and array values directly.
+  - Added `CALL_BUILTIN_PROC` and `CALL_USER_PROC`, storing builtin IDs alongside names and allowing user procedures (including nested Pascal routines and constructors) to be invoked by name.
+- Front-end languages
+  - Pascal and CLike now parse and fold `xor` expressions, emitting the VM's native XOR opcode; Rea lexes the keyword as well.
+  - Rea recognizes a `nil` literal and uses `TO_BOOL` for short-circuiting so boolean expressions match Pascal/CLike semantics.
+  - Pascal's lexer accepts ASCII identifiers on all libc implementations and comment directives such as `// override builtin fibonacci` to silence intentional builtin replacements.
+- CLI & Docs
+  - Pascal, CLike, and Rea CLIs gained `--no-cache` to force recompilation, and documentation for standalone front ends now covers the new builtin procedure call flow.
+  - Added `Examples/Pascal/PerformanceBenchmark`, a comprehensive workload that overrides builtin math routines, along with updated language reference notes.
+
+## Improvements
+- Compiler & VM
+  - Deferred global variable initializers until after vtables are emitted, queuing definitions and replaying them once constructor metadata is in place.
+  - Constant index array reads emit `LOAD_ELEMENT_VALUE_CONST`, `GET_ELEMENT_ADDRESS_CONST`, and other targeted bytecode, while `INC_LOCAL`/`DEC_LOCAL` update real and enum locals safely.
+  - Builtin registry ordering stays stable whether SDL is enabled or not, and console attribute tracking leaves terminals in their default color scheme.
+- Tooling & Tests
+  - Regression scripts run all front ends with `--no-cache`, normalize stderr without `memmem`, respect case-sensitive paths on macOS, and disassemble `Examples/rea/hangman5` to ensure vtables precede global constructors.
+- Build & Packaging
+  - The build probes for AddressSanitizer support before enabling it for `dascal`, falling back gracefully when the toolchain lacks `-fsanitize=address`.
+
+## Fixed
+- Ensured Pascal global initializers, zero-argument constructors, and nested `CALL_USER_PROC` invocations run in source order with correct vtable wiring.
+- Pascal cached-bytecode detection no longer depends on `memmem`, and musl-based builds tokenize identifiers correctly.
+- Rea keeps method metadata in sync when recompiling, allocates call-frame slots reliably, and the hangman example verifies that `WordRepository`'s vtable is emitted before its global constructor executes.
+- Mutex registries are shared between threads spawned from dynamic locals so mutex IDs remain valid across VM instances.
+
+## Build & Install
+- Configure and build:
+  - `cmake -S . -B build [-DSDL=ON] [-DRELEASE_BUILD=ON]`
+  - `cmake --build build -j`
+- Install (CMake):
+  - `cmake --install build` (installs `pascal`, `pscalvm`, `pscald` if enabled, `pscaljson2bc`, and optional completions)
+- Environment:
+  - `PASCAL_LIB_DIR`, `CLIKE_LIB_DIR`, `RUN_SDL`, `SDL_VIDEODRIVER`, `SDL_AUDIODRIVER`, `RUN_NET_TESTS`.
+
+## Testing
+- Run all suites:
+  - `Tests/run_all_tests` or `ctest --test-dir build -j`
+- Headless defaults for SDL remain off unless `RUN_SDL=1`.
+- Networked examples require `RUN_NET_TESTS=1`.
+
+## Compatibility
+- VM bytecode cache version: `PSCAL_VM_VERSION = 7`. Bytecode generated prior to v2.21 will be recompiled automatically because of new opcodes and cache metadata.
+- `CALL_BUILTIN_PROC`/`CALL_USER_PROC` and direct load instructions must be understood by consumer tools; update custom front ends accordingly.
+
+## Known Notes
+- Rea remains experimental; selected OO tests stay skipped via `REA_SKIP_TESTS`.
+- SDL graphics tests still need real video/audio drivers; otherwise they run under dummy backends when unset.


### PR DESCRIPTION
## Summary
- add v2.21 release notes covering new VM opcodes, language features, tooling, and fixes
- update the changelog with a v2.21 entry summarizing the release

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d04ef926f4832a8b9bfe7e6ce60944