### PR TITLE
Clarify pascal args for Xcode runner

### DIFF
--- a/xcode/README.md
+++ b/xcode/README.md
@@ -17,6 +17,10 @@ keys:
   `clike`, `clike-repl`, or `rea`).
 - `args` – shell-style argument string.  Add multiple `args` entries if you want
   to append more pieces of the command line.
+- When launching the `pascal` front end pass the source file path directly as an
+  argument (`args = "Examples/Pascal/ThreadsProcPtrDemo.pas"`).  VM-specific
+  flags such as `--input` are only accepted by binaries like `pscalvm` or
+  `pscald`.
 - `working_dir` – optional working directory.  Relative paths are resolved from
   the configuration file's location, so the default `..` value points at the
   repository root.

--- a/xcode/RunConfiguration.cfg
+++ b/xcode/RunConfiguration.cfg
@@ -14,7 +14,10 @@ binary = pascal
 # escape characters.  Specify additional "args" lines to append more
 # segments to the command line.
 # args = --help
-# args = --input "Examples/Pascal/ThreadsProcPtrDemo.pas"
+# args = "Examples/Pascal/ThreadsProcPtrDemo.pas"
+# args = "Examples/Pascal/ThreadsProcPtrDemo.pas" "--some-program-arg"
+# When using the `pascal` front end provide the source file directly.
+# Switch to `binary = pscalvm` if you need VM-style flags such as `--input`.
 
 # Working directory for the launched process.  Relative paths are
 # resolved against this file's location.  The default changes to the


### PR DESCRIPTION
## Summary
- document that the pascal front end expects a direct source file path
- update the sample arguments in RunConfiguration.cfg to avoid the unsupported --input flag

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d1a8ced018832aa806c64658a3eabf