### PR TITLE
Fix parameter scope lookup for Rea functions

### DIFF
--- a/Examples/rea/sdl_landscape
+++ b/Examples/rea/sdl_landscape
@@ -500,8 +500,13 @@ class LandscapeDemo {
     }
   }
 
-  void emitWaterVertex(int idx, int gridX, int gridZ, float groundHeight,
-                       float basePhase, float baseSecondary, float baseSparkle) {
+  void emitWaterVertex(int idx,
+                       int gridX,
+                       int gridZ,
+                       float groundHeight,
+                       float basePhase,
+                       float baseSecondary,
+                       float baseSparkle) {
     float depth = my.waterHeight - groundHeight;
     if (depth < 0.0) depth = 0.0;
     if (depth > 6.0) depth = 6.0;

--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -390,13 +390,14 @@ AST* findDeclarationInScope(const char* varName, AST* currentScopeNode, AST* ref
         return NULL;
     }
 
+    bool scanningParameters = (referenceNode == currentScopeNode);
     for (int i = 0; i < currentScopeNode->child_count; i++) {
         AST* paramDeclGroup = currentScopeNode->children[i];
         if (!paramDeclGroup) continue;
         if (paramDeclGroup->type == AST_VAR_DECL) {
             AST* found = matchVarDecl(paramDeclGroup, varName);
             if (found) {
-                if (referenceLine > 0) {
+                if (!scanningParameters && referenceLine > 0) {
                     int declLine = declarationLine(paramDeclGroup);
                     if (declLine > referenceLine) continue;
                 }


### PR DESCRIPTION
## Summary
- allow `findDeclarationInScope` to skip forward-declaration line checks when scanning procedure/function parameter lists so parameters remain visible even if they appear on later lines than the routine header

## Testing
- build/bin/rea Examples/rea/sdl_landscape

------
https://chatgpt.com/codex/tasks/task_b_68d47dcb9a448329b90a09e871540820