### PR TITLE
Handle unquoted build metadata in Xcode

### DIFF
--- a/src/Pascal/main.c
+++ b/src/Pascal/main.c
@@ -32,6 +32,7 @@
 #include "core/utils.h"
 #include "core/list.h"
 #include "core/preproc.h"
+#include "core/build_info.h"
 #include "globals.h"
 #include "backend_ast/builtin.h"
 #include "ext_builtins/dump.h"
@@ -56,14 +57,6 @@ char **gParamValues = NULL;
 
 #ifdef DEBUG
 List *inserted_global_names = NULL;
-#endif
-
-#ifndef PROGRAM_VERSION
-#define PROGRAM_VERSION "undefined.version_DEV"
-#endif
-
-#ifndef PSCAL_GIT_TAG
-#define PSCAL_GIT_TAG "untagged"
 #endif
 
 static int s_vm_trace_head = 0;
@@ -376,7 +369,7 @@ int main(int argc, char *argv[]) {
 
     if (argc == 1) {
         printf("Pscal Interpreter Version: %s (latest tag: %s)\n",
-               PROGRAM_VERSION, PSCAL_GIT_TAG);
+               pscal_program_version_string(), pscal_git_tag_string());
         printf("%s\n", PASCAL_USAGE);
         return vmExitWithCleanup(EXIT_SUCCESS);
     }
@@ -386,7 +379,7 @@ int main(int argc, char *argv[]) {
     for (; i < argc; ++i) {
         if (strcmp(argv[i], "-v") == 0) {
             printf("Pscal Interpreter Version: %s (latest tag: %s)\n",
-                   PROGRAM_VERSION, PSCAL_GIT_TAG);
+                   pscal_program_version_string(), pscal_git_tag_string());
             return vmExitWithCleanup(EXIT_SUCCESS);
         } else if (strcmp(argv[i], "--dump-ast-json") == 0) {
             dump_ast_json_flag = 1;

--- a/src/clike/main.c
+++ b/src/clike/main.c
@@ -39,18 +39,11 @@
 #include "vm/vm.h"
 #include "core/cache.h"
 #include "core/utils.h"
+#include "core/build_info.h"
 #include "symbol/symbol.h"
 #include "Pascal/globals.h"
 #include "backend_ast/builtin.h"
 #include "ext_builtins/dump.h"
-
-#ifndef PROGRAM_VERSION
-#define PROGRAM_VERSION "undefined.version_DEV"
-#endif
-
-#ifndef PSCAL_GIT_TAG
-#define PSCAL_GIT_TAG "untagged"
-#endif
 
 int gParamCount = 0;
 char **gParamValues = NULL;
@@ -120,7 +113,7 @@ int main(int argc, char **argv) {
     for (int i = 1; i < argc; ++i) {
         if (strcmp(argv[i], "-v") == 0) {
             printf("Clike Compiler Version: %s (latest tag: %s)\n",
-                   PROGRAM_VERSION, PSCAL_GIT_TAG);
+                   pscal_program_version_string(), pscal_git_tag_string());
             return vmExitWithCleanup(EXIT_SUCCESS);
         } else if (strcmp(argv[i], "--dump-ast-json") == 0) {
             dump_ast_json_flag = 1;

--- a/src/core/build_info.h
+++ b/src/core/build_info.h
@@ -1,0 +1,72 @@
+#ifndef PSCAL_BUILD_INFO_H
+#define PSCAL_BUILD_INFO_H
+
+#include <stddef.h>
+#include <string.h>
+
+#define PSCAL_STRINGIFY_IMPL(x) #x
+#define PSCAL_STRINGIFY(x) PSCAL_STRINGIFY_IMPL(x)
+
+#ifdef PROGRAM_VERSION
+#define PSCAL_PROGRAM_VERSION_RAW PSCAL_STRINGIFY(PROGRAM_VERSION)
+#else
+#define PSCAL_PROGRAM_VERSION_RAW PSCAL_STRINGIFY("undefined.version_DEV")
+#endif
+
+#ifdef PSCAL_GIT_TAG
+#define PSCAL_GIT_TAG_RAW PSCAL_STRINGIFY(PSCAL_GIT_TAG)
+#else
+#define PSCAL_GIT_TAG_RAW PSCAL_STRINGIFY("untagged")
+#endif
+
+static inline const char *pscal_normalize_define(const char *raw, char *buffer, size_t buffer_len) {
+    if (!raw) {
+        return "";
+    }
+
+    size_t len = strlen(raw);
+    if (len >= 2 && raw[0] == '"' && raw[len - 1] == '"') {
+        if (!buffer || buffer_len == 0) {
+            return "";
+        }
+
+        size_t copy_len = len - 2;
+        if (copy_len >= buffer_len) {
+            copy_len = buffer_len - 1;
+        }
+
+        memcpy(buffer, raw + 1, copy_len);
+        buffer[copy_len] = '\0';
+        return buffer;
+    }
+
+    return raw;
+}
+
+static inline const char *pscal_program_version_string(void) {
+    static int initialized = 0;
+    static char storage[sizeof(PSCAL_PROGRAM_VERSION_RAW)];
+    static const char *value = NULL;
+
+    if (!initialized) {
+        value = pscal_normalize_define(PSCAL_PROGRAM_VERSION_RAW, storage, sizeof(storage));
+        initialized = 1;
+    }
+
+    return value;
+}
+
+static inline const char *pscal_git_tag_string(void) {
+    static int initialized = 0;
+    static char storage[sizeof(PSCAL_GIT_TAG_RAW)];
+    static const char *value = NULL;
+
+    if (!initialized) {
+        value = pscal_normalize_define(PSCAL_GIT_TAG_RAW, storage, sizeof(storage));
+        initialized = 1;
+    }
+
+    return value;
+}
+
+#endif // PSCAL_BUILD_INFO_H

--- a/src/rea/main.c
+++ b/src/rea/main.c
@@ -35,6 +35,7 @@
 #include "core/cache.h"
 #include "core/utils.h"
 #include "core/preproc.h"
+#include "core/build_info.h"
 #include "symbol/symbol.h"
 #include "Pascal/globals.h"
 #include "ast/ast.h"
@@ -46,14 +47,6 @@
 #include "Pascal/lexer.h"
 #include "Pascal/parser.h"
 #include "ext_builtins/dump.h"
-
-#ifndef PROGRAM_VERSION
-#define PROGRAM_VERSION "undefined.version_DEV"
-#endif
-
-#ifndef PSCAL_GIT_TAG
-#define PSCAL_GIT_TAG "untagged"
-#endif
 
 int gParamCount = 0;
 char **gParamValues = NULL;
@@ -261,7 +254,7 @@ int main(int argc, char **argv) {
     while (argc > argi && argv[argi][0] == '-') {
         if (strcmp(argv[argi], "-v") == 0) {
             printf("Rea Compiler Version: %s (latest tag: %s)\n",
-                   PROGRAM_VERSION, PSCAL_GIT_TAG);
+                   pscal_program_version_string(), pscal_git_tag_string());
             return vmExitWithCleanup(EXIT_SUCCESS);
         } else if (strcmp(argv[argi], "--dump-ast-json") == 0) {
             dump_ast_json = 1;


### PR DESCRIPTION
## Summary
- add a shared helper that stringifies and normalizes PROGRAM_VERSION and PSCAL_GIT_TAG so builds tolerate unquoted defines
- use the sanitized build strings in the Pascal, C-like, and Rea entry points instead of the raw preprocessor macros

## Testing
- cmake -S . -B build
- cmake --build build --target pascal clike rea

------
https://chatgpt.com/codex/tasks/task_e_68d17dcb1f60832ab9074e5f5b2460c2