### PR TITLE
Handle missing killpg in run_with_timeout helper

### DIFF
--- a/Tests/tools/run_with_timeout.py
+++ b/Tests/tools/run_with_timeout.py
@@ -1,5 +1,50 @@
 #!/usr/bin/env python3
-import argparse, os, signal, subprocess, sys, time
+import argparse, errno, os, signal, subprocess, sys, time
+
+
+def _terminate_process_group(proc, sig):
+    """Send *sig* to the process group for *proc*, handling platform quirks."""
+
+    if proc is None:
+        return
+
+    pid = getattr(proc, "pid", None)
+    if not pid or pid <= 0:
+        return
+
+    killpg = getattr(os, "killpg", None)
+    if killpg is not None:
+        try:
+            killpg(pid, sig)
+            return
+        except ProcessLookupError:
+            return
+        except PermissionError:
+            # Fall back to trying os.kill below.
+            pass
+        except OSError as e:
+            if e.errno == errno.ESRCH:
+                return
+            # Unknown error: fall back to os.kill below.
+            pass
+
+    if os.name == "posix":
+        try:
+            os.kill(-pid, sig)
+            return
+        except ProcessLookupError:
+            return
+        except PermissionError:
+            pass
+        except OSError as e:
+            if e.errno == errno.ESRCH:
+                return
+
+    try:
+        proc.send_signal(sig)
+    except ProcessLookupError:
+        pass
+
 
 def main():
     p = argparse.ArgumentParser(description="Run a command with a timeout, killing it if it hangs.")
@@ -13,7 +58,17 @@ def main():
 
     # Start the process in a new process group so we can kill children too.
     try:
-        proc = subprocess.Popen(args.cmd, preexec_fn=os.setsid)
+        proc = subprocess.Popen(args.cmd, start_new_session=True)
+    except TypeError:
+        preexec_fn = getattr(os, "setsid", None)
+        try:
+            if preexec_fn is not None:
+                proc = subprocess.Popen(args.cmd, preexec_fn=preexec_fn)
+            else:
+                proc = subprocess.Popen(args.cmd)
+        except Exception as e:
+            print(f"Failed to start: {e}", file=sys.stderr)
+            return 127
     except Exception as e:
         print(f"Failed to start: {e}", file=sys.stderr)
         return 127
@@ -28,10 +83,7 @@ def main():
             time.sleep(0.1)
         if exit_code is None:
             # Timeout: terminate process group
-            try:
-                os.killpg(proc.pid, signal.SIGTERM)
-            except ProcessLookupError:
-                pass
+            _terminate_process_group(proc, signal.SIGTERM)
             # Give it a moment to exit
             deadline2 = time.time() + 2.0
             while time.time() < deadline2:
@@ -40,16 +92,10 @@ def main():
                     break
                 time.sleep(0.05)
             if exit_code is None:
-                try:
-                    os.killpg(proc.pid, signal.SIGKILL)
-                except ProcessLookupError:
-                    pass
+                _terminate_process_group(proc, signal.SIGKILL)
                 exit_code = 124  # timeout
     except KeyboardInterrupt:
-        try:
-            os.killpg(proc.pid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
+        _terminate_process_group(proc, signal.SIGKILL)
         raise
 
     return exit_code if exit_code is not None else 0


### PR DESCRIPTION
## Summary
- update the timeout runner to tolerate platforms without os.killpg by introducing a portable process-group terminator
- prefer subprocess start_new_session with a fallback to os.setsid to avoid AttributeErrors on restricted platforms

## Testing
- python3 Tests/tools/run_with_timeout.py --timeout 0.1 sleep 1

------
https://chatgpt.com/codex/tasks/task_e_68d054c66900832ab82b04e1754a1cc0