### PR TITLE
Fix Xcode header search path for generated project

### DIFF
--- a/tools/generate_xcodeproj.py
+++ b/tools/generate_xcodeproj.py
@@ -433,6 +433,10 @@ def build_project(output_path: Path) -> None:
         "ENABLE_EXT_BUILTIN_YYJSON=1",
         "ENABLE_EXT_BUILTIN_SQLITE=1",
     ]
+    # The generated .xcodeproj lives in xcode/ which means PROJECT_DIR points to
+    # that subdirectory. Header includes in the source expect to resolve against
+    # the repository root (e.g. "core/utils.h"), so the header search path must
+    # explicitly reach back up to the real src/ tree.
     common_project_settings = OrderedDict(
         [
             ("ALWAYS_SEARCH_USER_PATHS", "NO"),
@@ -440,7 +444,7 @@ def build_project(output_path: Path) -> None:
             ("CODE_SIGNING_ALLOWED", "NO"),
             ("ENABLE_BITCODE", "NO"),
             ("GCC_PREPROCESSOR_DEFINITIONS", ["$(inherited)"] + base_preprocessor_defs),
-            ("HEADER_SEARCH_PATHS", ["$(PROJECT_DIR)/src", "$(PROJECT_DIR)/src/**"]),
+            ("HEADER_SEARCH_PATHS", ["$(PROJECT_DIR)/../src", "$(PROJECT_DIR)/../src/**"]),
             ("LIBRARY_SEARCH_PATHS", ["$(inherited)"]),
             ("MACOSX_DEPLOYMENT_TARGET", "11.0"),
             ("OTHER_CFLAGS", ["$(inherited)", "-Wall"]),

--- a/xcode/Pscal.xcodeproj/project.pbxproj
+++ b/xcode/Pscal.xcodeproj/project.pbxproj
@@ -2720,8 +2720,8 @@
 						"DEBUG=1",
 					);
 				HEADER_SEARCH_PATHS = (
-						"$(PROJECT_DIR)/src",
-						"$(PROJECT_DIR)/src/**",
+						"$(PROJECT_DIR)/../src",
+						"$(PROJECT_DIR)/../src/**",
 					);
 				LIBRARY_SEARCH_PATHS = (
 						"$(inherited)",
@@ -3032,8 +3032,8 @@
 						"NDEBUG=1",
 					);
 				HEADER_SEARCH_PATHS = (
-						"$(PROJECT_DIR)/src",
-						"$(PROJECT_DIR)/src/**",
+						"$(PROJECT_DIR)/../src",
+						"$(PROJECT_DIR)/../src/**",
 					);
 				LIBRARY_SEARCH_PATHS = (
 						"$(inherited)",


### PR DESCRIPTION
## Summary
- update the Xcode project generator to point header searches at the repository src directory
- regenerate the checked-in Pscal.xcodeproj with the corrected include paths

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d16c0ea8b8832a98bd1caa144c58d5