### PR TITLE
Add scoped pattern matching and exception support to Rea

### DIFF
--- a/src/core/types.h
+++ b/src/core/types.h
@@ -230,7 +230,13 @@ typedef enum {
     AST_DEREFERENCE,
     AST_ADDR_OF,
     AST_NIL,
-    AST_NEW
+    AST_NEW,
+    AST_MATCH,
+    AST_MATCH_BRANCH,
+    AST_PATTERN_BINDING,
+    AST_TRY,
+    AST_CATCH,
+    AST_THROW
 } ASTNodeType;
 
 // Define the function pointer type for built-in handlers

--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -201,6 +201,12 @@ const char *astTypeToString(ASTNodeType type) {
         case AST_DEREFERENCE:    return "DEREFERENCE";
         case AST_ADDR_OF:        return "ADDR_OF";
         case AST_NIL:            return "NIL";
+        case AST_MATCH:          return "MATCH";
+        case AST_MATCH_BRANCH:   return "MATCH_BRANCH";
+        case AST_PATTERN_BINDING:return "PATTERN_BINDING";
+        case AST_TRY:            return "TRY";
+        case AST_CATCH:          return "CATCH";
+        case AST_THROW:          return "THROW";
         default:                 return "UNKNOWN_AST_TYPE";
     }
 }


### PR DESCRIPTION
## Summary
- add AST node kinds and parser handling for Rea `match`, `try`/`catch`, and `throw`
- desugar the new constructs into Pascal-compatible statements and inject shared exception globals
- tighten module resolution and nested function visibility to match scope expectations

## Testing
- python3 scope_verify/rea/rea_scope_test_harness.py --manifest scope_verify/rea/tests/manifest.json

------
https://chatgpt.com/codex/tasks/task_b_68d34a54806883298097b5566807a254