### PR TITLE
Add Rea OpenWeather forecast example

### DIFF
--- a/Examples/rea/openweather_forecast
+++ b/Examples/rea/openweather_forecast
@@ -1,0 +1,446 @@
+#!/usr/bin/env rea
+// OpenWeather One Call 3.0 forecast demo.
+// Documentation: https://openweathermap.org/api/one-call-3
+// Usage: RUN_NET_TESTS=1 OPENWEATHER_API_KEY=<key> ./openweather_forecast <zip> [country] [units]
+
+str pad2(int value) {
+  if (value < 10) {
+    return "0" + inttostr(value);
+  }
+  return inttostr(value);
+}
+
+str formatUtcOffset(int offsetSeconds) {
+  int absSeconds = offsetSeconds;
+  str sign = "+";
+  if (absSeconds < 0) {
+    sign = "-";
+    absSeconds = -absSeconds;
+  }
+  int hours = absSeconds / 3600;
+  int minutes = (absSeconds % 3600) / 60;
+  return sign + pad2(hours) + ":" + pad2(minutes);
+}
+
+str formatDateTime(int epochSeconds, int offsetSeconds) {
+  int total = epochSeconds + offsetSeconds;
+  if (total < 0) {
+    total = 0;
+  }
+  int days = total / 86400;
+  int secondsOfDay = total % 86400;
+  int hour = secondsOfDay / 3600;
+  int minute = (secondsOfDay % 3600) / 60;
+
+  int z = days + 719468;
+  int era;
+  if (z >= 0) {
+    era = z / 146097;
+  } else {
+    era = (z - 146096) / 146097;
+  }
+  int doe = z - era * 146097;
+  int yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+  int year = yoe + era * 400;
+  int doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+  int mp = (5 * doy + 2) / 153;
+  int day = doy - (153 * mp + 2) / 5 + 1;
+  int month;
+  if (mp < 10) {
+    month = mp + 3;
+  } else {
+    month = mp - 9;
+  }
+  if (month <= 2) {
+    year = year + 1;
+  }
+
+  str date = inttostr(year) + "-" + pad2(month) + "-" + pad2(day);
+  return date + " " + pad2(hour) + ":" + pad2(minute);
+}
+
+int main() {
+  if (getenvint("RUN_NET_TESTS", 0) != 1) {
+    writeln("RUN_NET_TESTS=1 is required to run this network demo. Exiting without contacting the API.");
+    return 0;
+  }
+
+  if (!hasextbuiltin("yyjson", "YyjsonRead")) {
+    writeln("Error: yyjson extended built-ins are required. Rebuild with yyjson support enabled.");
+    return 1;
+  }
+
+  str apiKey = getenv("OPENWEATHER_API_KEY");
+  if (apiKey == "") {
+    writeln("Error: Please set the OPENWEATHER_API_KEY environment variable with your OpenWeather API key.");
+    return 1;
+  }
+
+  int argc = paramcount();
+  str programName = paramstr(0);
+  if (argc < 1) {
+    writeln("Usage: ", programName, " <zip> [country] [units]");
+    writeln("  country defaults to US; units may be imperial, metric, or standard.");
+    return 1;
+  }
+
+  str zip = paramstr(1);
+  str country = "US";
+  if (argc >= 2) {
+    str c = paramstr(2);
+    if (c != "") {
+      country = c;
+    }
+  }
+
+  str unitsInput = "imperial";
+  if (argc >= 3) {
+    str u = paramstr(3);
+    if (u != "") {
+      unitsInput = u;
+    }
+  }
+
+  str unitsParam;
+  str tempUnitSymbol;
+  if (unitsInput == "imperial" || unitsInput == "Imperial" || unitsInput == "IMPERIAL") {
+    unitsParam = "imperial";
+    tempUnitSymbol = "°F";
+  } else if (unitsInput == "metric" || unitsInput == "Metric" || unitsInput == "METRIC") {
+    unitsParam = "metric";
+    tempUnitSymbol = "°C";
+  } else if (unitsInput == "standard" || unitsInput == "Standard" || unitsInput == "STANDARD") {
+    unitsParam = "standard";
+    tempUnitSymbol = "K";
+  } else {
+    writeln("Warning: Unknown units '", unitsInput, "'. Falling back to 'imperial'.");
+    unitsParam = "imperial";
+    tempUnitSymbol = "°F";
+  }
+
+  int session = httpsession();
+  if (session < 0) {
+    writeln("Error: Unable to allocate an HTTP session.");
+    return 1;
+  }
+
+  httpsetheader(session, "Accept", "application/json");
+
+  bool ok = true;
+  int exitCode = 0;
+  float lat = 0.0;
+  float lon = 0.0;
+  str resolvedZip = zip;
+  str placeName = "";
+  str stateName = "";
+  str countryName = "";
+
+  if (ok) {
+    str geocodeUrl = "https://api.openweathermap.org/geo/1.0/zip?zip=" + zip + "," + country + "&appid=" + apiKey;
+    mstream geoOut = mstreamcreate();
+    int geoStatus = httprequest(session, "GET", geocodeUrl, nil, geoOut);
+    str geoBody = mstreambuffer(geoOut);
+
+    if (geoStatus != 200) {
+      writeln("Geocoding request failed with HTTP status ", geoStatus, ".");
+      if (geoBody != "") {
+        writeln("Response: ", geoBody);
+      }
+      ok = false;
+      exitCode = 1;
+    } else {
+      int geoDoc = YyjsonRead(geoBody);
+      if (geoDoc < 0) {
+        writeln("Error: Failed to parse geocoding response as JSON.");
+        ok = false;
+        exitCode = 1;
+      } else {
+        int geoRoot = YyjsonGetRoot(geoDoc);
+        int latHandle = YyjsonGetKey(geoRoot, "lat");
+        int lonHandle = YyjsonGetKey(geoRoot, "lon");
+        if (latHandle < 0 || lonHandle < 0) {
+          int messageHandle = YyjsonGetKey(geoRoot, "message");
+          if (messageHandle >= 0) {
+            writeln("Geocoding API error: ", YyjsonGetString(messageHandle));
+            YyjsonFreeValue(messageHandle);
+          } else {
+            writeln("Geocoding response was missing coordinates.");
+          }
+          if (latHandle >= 0) { YyjsonFreeValue(latHandle); }
+          if (lonHandle >= 0) { YyjsonFreeValue(lonHandle); }
+          ok = false;
+          exitCode = 1;
+        } else {
+          lat = YyjsonGetNumber(latHandle);
+          lon = YyjsonGetNumber(lonHandle);
+          YyjsonFreeValue(latHandle);
+          YyjsonFreeValue(lonHandle);
+
+          int zipHandle = YyjsonGetKey(geoRoot, "zip");
+          if (zipHandle >= 0) {
+            resolvedZip = YyjsonGetString(zipHandle);
+            YyjsonFreeValue(zipHandle);
+          }
+          int nameHandle = YyjsonGetKey(geoRoot, "name");
+          if (nameHandle >= 0) {
+            placeName = YyjsonGetString(nameHandle);
+            YyjsonFreeValue(nameHandle);
+          }
+          int stateHandle = YyjsonGetKey(geoRoot, "state");
+          if (stateHandle >= 0) {
+            stateName = YyjsonGetString(stateHandle);
+            YyjsonFreeValue(stateHandle);
+          }
+          int countryHandle = YyjsonGetKey(geoRoot, "country");
+          if (countryHandle >= 0) {
+            countryName = YyjsonGetString(countryHandle);
+            YyjsonFreeValue(countryHandle);
+          }
+        }
+        YyjsonFreeValue(geoRoot);
+        YyjsonDocFree(geoDoc);
+      }
+    }
+    mstreamfree(geoOut);
+  }
+
+  if (ok) {
+    str latStr = realtostr(lat);
+    str lonStr = realtostr(lon);
+    str forecastUrl = "https://api.openweathermap.org/data/3.0/onecall?lat=" + latStr + "&lon=" + lonStr + "&units=" + unitsParam + "&exclude=minutely,alerts&appid=" + apiKey;
+    mstream forecastOut = mstreamcreate();
+    int forecastStatus = httprequest(session, "GET", forecastUrl, nil, forecastOut);
+    str forecastBody = mstreambuffer(forecastOut);
+
+    if (forecastStatus != 200) {
+      writeln("Forecast request failed with HTTP status ", forecastStatus, ".");
+      if (forecastBody != "") {
+        writeln("Response: ", forecastBody);
+      }
+      ok = false;
+      exitCode = 1;
+    } else {
+      int forecastDoc = YyjsonRead(forecastBody);
+      if (forecastDoc < 0) {
+        writeln("Error: Failed to parse forecast response as JSON.");
+        ok = false;
+        exitCode = 1;
+      } else {
+        int root = YyjsonGetRoot(forecastDoc);
+        bool forecastOk = true;
+
+        int codHandle = YyjsonGetKey(root, "cod");
+        if (codHandle >= 0) {
+          int messageHandle = YyjsonGetKey(root, "message");
+          if (messageHandle >= 0) {
+            writeln("One Call API error: ", YyjsonGetString(messageHandle));
+            YyjsonFreeValue(messageHandle);
+          } else {
+            writeln("One Call API returned an error response.");
+          }
+          YyjsonFreeValue(codHandle);
+          forecastOk = false;
+          ok = false;
+          exitCode = 1;
+        }
+
+        int timezoneOffset = 0;
+        str timezoneName = "";
+        if (forecastOk) {
+          int tzHandle = YyjsonGetKey(root, "timezone");
+          if (tzHandle >= 0) {
+            timezoneName = YyjsonGetString(tzHandle);
+            YyjsonFreeValue(tzHandle);
+          }
+          int tzOffsetHandle = YyjsonGetKey(root, "timezone_offset");
+          if (tzOffsetHandle >= 0) {
+            timezoneOffset = (int)YyjsonGetInt(tzOffsetHandle);
+            YyjsonFreeValue(tzOffsetHandle);
+          }
+
+          str locationLine;
+          if (placeName != "") {
+            locationLine = "Forecast for " + placeName;
+            if (stateName != "") {
+              locationLine = locationLine + ", " + stateName;
+            }
+            if (countryName != "") {
+              locationLine = locationLine + " " + countryName;
+            }
+            locationLine = locationLine + " (" + resolvedZip + ")";
+          } else {
+            locationLine = "Forecast for " + resolvedZip;
+            if (countryName != "") {
+              locationLine = locationLine + " " + countryName;
+            }
+          }
+
+          writeln(locationLine);
+          writeln("Coordinates: ", latStr, ", ", lonStr);
+          str offsetStr = formatUtcOffset(timezoneOffset);
+          if (timezoneName != "") {
+            writeln("Timezone: ", timezoneName, " (UTC", offsetStr, ")");
+          } else {
+            writeln("Timezone offset: UTC", offsetStr);
+          }
+          writeln("Units: ", unitsParam, " (temperature in ", tempUnitSymbol, ")");
+
+          int currentHandle = YyjsonGetKey(root, "current");
+          if (currentHandle >= 0) {
+            float currentTemp = 0.0;
+            int humidity = -1;
+            str currentSummary = "";
+            int currentTempHandle = YyjsonGetKey(currentHandle, "temp");
+            if (currentTempHandle >= 0) {
+              currentTemp = YyjsonGetNumber(currentTempHandle);
+              YyjsonFreeValue(currentTempHandle);
+            }
+            int humidityHandle = YyjsonGetKey(currentHandle, "humidity");
+            if (humidityHandle >= 0) {
+              humidity = (int)YyjsonGetInt(humidityHandle);
+              YyjsonFreeValue(humidityHandle);
+            }
+            int weatherArrayHandle = YyjsonGetKey(currentHandle, "weather");
+            if (weatherArrayHandle >= 0) {
+              int weatherLen = YyjsonGetLength(weatherArrayHandle);
+              if (weatherLen > 0) {
+                int weatherEntry = YyjsonGetIndex(weatherArrayHandle, 0);
+                if (weatherEntry >= 0) {
+                  int descHandle = YyjsonGetKey(weatherEntry, "description");
+                  if (descHandle >= 0) {
+                    currentSummary = YyjsonGetString(descHandle);
+                    YyjsonFreeValue(descHandle);
+                  }
+                  YyjsonFreeValue(weatherEntry);
+                }
+              }
+              YyjsonFreeValue(weatherArrayHandle);
+            }
+            str summaryText = currentSummary;
+            if (summaryText == "") {
+              summaryText = "No description";
+            }
+            if (humidity >= 0) {
+              printf("Current: %.1f%s, %s (humidity %d%%)\n", currentTemp, tempUnitSymbol, summaryText, humidity);
+            } else {
+              printf("Current: %.1f%s, %s\n", currentTemp, tempUnitSymbol, summaryText);
+            }
+            YyjsonFreeValue(currentHandle);
+          }
+
+          int dailyHandle = YyjsonGetKey(root, "daily");
+          if (dailyHandle >= 0) {
+            int dailyLen = YyjsonGetLength(dailyHandle);
+            if (dailyLen > 0) {
+              writeln("\nDaily forecast:");
+            }
+            int daysToShow = dailyLen;
+            if (daysToShow > 7) {
+              daysToShow = 7;
+            }
+            int i = 0;
+            while (i < daysToShow) {
+              int dayHandle = YyjsonGetIndex(dailyHandle, i);
+              if (dayHandle >= 0) {
+                int dtHandle = YyjsonGetKey(dayHandle, "dt");
+                int dt = 0;
+                if (dtHandle >= 0) {
+                  dt = (int)YyjsonGetInt(dtHandle);
+                  YyjsonFreeValue(dtHandle);
+                }
+                str dayLabel = formatDateTime(dt, timezoneOffset);
+
+                float minTemp = 0.0;
+                float maxTemp = 0.0;
+                int tempBlock = YyjsonGetKey(dayHandle, "temp");
+                if (tempBlock >= 0) {
+                  int minHandle = YyjsonGetKey(tempBlock, "min");
+                  if (minHandle >= 0) {
+                    minTemp = YyjsonGetNumber(minHandle);
+                    YyjsonFreeValue(minHandle);
+                  }
+                  int maxHandle = YyjsonGetKey(tempBlock, "max");
+                  if (maxHandle >= 0) {
+                    maxTemp = YyjsonGetNumber(maxHandle);
+                    YyjsonFreeValue(maxHandle);
+                  }
+                  YyjsonFreeValue(tempBlock);
+                }
+
+                float pop = -1.0;
+                int popHandle = YyjsonGetKey(dayHandle, "pop");
+                if (popHandle >= 0) {
+                  pop = YyjsonGetNumber(popHandle);
+                  YyjsonFreeValue(popHandle);
+                }
+
+                float rain = -1.0;
+                int rainHandle = YyjsonGetKey(dayHandle, "rain");
+                if (rainHandle >= 0) {
+                  rain = YyjsonGetNumber(rainHandle);
+                  YyjsonFreeValue(rainHandle);
+                }
+
+                float snow = -1.0;
+                int snowHandle = YyjsonGetKey(dayHandle, "snow");
+                if (snowHandle >= 0) {
+                  snow = YyjsonGetNumber(snowHandle);
+                  YyjsonFreeValue(snowHandle);
+                }
+
+                str summary = "";
+                int weatherHandle = YyjsonGetKey(dayHandle, "weather");
+                if (weatherHandle >= 0) {
+                  int weatherLen = YyjsonGetLength(weatherHandle);
+                  if (weatherLen > 0) {
+                    int weatherEntry = YyjsonGetIndex(weatherHandle, 0);
+                    if (weatherEntry >= 0) {
+                      int descHandle = YyjsonGetKey(weatherEntry, "description");
+                      if (descHandle >= 0) {
+                        summary = YyjsonGetString(descHandle);
+                        YyjsonFreeValue(descHandle);
+                      }
+                      YyjsonFreeValue(weatherEntry);
+                    }
+                  }
+                  YyjsonFreeValue(weatherHandle);
+                }
+                if (summary == "") {
+                  summary = "No description";
+                }
+
+                printf("  %s — %s. High %.1f%s / Low %.1f%s", dayLabel, summary, maxTemp, tempUnitSymbol, minTemp, tempUnitSymbol);
+                if (pop >= 0.0) {
+                  float popPercent = pop * 100.0;
+                  printf(", precip %.0f%%", popPercent);
+                }
+                if (rain >= 0.0) {
+                  printf(", rain %.1f mm", rain);
+                }
+                if (snow >= 0.0) {
+                  printf(", snow %.1f mm", snow);
+                }
+                printf("\n");
+
+                YyjsonFreeValue(dayHandle);
+              }
+              i = i + 1;
+            }
+            YyjsonFreeValue(dailyHandle);
+          } else {
+            writeln("No daily forecast data was returned.");
+          }
+        }
+
+        YyjsonFreeValue(root);
+        YyjsonDocFree(forecastDoc);
+      }
+    }
+    mstreamfree(forecastOut);
+  }
+
+  httpclose(session);
+  return exitCode;
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a Rea example script that looks up coordinates for a ZIP code via OpenWeather's geocoding endpoint and then calls the One Call 3.0 API using the built-in HTTP client and yyjson helpers
- format the resolved location, timezone, current conditions, and up to seven daily forecast entries with unit selection, precipitation stats, and graceful error handling

## Testing
- not run (example code only)


------
https://chatgpt.com/codex/tasks/task_e_68d1f844139c832abf526a07923e64e4