### PR TITLE
Fix Pascal local var registration for nested routines

### DIFF
--- a/Tests/Pascal/ProcVarLocalScope
+++ b/Tests/Pascal/ProcVarLocalScope
@@ -1,0 +1,34 @@
+program ProcVarLocalScope;
+
+type
+  TProc = procedure(n: integer);
+  TFunc = function(x: integer): integer;
+
+procedure IncVar(n: integer);
+begin
+  writeln('inc ', n);
+end;
+
+function AddOffset(x: integer): integer;
+begin
+  AddOffset := x + 7;
+end;
+
+procedure Run;
+var
+  worker: TProc;
+  evaluator: TFunc;
+  value: integer;
+
+begin
+  value := 2;
+  worker := @IncVar;
+  evaluator := @AddOffset;
+  worker(value);
+  worker(value + 1);
+  writeln('eval=', evaluator(5));
+end;
+
+begin
+  Run;
+end.

--- a/Tests/Pascal/ProcVarLocalScope.out
+++ b/Tests/Pascal/ProcVarLocalScope.out
@@ -1,0 +1,3 @@
+inc 2
+inc 3
+eval=12

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -3541,6 +3541,9 @@ static void compileNode(AST* node, BytecodeChunk* chunk, int current_line_approx
                                             node->left != NULL);
                 }
             } else { // Local variables
+                if (current_function_compiler != NULL) {
+                    registerVarDeclLocals(node, false);
+                }
                 AST* type_specifier_node = node->right;
 
                 // Resolve type alias if necessary


### PR DESCRIPTION
## Summary
- ensure registerVarDeclLocals runs when compiling local var declarations so nested procedure scopes resolve their bindings
- add a Pascal regression exercising local procedure/function pointer variables to guard the fix

## Testing
- build/bin/pascal Tests/Pascal/ProcVarLocalScope
- python3 scope_verify/rea/rea_scope_test_harness.py --manifest scope_verify/rea/tests/manifest.json --out-dir scope_verify/rea/out


------
https://chatgpt.com/codex/tasks/task_b_68d4650cb4288329ae72f5800a594f4d