### PR TITLE
Fix debug global linkage for Xcode targets

### DIFF
--- a/src/Pascal/globals.c
+++ b/src/Pascal/globals.c
@@ -13,6 +13,10 @@
 int last_io_error = 0; // Stores the error code of the last I/O operation.
 int typeWarn = 1; // Flag to control type warning messages (e.g., 1 for enabled, 0 for disabled).
 
+#ifdef DEBUG
+List *inserted_global_names = NULL; // Tracks globals inserted during debugging sessions.
+#endif
+
 // Symbol table globals - NOW POINTERS TO HASHTABLES.
 // These will be initialized by calling createHashTable() in initSymbolSystem().
 HashTable *globalSymbols = NULL; // Global symbol table (initialized to NULL, will point to a HashTable).

--- a/src/Pascal/main.c
+++ b/src/Pascal/main.c
@@ -55,10 +55,6 @@
 int gParamCount = 0;
 char **gParamValues = NULL;
 
-#ifdef DEBUG
-List *inserted_global_names = NULL;
-#endif
-
 static int s_vm_trace_head = 0;
 
 typedef struct {


### PR DESCRIPTION
## Summary
- define the debug-only `inserted_global_names` global in `globals.c` so every target exports it
- remove the redundant definition from the Pascal front-end main file

## Testing
- cmake -S . -B build
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_e_68d18c6679d4832a973bc8d76594427e