### PR TITLE
Seed SDL include paths for Xcode builds

### DIFF
--- a/Docs/xcode.md
+++ b/Docs/xcode.md
@@ -52,8 +52,11 @@ schemes:
 3. Open the **Build Phases** tab, expand **Link Binary With Libraries**, and add
    `SDL2.framework`, `SDL2_ttf.framework`, and `SDL2_mixer.framework` (or the
    dynamic libraries from Homebrew if you prefer `.dylib`s).
-4. If the SDL headers live outside `/Library/Frameworks`, add the parent folder
-   to **Header Search Paths** (e.g. `/opt/homebrew/include`).
+4. The generated project now seeds common SDL include locations—Homebrew's
+   `/opt/homebrew/include`, `/usr/local/include`, and the standard
+   `SDL2.framework` headers—so most macOS setups work without extra tweaks. If
+   your installation lives somewhere else, add its parent folder to
+   **Header Search Paths**.
 5. Clean and rebuild; SDL-only examples such as
    `Examples/Pascal/SDLMultiBouncingBalls` will now launch from within Xcode.
 

--- a/tools/generate_xcodeproj.py
+++ b/tools/generate_xcodeproj.py
@@ -24,6 +24,22 @@ PROJECT_NAME = "Pscal"
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
+SDL_HEADER_HINTS = [
+    "/Library/Frameworks/SDL2.framework/Headers",
+    "$(HOME)/Library/Frameworks/SDL2.framework/Headers",
+    "/opt/homebrew/include",
+    "/opt/homebrew/include/SDL2",
+    "/opt/homebrew/opt/sdl2/include",
+    "/opt/homebrew/opt/sdl2/include/SDL2",
+    "/usr/local/include",
+    "/usr/local/include/SDL2",
+    "/usr/local/opt/sdl2/include",
+    "/usr/local/opt/sdl2/include/SDL2",
+    "/usr/include",
+    "/usr/include/SDL2",
+]
+
+
 def determine_version_info(release_build: bool) -> Tuple[str, str]:
     """Mirror the CMake version and tag discovery logic."""
 
@@ -476,6 +492,10 @@ def build_project(output_path: Path, release_build: bool) -> None:
     # that subdirectory. Header includes in the source expect to resolve against
     # the repository root (e.g. "core/utils.h"), so the header search path must
     # explicitly reach back up to the real src/ tree.
+    header_search_paths = ["$(PROJECT_DIR)/../src", "$(PROJECT_DIR)/../src/**"]
+    header_search_paths.extend(SDL_HEADER_HINTS)
+    header_search_paths = list(dict.fromkeys(header_search_paths))
+
     common_project_settings = OrderedDict(
         [
             ("ALWAYS_SEARCH_USER_PATHS", "NO"),
@@ -483,7 +503,7 @@ def build_project(output_path: Path, release_build: bool) -> None:
             ("CODE_SIGNING_ALLOWED", "NO"),
             ("ENABLE_BITCODE", "NO"),
             ("GCC_PREPROCESSOR_DEFINITIONS", ["$(inherited)"] + base_preprocessor_defs),
-            ("HEADER_SEARCH_PATHS", ["$(PROJECT_DIR)/../src", "$(PROJECT_DIR)/../src/**"]),
+            ("HEADER_SEARCH_PATHS", header_search_paths),
             ("LIBRARY_SEARCH_PATHS", ["$(inherited)"]),
             ("MACOSX_DEPLOYMENT_TARGET", "11.0"),
             ("OTHER_CFLAGS", ["$(inherited)", "-Wall"]),

--- a/xcode/Pscal.xcodeproj/project.pbxproj
+++ b/xcode/Pscal.xcodeproj/project.pbxproj
@@ -2837,10 +2837,22 @@
 						"PSCAL_GIT_TAG=\"untagged\"",
 						"DEBUG=1",
 					);
-				HEADER_SEARCH_PATHS = (
-						"$(PROJECT_DIR)/../src",
-						"$(PROJECT_DIR)/../src/**",
-					);
+                               HEADER_SEARCH_PATHS = (
+                                               "$(PROJECT_DIR)/../src",
+                                               "$(PROJECT_DIR)/../src/**",
+                                               "/Library/Frameworks/SDL2.framework/Headers",
+                                               "$(HOME)/Library/Frameworks/SDL2.framework/Headers",
+                                               "/opt/homebrew/include",
+                                               "/opt/homebrew/include/SDL2",
+                                               "/opt/homebrew/opt/sdl2/include",
+                                               "/opt/homebrew/opt/sdl2/include/SDL2",
+                                               "/usr/local/include",
+                                               "/usr/local/include/SDL2",
+                                               "/usr/local/opt/sdl2/include",
+                                               "/usr/local/opt/sdl2/include/SDL2",
+                                               "/usr/include",
+                                               "/usr/include/SDL2",
+                                       );
 				LIBRARY_SEARCH_PATHS = (
 						"$(inherited)",
 					);
@@ -3179,10 +3191,22 @@
 						"PSCAL_GIT_TAG=\"untagged\"",
 						"NDEBUG=1",
 					);
-				HEADER_SEARCH_PATHS = (
-						"$(PROJECT_DIR)/../src",
-						"$(PROJECT_DIR)/../src/**",
-					);
+                               HEADER_SEARCH_PATHS = (
+                                               "$(PROJECT_DIR)/../src",
+                                               "$(PROJECT_DIR)/../src/**",
+                                               "/Library/Frameworks/SDL2.framework/Headers",
+                                               "$(HOME)/Library/Frameworks/SDL2.framework/Headers",
+                                               "/opt/homebrew/include",
+                                               "/opt/homebrew/include/SDL2",
+                                               "/opt/homebrew/opt/sdl2/include",
+                                               "/opt/homebrew/opt/sdl2/include/SDL2",
+                                               "/usr/local/include",
+                                               "/usr/local/include/SDL2",
+                                               "/usr/local/opt/sdl2/include",
+                                               "/usr/local/opt/sdl2/include/SDL2",
+                                               "/usr/include",
+                                               "/usr/include/SDL2",
+                                       );
 				LIBRARY_SEARCH_PATHS = (
 						"$(inherited)",
 					);


### PR DESCRIPTION
## Summary
- seed the Xcode project generator with common SDL include search hints
- bake the SDL include hints into the checked-in project so Debug/Release pick them up
- document that the project now pre-populates typical SDL header paths

## Testing
- python tools/generate_xcodeproj.py --output /tmp/test.pbxproj


------
https://chatgpt.com/codex/tasks/task_e_68d1ba394c24832aaddf22978fecd8bb