### PR TITLE
Gate Rea terminal init behind PSCAL_INIT_TERM

### DIFF
--- a/src/rea/main.c
+++ b/src/rea/main.c
@@ -235,7 +235,10 @@ static void collectUsesClauses(AST* node, List* out) {
 }
 
 int main(int argc, char **argv) {
-    vmInitTerminalState();
+    const char *initTerm = getenv("PSCAL_INIT_TERM");
+    if (initTerm && *initTerm && *initTerm != '0') {
+        vmInitTerminalState();
+    }
 
     int dump_ast_json = 0;
     int dump_bytecode_flag = 0;


### PR DESCRIPTION
## Summary
- Gate REA's terminal initialization behind the PSCAL_INIT_TERM environment flag so non-interactive commands (like --dump-ext-builtins) no longer emit escape sequences.

## Testing
- Tests/run_rea_tests.sh

------
https://chatgpt.com/codex/tasks/task_e_68d0aa174f0c832abd9ac7024115813e