### PR TITLE
Fix Rea scoping for grouped declarations

### DIFF
--- a/src/rea/parser.c
+++ b/src/rea/parser.c
@@ -2046,6 +2046,9 @@ static AST *parseVarDecl(ReaParser *p) {
 
     AST *baseType = copyAST(typeNode); // copy uses original token pointers; keep until end
     AST *compound = newASTNode(AST_COMPOUND, NULL);
+    if (compound) {
+        compound->i_val = 1; // mark as declaration group wrapper
+    }
     // Mark as global scope only when parsing at the top level
     compound->is_global_scope = (p->functionDepth == 0 && p->currentClassName == NULL);
 


### PR DESCRIPTION
## Summary
- tag multi-variable declaration compounds in the Rea parser so they can be recognised later as declaration groups
- teach Rea semantic resolution to inspect those marked groups when searching preceding statements for variable and const declarations

## Testing
- build/bin/rea --dump-ast-json Examples/rea/sdl_mandelbrot_interactive
- Tests/run_all_tests *(fails: numerous existing mismatches in Pascal suite)*
- python3 scope_verify/rea/rea_scope_test_harness.py --manifest scope_verify/rea/tests/manifest.json

------
https://chatgpt.com/codex/tasks/task_b_68d4379b80f883298d89504136cff863