### PR TITLE
Improve Mandelbrot thread scheduling

### DIFF
--- a/Examples/Pascal/Mando256ColorThreads
+++ b/Examples/Pascal/Mando256ColorThreads
@@ -28,93 +28,136 @@ VAR
   ScaleX, ScaleY: Real;
   DrawChar      : Char;
   ColorBuffer   : array[1..MaxBufferRows, 1..MaxBufferCols] of Byte;
-  ThreadRanges  : array[0..ThreadCount - 1] of TRowRange;
   ThreadHandles : array[0..ThreadCount - 1] of Integer;
+  RowMutex      : Integer;
+  NextRow       : Integer;
+  ThreadingEnabled: Boolean;
+
+PROCEDURE ComputeRow(Row: Integer);
+VAR
+  Col      : Integer;
+  cx, cy   : Real;
+  zx, zy   : Real;
+  xTemp    : Real;
+  iter     : Integer;
+  ColorIndex: Byte;
+BEGIN
+  IF (Row < 1) OR (Row > Height) THEN
+    EXIT;
+
+  cy := MinY + Row * ScaleY;
+
+  FOR Col := 1 TO Width DO
+  BEGIN
+    cx := MinX + Col * ScaleX;
+    zx := 0.0;
+    zy := 0.0;
+    iter := 0;
+
+    WHILE (iter < MaxIter) AND ((zx*zx + zy*zy) < EscapeRadiusSq) DO
+    BEGIN
+      xTemp := zx*zx - zy*zy + cx;
+      zy := 2.0 * zx * zy + cy;
+      zx := xTemp;
+      iter := iter + 1;
+    END;
+
+    IF iter = MaxIter THEN
+      ColorIndex := InsideColorIndex
+    ELSE
+      ColorIndex := Byte(16 + (iter MOD PaletteSize));
+
+    ColorBuffer[Row, Col] := ColorIndex;
+  END;
+END;
+
+PROCEDURE ComputeRowRange(startRow, endRow: Integer);
+VAR
+  Row: Integer;
+BEGIN
+  IF startRow < 1 THEN
+    startRow := 1;
+  IF endRow > Height THEN
+    endRow := Height;
+  IF endRow < startRow THEN
+    EXIT;
+
+  FOR Row := startRow TO endRow DO
+    ComputeRow(Row);
+END;
+
+FUNCTION TryGetNextRow(VAR rowOut: Integer): Boolean;
+BEGIN
+  TryGetNextRow := FALSE;
+  IF (NOT ThreadingEnabled) OR (RowMutex < 0) THEN
+    EXIT;
+
+  lock(RowMutex);
+  IF NextRow <= Height THEN
+  BEGIN
+    rowOut := NextRow;
+    NextRow := NextRow + 1;
+    TryGetNextRow := TRUE;
+  END;
+  unlock(RowMutex);
+END;
 
 PROCEDURE ComputeRows(rangePtr: PRowRange);
 VAR
-  Row, Col      : Integer;
-  cx, cy        : Real;
-  zx, zy        : Real;
-  xTemp         : Real;
-  iter          : Integer;
-  ColorIndex    : Byte;
+  Row: Integer;
   startRow, endRow: Integer;
 BEGIN
   IF rangePtr = NIL THEN
+  BEGIN
+    IF NOT ThreadingEnabled THEN
+      EXIT;
+
+    WHILE TryGetNextRow(Row) DO
+      ComputeRow(Row);
     EXIT;
+  END;
 
   startRow := rangePtr^.StartRow;
   endRow := rangePtr^.EndRow;
 
-  IF (startRow <= 0) OR (endRow <= 0) OR (endRow < startRow) THEN
-    EXIT;
-
-  FOR Row := startRow TO endRow DO
-  BEGIN
-    cy := MinY + Row * ScaleY;
-    FOR Col := 1 TO Width DO
-    BEGIN
-      cx := MinX + Col * ScaleX;
-      zx := 0.0;
-      zy := 0.0;
-      iter := 0;
-
-      WHILE (iter < MaxIter) AND ((zx*zx + zy*zy) < EscapeRadiusSq) DO
-      BEGIN
-        xTemp := zx*zx - zy*zy + cx;
-        zy := 2.0 * zx * zy + cy;
-        zx := xTemp;
-        iter := iter + 1;
-      END;
-
-      IF iter = MaxIter THEN
-        ColorIndex := InsideColorIndex
-      ELSE
-        ColorIndex := Byte(16 + (iter MOD PaletteSize));
-
-      ColorBuffer[Row, Col] := ColorIndex;
-    END;
-  END;
+  ComputeRowRange(startRow, endRow);
 END;
 
 PROCEDURE SpawnThreads;
 VAR
-  i, rowsPerThread, extraRows, startRow, endRow: Integer;
-  handle: Integer;
+  i, handle: Integer;
+  anyThread: Boolean;
 BEGIN
-  rowsPerThread := Height DIV ThreadCount;
-  extraRows := Height MOD ThreadCount;
-  startRow := 1;
+  ThreadingEnabled := FALSE;
+  RowMutex := mutex();
+  IF RowMutex < 0 THEN
+  BEGIN
+    RowMutex := -1;
+    FOR i := 0 TO ThreadCount - 1 DO
+      ThreadHandles[i] := -1;
+    EXIT;
+  END;
+
+  NextRow := 1;
+  ThreadingEnabled := TRUE;
+  anyThread := FALSE;
 
   FOR i := 0 TO ThreadCount - 1 DO
   BEGIN
     ThreadHandles[i] := -1;
-    IF startRow > Height THEN
+    handle := CreateThread(@ComputeRows, NIL);
+    IF handle >= 0 THEN
     BEGIN
-      ThreadRanges[i].StartRow := 0;
-      ThreadRanges[i].EndRow := -1;
-    END
-    ELSE
-    BEGIN
-      endRow := startRow + rowsPerThread - 1;
-      IF extraRows > 0 THEN
-      BEGIN
-        endRow := endRow + 1;
-        extraRows := extraRows - 1;
-      END;
-      IF endRow > Height THEN
-        endRow := Height;
-      ThreadRanges[i].StartRow := startRow;
-      ThreadRanges[i].EndRow := endRow;
-      startRow := endRow + 1;
-
-      handle := CreateThread(@ComputeRows, @ThreadRanges[i]);
-      IF handle >= 0 THEN
-        ThreadHandles[i] := handle
-      ELSE
-        ComputeRows(@ThreadRanges[i]);
+      ThreadHandles[i] := handle;
+      anyThread := TRUE;
     END;
+  END;
+
+  IF NOT anyThread THEN
+  BEGIN
+    ThreadingEnabled := FALSE;
+    destroy(RowMutex);
+    RowMutex := -1;
   END;
 END;
 
@@ -125,6 +168,13 @@ BEGIN
   FOR i := 0 TO ThreadCount - 1 DO
     IF ThreadHandles[i] >= 0 THEN
       WaitForThread(ThreadHandles[i]);
+
+  IF RowMutex >= 0 THEN
+  BEGIN
+    destroy(RowMutex);
+    RowMutex := -1;
+  END;
+  ThreadingEnabled := FALSE;
 END;
 
 PROCEDURE DisplayBuffer;
@@ -172,6 +222,11 @@ BEGIN
   DrawChar := '#';
 
   SpawnThreads;
+  IF ThreadingEnabled THEN
+    ComputeRows(NIL)
+  ELSE
+    ComputeRowRange(1, Height);
+
   JoinThreads;
 
   DisplayBuffer;

--- a/Examples/Pascal/Mando256ColorThreads_ext
+++ b/Examples/Pascal/Mando256ColorThreads_ext
@@ -28,83 +28,122 @@ VAR
   ScaleX, ScaleY: Real;
   DrawChar      : Char;
   ColorBuffer   : array[1..MaxBufferRows, 1..MaxBufferCols] of Byte;
-  ThreadRanges  : array[0..ThreadCount - 1] of TRowRange;
   ThreadHandles : array[0..ThreadCount - 1] of Integer;
+  RowMutex      : Integer;
+  NextRow       : Integer;
+  ThreadingEnabled: Boolean;
 
-PROCEDURE ComputeRows(rangePtr: PRowRange);
+PROCEDURE ComputeRow(Row: Integer);
 VAR
-  Row, Col      : Integer;
   cy            : Real;
   iter          : Integer;
   ColorIndex    : Byte;
-  startRow, endRow: Integer;
   RowIterations : TIterationRow;
-  rowMinRe      : Real;
+  Col           : Integer;
+BEGIN
+  IF (Row < 1) OR (Row > Height) THEN
+    EXIT;
+
+  cy := MinY + Row * ScaleY;
+  MandelbrotRow(MinX + ScaleX, ScaleX, cy, MaxIter, Width - 1, RowIterations);
+  FOR Col := 1 TO Width DO
+  BEGIN
+    iter := RowIterations[Col - 1];
+    IF iter = MaxIter THEN
+      ColorIndex := InsideColorIndex
+    ELSE
+      ColorIndex := Byte(16 + (iter MOD PaletteSize));
+    ColorBuffer[Row, Col] := ColorIndex;
+  END;
+END;
+
+PROCEDURE ComputeRowRange(startRow, endRow: Integer);
+VAR
+  Row: Integer;
+BEGIN
+  IF startRow < 1 THEN
+    startRow := 1;
+  IF endRow > Height THEN
+    endRow := Height;
+  IF endRow < startRow THEN
+    EXIT;
+
+  FOR Row := startRow TO endRow DO
+    ComputeRow(Row);
+END;
+
+FUNCTION TryGetNextRow(VAR rowOut: Integer): Boolean;
+BEGIN
+  TryGetNextRow := FALSE;
+  IF (NOT ThreadingEnabled) OR (RowMutex < 0) THEN
+    EXIT;
+
+  lock(RowMutex);
+  IF NextRow <= Height THEN
+  BEGIN
+    rowOut := NextRow;
+    NextRow := NextRow + 1;
+    TryGetNextRow := TRUE;
+  END;
+  unlock(RowMutex);
+END;
+
+PROCEDURE ComputeRows(rangePtr: PRowRange);
+VAR
+  Row: Integer;
+  startRow, endRow: Integer;
 BEGIN
   IF rangePtr = NIL THEN
+  BEGIN
+    IF NOT ThreadingEnabled THEN
+      EXIT;
+
+    WHILE TryGetNextRow(Row) DO
+      ComputeRow(Row);
     EXIT;
+  END;
 
   startRow := rangePtr^.StartRow;
   endRow := rangePtr^.EndRow;
 
-  IF (startRow <= 0) OR (endRow <= 0) OR (endRow < startRow) THEN
-    EXIT;
-
-  rowMinRe := MinX + ScaleX;
-
-  FOR Row := startRow TO endRow DO
-  BEGIN
-    cy := MinY + Row * ScaleY;
-    MandelbrotRow(rowMinRe, ScaleX, cy, MaxIter, Width - 1, RowIterations);
-    FOR Col := 1 TO Width DO
-    BEGIN
-      iter := RowIterations[Col - 1];
-      IF iter = MaxIter THEN
-        ColorIndex := InsideColorIndex
-      ELSE
-        ColorIndex := Byte(16 + (iter MOD PaletteSize));
-      ColorBuffer[Row, Col] := ColorIndex;
-    END;
-  END;
+  ComputeRowRange(startRow, endRow);
 END;
 
 PROCEDURE SpawnThreads;
 VAR
-  i, rowsPerThread, extraRows, startRow, endRow: Integer;
-  handle: Integer;
+  i, handle: Integer;
+  anyThread: Boolean;
 BEGIN
-  rowsPerThread := Height DIV ThreadCount;
-  extraRows := Height MOD ThreadCount;
-  startRow := 1;
+  ThreadingEnabled := FALSE;
+  RowMutex := mutex();
+  IF RowMutex < 0 THEN
+  BEGIN
+    RowMutex := -1;
+    FOR i := 0 TO ThreadCount - 1 DO
+      ThreadHandles[i] := -1;
+    EXIT;
+  END;
+
+  NextRow := 1;
+  ThreadingEnabled := TRUE;
+  anyThread := FALSE;
 
   FOR i := 0 TO ThreadCount - 1 DO
   BEGIN
     ThreadHandles[i] := -1;
-    IF startRow > Height THEN
+    handle := CreateThread(@ComputeRows, NIL);
+    IF handle >= 0 THEN
     BEGIN
-      ThreadRanges[i].StartRow := 0;
-      ThreadRanges[i].EndRow := -1;
-    END
-    ELSE
-    BEGIN
-      endRow := startRow + rowsPerThread - 1;
-      IF extraRows > 0 THEN
-      BEGIN
-        endRow := endRow + 1;
-        extraRows := extraRows - 1;
-      END;
-      IF endRow > Height THEN
-        endRow := Height;
-      ThreadRanges[i].StartRow := startRow;
-      ThreadRanges[i].EndRow := endRow;
-      startRow := endRow + 1;
-
-      handle := CreateThread(@ComputeRows, @ThreadRanges[i]);
-      IF handle >= 0 THEN
-        ThreadHandles[i] := handle
-      ELSE
-        ComputeRows(@ThreadRanges[i]);
+      ThreadHandles[i] := handle;
+      anyThread := TRUE;
     END;
+  END;
+
+  IF NOT anyThread THEN
+  BEGIN
+    ThreadingEnabled := FALSE;
+    destroy(RowMutex);
+    RowMutex := -1;
   END;
 END;
 
@@ -115,6 +154,13 @@ BEGIN
   FOR i := 0 TO ThreadCount - 1 DO
     IF ThreadHandles[i] >= 0 THEN
       WaitForThread(ThreadHandles[i]);
+
+  IF RowMutex >= 0 THEN
+  BEGIN
+    destroy(RowMutex);
+    RowMutex := -1;
+  END;
+  ThreadingEnabled := FALSE;
 END;
 
 PROCEDURE DisplayBuffer;
@@ -171,6 +217,11 @@ BEGIN
   DrawChar := '#';
 
   SpawnThreads;
+  IF ThreadingEnabled THEN
+    ComputeRows(NIL)
+  ELSE
+    ComputeRowRange(1, Height);
+
   JoinThreads;
 
   DisplayBuffer;


### PR DESCRIPTION
## Summary
- add per-row worker routine and mutex-protected work queue so Mandelbrot threads steal rows dynamically
- let the main thread participate in the work queue or fall back to sequential rendering when threading is unavailable
- mirror the dynamic scheduling changes in the extended MandelbrotRow example

## Testing
- Tests/run_pascal_tests.sh *(fails: pascal binary not found at /workspace/pscal/build/bin/pascal)*

------
https://chatgpt.com/codex/tasks/task_e_68d08cca6860832a9996343474d48611