### PR TITLE
Fix Xcode project root path

### DIFF
--- a/tools/generate_xcodeproj.py
+++ b/tools/generate_xcodeproj.py
@@ -403,11 +403,16 @@ def build_project(output_path: Path) -> None:
     products_ref = add_object(products_identifier, products_group)
 
     root_identifier = md5_id("GROUP", "")
+    root_fields = {
+        "children": [src_group, products_ref],
+        "sourceTree": "<group>",
+        "path": "..",
+        "name": PROJECT_NAME,
+    }
     root_group = PBXObject(
         comment=PROJECT_NAME.lower(),
         isa="PBXGroup",
-        children=[src_group, products_ref],
-        sourceTree="<group>",
+        **root_fields,
     )
     root_ref = add_object(root_identifier, root_group)
 

--- a/xcode/Pscal.xcodeproj/project.pbxproj
+++ b/xcode/Pscal.xcodeproj/project.pbxproj
@@ -2403,6 +2403,8 @@
 					8B60E3824A4B5D0B534EFDAE /* Products */,
 				);
 			sourceTree = "<group>";
+			path = "..";
+			name = Pscal;
 		};
 		9F90D12262F2EBCD1CCCA58B /* strings */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
## Summary
- point the generated Xcode project's top-level group at the repository root so source groups resolve correctly
- regenerate project.pbxproj with the updated location metadata

## Testing
- python3 tools/generate_xcodeproj.py

------
https://chatgpt.com/codex/tasks/task_e_68d152cd89f4832a8b79a7c182e40a9d