### PR TITLE
Add Xcode runner target for configurable launch

### DIFF
--- a/Docs/xcode.md
+++ b/Docs/xcode.md
@@ -23,6 +23,7 @@ The following command-line targets are available inside Xcode:
 - **clike** / **clike-repl** – Tiny C front-end and REPL
 - **rea** – REA front-end
 - **pscaljson2bc** – JSON-to-bytecode conversion utility
+- **pscal-runner** – Helper executable that launches another PSCAL binary
 
 Every target inherits the same header search paths and links against the system
 `curl`, `sqlite3`, `m`, and `pthread` libraries.  Extended builtins are enabled
@@ -38,3 +39,22 @@ CMake build.
 - SDL-dependent sources are present but guarded by `#ifdef SDL`; if you need the
   SDL runtime in Xcode, add the SDL frameworks via the target build settings and
   define the `SDL` macro.
+
+## Running Different Executables
+
+The shared **pascal** scheme now builds a lightweight `pscal-runner` helper.
+When you press **Run**, the helper invokes whichever PSCAL binary you request
+and forwards any launch arguments.
+
+- Use the scheme's *Run > Environment Variables* table to change the
+  `PSCAL_RUN_TARGET` value (default `pascal`). Set it to another product name
+  such as `pscalvm`, `clike`, or `pscaljson2bc`.
+- Alternatively, enable `PSCAL_RUN_EXECUTABLE` and point it at a specific
+  relative or absolute path if you need to run a custom build.
+- Arguments added under *Run > Arguments Passed On Launch* are passed directly
+  to the selected executable so you can test different flag combinations
+  without editing source files.
+
+This keeps the build products in sync—every binary listed above is built when
+you run the scheme—while making it easy to swap the active executable and its
+command-line arguments from inside Xcode.

--- a/src/xcode/runner_main.c
+++ b/src/xcode/runner_main.c
@@ -1,0 +1,88 @@
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static void print_error(const char *message) {
+    fprintf(stderr, "pscal-runner: %s\n", message);
+}
+
+static int join_path(char *dest, size_t dest_size, const char *prefix, const char *suffix) {
+    int written = snprintf(dest, dest_size, "%s%s", prefix, suffix);
+    if (written < 0 || (size_t)written >= dest_size) {
+        print_error("computed executable path is too long");
+        return -1;
+    }
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    char resolved_self[PATH_MAX];
+    if (realpath(argv[0], resolved_self) == NULL) {
+        fprintf(
+            stderr,
+            "pscal-runner: unable to resolve runner path '%s': %s\n",
+            argv[0],
+            strerror(errno)
+        );
+        return 1;
+    }
+
+    char runner_dir[PATH_MAX];
+    if (snprintf(runner_dir, sizeof(runner_dir), "%s", resolved_self) >= (int)sizeof(runner_dir)) {
+        print_error("runner path is too long");
+        return 1;
+    }
+
+    char *slash = strrchr(runner_dir, '/');
+    if (slash == NULL) {
+        print_error("runner path is missing a directory component");
+        return 1;
+    }
+    slash[1] = '\0';
+
+    const char *override_exec = getenv("PSCAL_RUN_EXECUTABLE");
+    const char *target_name = getenv("PSCAL_RUN_TARGET");
+    if (target_name == NULL || target_name[0] == '\0') {
+        target_name = "pascal";
+    }
+
+    char target_path[PATH_MAX];
+    if (override_exec != NULL && override_exec[0] != '\0') {
+        if (override_exec[0] == '/') {
+            if ((size_t)snprintf(target_path, sizeof(target_path), "%s", override_exec) >= sizeof(target_path)) {
+                print_error("override executable path is too long");
+                return 1;
+            }
+        } else if (join_path(target_path, sizeof(target_path), runner_dir, override_exec) != 0) {
+            return 1;
+        }
+    } else if (join_path(target_path, sizeof(target_path), runner_dir, target_name) != 0) {
+        return 1;
+    }
+
+    if (access(target_path, X_OK) != 0) {
+        fprintf(stderr, "pscal-runner: executable '%s' is not available: %s\n", target_path, strerror(errno));
+        return 1;
+    }
+
+    char **child_argv = calloc((size_t)argc + 1, sizeof(char *));
+    if (child_argv == NULL) {
+        print_error("out of memory");
+        return 1;
+    }
+
+    child_argv[0] = target_path;
+    for (int index = 1; index < argc; ++index) {
+        child_argv[index] = argv[index];
+    }
+
+    fprintf(stderr, "pscal-runner: executing %s\n", target_path);
+    execv(target_path, child_argv);
+
+    fprintf(stderr, "pscal-runner: execv('%s') failed: %s\n", target_path, strerror(errno));
+    free(child_argv);
+    return 1;
+}

--- a/tools/generate_xcodeproj.py
+++ b/tools/generate_xcodeproj.py
@@ -368,6 +368,12 @@ def build_project(output_path: Path, release_build: bool) -> None:
                 },
             ),
             ("pscaljson2bc", {"sources": json2bc_sources}),
+            (
+                "pscal-runner",
+                {
+                    "sources": ["src/xcode/runner_main.c"],
+                },
+            ),
         ]
     )
 

--- a/xcode/Pscal.xcodeproj/project.pbxproj
+++ b/xcode/Pscal.xcodeproj/project.pbxproj
@@ -696,6 +696,10 @@
 			isa = PBXBuildFile;
 			fileRef = DB7CB696D0F4C0200AA3ACE1 /* register.c */;
 		};
+		822F9BEBBDF6F639CEF6BBD1 /* runner_main.c in Sources */ = {
+			isa = PBXBuildFile;
+			fileRef = 9827DC89B3A8EA0C881347BE /* runner_main.c */;
+		};
 		82464A15DEA94F45336D18A9 /* swap.c in Sources */ = {
 			isa = PBXBuildFile;
 			fileRef = 78E382CA6464C0DA12F3C75F /* swap.c */;
@@ -1587,6 +1591,13 @@
 			path = "query_builtin.c";
 			sourceTree = "<group>";
 		};
+		9827DC89B3A8EA0C881347BE /* runner_main.c */ = {
+			isa = PBXFileReference;
+			fileEncoding = 4;
+			lastKnownFileType = "sourcecode.c.c";
+			path = "runner_main.c";
+			sourceTree = "<group>";
+		};
 		988F98CFBAF3556D194CA40E /* register.c */ = {
 			isa = PBXFileReference;
 			fileEncoding = 4;
@@ -1663,6 +1674,13 @@
 			lastKnownFileType = "sourcecode.c.c";
 			path = "getpid.c";
 			sourceTree = "<group>";
+		};
+		C04721785837A0EB7B9D8A1D /* pscal-runner */ = {
+			isa = PBXFileReference;
+			explicitFileType = "compiled.mach-o.executable";
+			includeInIndex = 0;
+			path = "pscal-runner";
+			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		CFD96FBE09D3B3111F48DAFD /* bytecode.c */ = {
 			isa = PBXFileReference;
@@ -1796,6 +1814,12 @@
 			lastKnownFileType = "sourcecode.c.c";
 			path = "registry.c";
 			sourceTree = "<group>";
+		};
+		0D70100BC7F7B0C188AB492A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = ();
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 		18DF9DF2E9ED7EA5AFB0F8A3 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
@@ -2032,6 +2056,14 @@
 					3BBFCC2C6ADB64C33F6BADE2 /* sqlite_builtins.c in Sources */,
 					73448BECBF9C5757A08EC790 /* register.c in Sources */,
 					EAF2E939EE747A91EAB9D58B /* yyjson.c in Sources */,
+				);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6225352F9B46B59DB9253B17 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+					822F9BEBBDF6F639CEF6BBD1 /* runner_main.c in Sources */,
 				);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2331,6 +2363,15 @@
 			path = backend_ast;
 			name = backend_ast;
 		};
+		644211163E78545FC77F2AFC /* xcode */ = {
+			isa = PBXGroup;
+			children = (
+					9827DC89B3A8EA0C881347BE /* runner_main.c */,
+				);
+			sourceTree = "<group>";
+			path = xcode;
+			name = xcode;
+		};
 		89733B26D163C0BDF7131316 /* vm */ = {
 			isa = PBXGroup;
 			children = (
@@ -2348,6 +2389,7 @@
 					EB2C57F0682B5DF0D65C851D /* clike-repl */,
 					88FB6D7F8F9A20A50F7FB116 /* dascal */,
 					780ED30DC78EA640890E2AC6 /* pascal */,
+					C04721785837A0EB7B9D8A1D /* pscal-runner */,
 					80E7B0E79A788C3B481159AB /* pscald */,
 					A2EA821998C06580C5BB49AB /* pscaljson2bc */,
 					E0BB334EC6C0A1BEC70B2E19 /* pscalvm */,
@@ -2496,10 +2538,25 @@
 					D5A504733A16870BEDB85144 /* third_party */,
 					C8A1EC4ACBD71C1A702DB301 /* tools */,
 					89733B26D163C0BDF7131316 /* vm */,
+					644211163E78545FC77F2AFC /* xcode */,
 				);
 			sourceTree = "<group>";
 			path = src;
 			name = src;
+		};
+		042E9EE660D16CAF2B97C13D /* pscal-runner */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FC013A7165AF77834EB6083D /* Build configuration list for PBXNativeTarget "pscal-runner" */;
+			buildPhases = (
+					6225352F9B46B59DB9253B17 /* Sources */,
+					0D70100BC7F7B0C188AB492A /* Frameworks */,
+				);
+			buildRules = ();
+			dependencies = ();
+			name = "pscal-runner";
+			productName = "pscal-runner";
+			productReference = C04721785837A0EB7B9D8A1D /* pscal-runner */;
+			productType = "com.apple.product-type.tool";
 		};
 		10357B4171CB4A9AD54D88D2 /* pscalvm */ = {
 			isa = PBXNativeTarget;
@@ -2651,6 +2708,10 @@
 						CreatedOnToolsVersion = "15.0";
 						ProvisioningStyle = Automatic;
 					};
+					042E9EE660D16CAF2B97C13D = {
+						CreatedOnToolsVersion = "15.0";
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = 312100B82E481929C53FCB71 /* Build configuration list for PBXProject "Pscal" */;
@@ -2674,6 +2735,7 @@
 					985BEEC4149D1FE3D8B1FE84 /* clike-repl */,
 					CDD43774BFDB2E25DBF71290 /* rea */,
 					82B740F1338F2D1E38BD662A /* pscaljson2bc */,
+					042E9EE660D16CAF2B97C13D /* pscal-runner */,
 				);
 		};
 		092247FF457ECF0C36067D0E /* Debug */ = {
@@ -2717,7 +2779,7 @@
 						"ENABLE_EXT_BUILTIN_USER=1",
 						"ENABLE_EXT_BUILTIN_YYJSON=1",
 						"ENABLE_EXT_BUILTIN_SQLITE=1",
-						"PROGRAM_VERSION=\"20250922.1600_DEV\"",
+						"PROGRAM_VERSION=\"20250922.1722_DEV\"",
 						"PSCAL_GIT_TAG=\"untagged\"",
 						"DEBUG=1",
 					);
@@ -2856,6 +2918,32 @@
 			};
 			name = Debug;
 		};
+		5066F2CEF4B4BD478E45C845 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGNING_ALLOWED = NO;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_BITCODE = NO;
+				HEADER_SEARCH_PATHS = (
+						"$(inherited)",
+					);
+				LIBRARY_SEARCH_PATHS = (
+						"$(inherited)",
+					);
+				OTHER_CFLAGS = (
+						"$(inherited)",
+					);
+				OTHER_LDFLAGS = (
+						"$(inherited)",
+					);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+						"$(inherited)",
+					);
+			};
+			name = Release;
+		};
 		63B8BC9736645B3F130936BE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2990,6 +3078,32 @@
 			};
 			name = Release;
 		};
+		8D68A6D038B3B45598312C5E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGNING_ALLOWED = NO;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_BITCODE = NO;
+				HEADER_SEARCH_PATHS = (
+						"$(inherited)",
+					);
+				LIBRARY_SEARCH_PATHS = (
+						"$(inherited)",
+					);
+				OTHER_CFLAGS = (
+						"$(inherited)",
+					);
+				OTHER_LDFLAGS = (
+						"$(inherited)",
+					);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+						"$(inherited)",
+					);
+			};
+			name = Debug;
+		};
 		8E6C5F4C8C10F477F2E498AB /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3031,7 +3145,7 @@
 						"ENABLE_EXT_BUILTIN_USER=1",
 						"ENABLE_EXT_BUILTIN_YYJSON=1",
 						"ENABLE_EXT_BUILTIN_SQLITE=1",
-						"PROGRAM_VERSION=\"20250922.1600_DEV\"",
+						"PROGRAM_VERSION=\"20250922.1722_DEV\"",
 						"PSCAL_GIT_TAG=\"untagged\"",
 						"NDEBUG=1",
 					);
@@ -3273,6 +3387,15 @@
 			buildConfigurations = (
 					A4634666B8FE2290D35B8C1C /* Debug */,
 					42144B629B17D7910882E00C /* Release */,
+				);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FC013A7165AF77834EB6083D /* Build configuration list for PBXNativeTarget "pscal-runner" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+					8D68A6D038B3B45598312C5E /* Debug */,
+					5066F2CEF4B4BD478E45C845 /* Release */,
 				);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/xcode/Pscal.xcodeproj/xcshareddata/xcschemes/pascal.xcscheme
+++ b/xcode/Pscal.xcodeproj/xcshareddata/xcschemes/pascal.xcscheme
@@ -7,6 +7,20 @@
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "042E9EE660D16CAF2B97C13D"
+               BuildableName = "pscal-runner"
+               BlueprintName = "pscal-runner"
+               ReferencedContainer = "container:Pscal.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
             buildForProfiling = "YES"
@@ -17,6 +31,104 @@
                BlueprintIdentifier = "5E25023744E0C0A65A215CA9"
                BuildableName = "pascal"
                BlueprintName = "pascal"
+               ReferencedContainer = "container:Pscal.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "10357B4171CB4A9AD54D88D2"
+               BuildableName = "pscalvm"
+               BlueprintName = "pscalvm"
+               ReferencedContainer = "container:Pscal.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "82B740F1338F2D1E38BD662A"
+               BuildableName = "pscaljson2bc"
+               BlueprintName = "pscaljson2bc"
+               ReferencedContainer = "container:Pscal.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "88B0AF68E103CCC4F85A8070"
+               BuildableName = "clike"
+               BlueprintName = "clike"
+               ReferencedContainer = "container:Pscal.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "985BEEC4149D1FE3D8B1FE84"
+               BuildableName = "clike-repl"
+               BlueprintName = "clike-repl"
+               ReferencedContainer = "container:Pscal.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CDD43774BFDB2E25DBF71290"
+               BuildableName = "rea"
+               BlueprintName = "rea"
+               ReferencedContainer = "container:Pscal.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D46234A48DF5C07F314CF022"
+               BuildableName = "dascal"
+               BlueprintName = "dascal"
+               ReferencedContainer = "container:Pscal.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EF0A27A8DC1B4F130FC6CECC"
+               BuildableName = "pscald"
+               BlueprintName = "pscald"
                ReferencedContainer = "container:Pscal.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -44,12 +156,26 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "5E25023744E0C0A65A215CA9"
-            BuildableName = "pascal"
-            BlueprintName = "pascal"
+            BlueprintIdentifier = "042E9EE660D16CAF2B97C13D"
+            BuildableName = "pscal-runner"
+            BlueprintName = "pscal-runner"
             ReferencedContainer = "container:Pscal.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "PSCAL_RUN_TARGET"
+            value = "pascal"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "PSCAL_RUN_EXECUTABLE"
+            value = ""
+            isEnabled = "NO">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -61,9 +187,9 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "5E25023744E0C0A65A215CA9"
-            BuildableName = "pascal"
-            BlueprintName = "pascal"
+            BlueprintIdentifier = "042E9EE660D16CAF2B97C13D"
+            BuildableName = "pscal-runner"
+            BlueprintName = "pscal-runner"
             ReferencedContainer = "container:Pscal.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>


### PR DESCRIPTION
## Summary
- add a lightweight pscal-runner target that executes the selected PSCAL binary
- update the shared scheme and docs so the Run action can pick executables and forward command-line arguments
- teach the Xcode project generator about the new target so regenerating keeps the configuration

## Testing
- python tools/generate_xcodeproj.py

------
https://chatgpt.com/codex/tasks/task_e_68d183d923cc832a8ad5b523a3bf1564