### PR TITLE
Free weather_json HTTP response stream

### DIFF
--- a/Examples/Pascal/weather_json
+++ b/Examples/Pascal/weather_json
@@ -219,6 +219,7 @@ begin
 
   ms := apiSend(url, '');
   response := apiReceive(ms);
+  MStreamFree(ms);
 
   doc := YyjsonRead(response);
   if doc < 0 then


### PR DESCRIPTION
## Summary
- release the API response memory stream once apiReceive copies the payload

## Testing
- `build/bin/pascal /tmp/weather_json_no_clrscr.pas 98672`


------
https://chatgpt.com/codex/tasks/task_e_68d14aae52f8832a81cb75cd232a324e