### PR TITLE
Fix SDL landscape setup and camera controls

### DIFF
--- a/Examples/rea/sdl_landscape
+++ b/Examples/rea/sdl_landscape
@@ -267,24 +267,12 @@ class LandscapeDemo {
   void LandscapeDemo(int initialSeed) {
     my.field = new TerrainField();
     my.seed = initialSeed;
-    my.useFastWorldCoords = hasextbuiltin("user", "LandscapePrecomputeWorldCoords");
-    my.useFastWaterOffsets = hasextbuiltin("user", "LandscapePrecomputeWaterOffsets");
-    if (my.useFastWorldCoords) {
-      landscapeprecomputeworldcoords(my.worldXCoords,
-                                     my.worldZCoords,
-                                     TileScale,
-                                     TerrainSize,
-                                     VertexStride);
-    } else {
+    my.useFastWorldCoords = my.tryPrecomputeWorldCoordinates();
+    if (!my.useFastWorldCoords) {
       my.precomputeWorldCoordinates();
     }
-    if (my.useFastWaterOffsets) {
-      landscapeprecomputewateroffsets(my.waterPhaseOffset,
-                                      my.waterSecondaryOffset,
-                                      my.waterSparkleOffset,
-                                      TerrainSize,
-                                      VertexStride);
-    } else {
+    my.useFastWaterOffsets = my.tryPrecomputeWaterOffsets();
+    if (!my.useFastWaterOffsets) {
       my.precomputeWaterOffsets();
     }
     my.useFastTerrain = hasextbuiltin("user", "LandscapeDrawTerrain");
@@ -313,6 +301,28 @@ class LandscapeDemo {
     my.hasMouseSample = false;
   }
 
+  bool tryPrecomputeWorldCoordinates() {
+    if (!hasextbuiltin("user", "LandscapePrecomputeWorldCoords")) {
+      return false;
+    }
+    landscapeprecomputeworldcoords(my.worldXCoords,
+                                   my.worldZCoords,
+                                   TileScale,
+                                   TerrainSize,
+                                   VertexStride);
+    float half = TerrainSize * 0.5;
+    float expectedMin = (0.0 - half) * TileScale;
+    float expectedMax = (TerrainSize - half) * TileScale;
+    float diffMin = my.worldXCoords[0] - expectedMin;
+    if (diffMin < 0.0) diffMin = -diffMin;
+    float diffMax = my.worldXCoords[TerrainSize] - expectedMax;
+    if (diffMax < 0.0) diffMax = -diffMax;
+    if (diffMin > 0.0005 || diffMax > 0.0005) {
+      return false;
+    }
+    return true;
+  }
+
   void precomputeWorldCoordinates() {
     float half = TerrainSize * 0.5;
     int i = 0;
@@ -322,6 +332,31 @@ class LandscapeDemo {
       my.worldZCoords[i] = world;
       i = i + 1;
     }
+  }
+
+  bool tryPrecomputeWaterOffsets() {
+    if (!hasextbuiltin("user", "LandscapePrecomputeWaterOffsets")) {
+      return false;
+    }
+    landscapeprecomputewateroffsets(my.waterPhaseOffset,
+                                    my.waterSecondaryOffset,
+                                    my.waterSparkleOffset,
+                                    TerrainSize,
+                                    VertexStride);
+    if (TerrainSize >= 1) {
+      int checkIdx = 1;
+      float expectedPhase = 0.18;
+      float phaseDiff = my.waterPhaseOffset[checkIdx] - expectedPhase;
+      if (phaseDiff < 0.0) phaseDiff = -phaseDiff;
+      float expectedSecondary = 0.05;
+      float secondaryDiff =
+          my.waterSecondaryOffset[checkIdx] - expectedSecondary;
+      if (secondaryDiff < 0.0) secondaryDiff = -secondaryDiff;
+      if (phaseDiff > 0.0005 || secondaryDiff > 0.0005) {
+        return false;
+      }
+    }
+    return true;
   }
 
   void precomputeWaterOffsets() {
@@ -893,8 +928,8 @@ class LandscapeDemo {
       }
     }
 
-    bool forward = IsKeyDown(ScanCodeS);
-    bool backward = IsKeyDown(ScanCodeW);
+    bool forward = IsKeyDown(ScanCodeW);
+    bool backward = IsKeyDown(ScanCodeS);
 
     float moveForward = 0.0;
     if (forward) moveForward = moveForward + 1.0;

--- a/Examples/rea/sdl_landscape_simple
+++ b/Examples/rea/sdl_landscape_simple
@@ -400,8 +400,8 @@ class LandscapeDemo {
       }
     }
 
-    bool forward = IsKeyDown(ScanCodeS);
-    bool backward = IsKeyDown(ScanCodeW);
+    bool forward = IsKeyDown(ScanCodeW);
+    bool backward = IsKeyDown(ScanCodeS);
 
     float moveForward = 0.0;
     if (forward) moveForward = moveForward + 1.0;


### PR DESCRIPTION
## Summary
- guard the landscape extended builtins by validating their output and falling back to the manual loops when unavailable
- reuse the manual precomputations when the fast path fails so the terrain data is always populated
- correct the W/S movement mapping in both SDL landscape demos so forward and backward movement matches the key labels

## Testing
- not run (SDL example)


------
https://chatgpt.com/codex/tasks/task_b_68d495c00fc4832998139b431e26d12e