### PR TITLE
Improve SDL landscape input handling

### DIFF
--- a/Examples/rea/sdl_landscape
+++ b/Examples/rea/sdl_landscape
@@ -753,10 +753,15 @@ class LandscapeDemo {
     int mouseX = 0;
     int mouseY = 0;
     int mouseButtons = 0;
-    getmousestate(mouseX, mouseY, mouseButtons);
-    my.lastMouseX = mouseX;
-    my.lastMouseY = mouseY;
-    my.hasMouseSample = true;
+    int mouseInside = 0;
+    getmousestate(mouseX, mouseY, mouseButtons, mouseInside);
+    if (mouseInside != 0) {
+      my.lastMouseX = mouseX;
+      my.lastMouseY = mouseY;
+      my.hasMouseSample = true;
+    } else {
+      my.hasMouseSample = false;
+    }
   }
 
   void regenerate(int newSeed) {
@@ -916,8 +921,12 @@ class LandscapeDemo {
     int mouseX = 0;
     int mouseY = 0;
     int mouseButtons = 0;
-    getmousestate(mouseX, mouseY, mouseButtons);
-    if (!my.hasMouseSample) {
+    int mouseInside = 0;
+    getmousestate(mouseX, mouseY, mouseButtons, mouseInside);
+    bool insideWindow = mouseInside != 0;
+    if (!insideWindow) {
+      my.hasMouseSample = false;
+    } else if (!my.hasMouseSample) {
       my.lastMouseX = mouseX;
       my.lastMouseY = mouseY;
       my.hasMouseSample = true;
@@ -946,8 +955,19 @@ class LandscapeDemo {
     if (moveForward != 0.0) {
       float speed = MoveSpeed * dt * moveForward;
       float yawRadians = my.yaw * DegreesToRadians;
-      float forwardX = sin(yawRadians);
-      float forwardZ = cos(yawRadians);
+      float pitchRadians = my.pitch * DegreesToRadians;
+      float forwardX = sin(yawRadians) * cos(pitchRadians);
+      float forwardZ = cos(yawRadians) * cos(pitchRadians);
+      float forwardLen = sqrt(forwardX * forwardX + forwardZ * forwardZ);
+      if (forwardLen < 0.0001) {
+        forwardX = sin(yawRadians);
+        forwardZ = cos(yawRadians);
+        forwardLen = sqrt(forwardX * forwardX + forwardZ * forwardZ);
+      }
+      if (forwardLen > 0.0001) {
+        forwardX = forwardX / forwardLen;
+        forwardZ = forwardZ / forwardLen;
+      }
       float deltaX = forwardX * (speed / TileScale);
       float deltaZ = forwardZ * (speed / TileScale);
       my.camX = my.camX + deltaX;

--- a/src/backend_ast/sdl.h
+++ b/src/backend_ast/sdl.h
@@ -33,6 +33,9 @@ extern int gSdlTextureHeights[MAX_SDL_TEXTURES];
 extern bool gSdlTtfInitialized;
 extern bool gSdlImageInitialized;
 
+void sdlEnsureInputWatch(void);
+bool sdlCachedKeyDown(SDL_Scancode sc);
+
 
 // System Functions
 void initializeSdlSystems(void);

--- a/src/backend_ast/sdl3d.c
+++ b/src/backend_ast/sdl3d.c
@@ -82,6 +82,7 @@ Value vmBuiltinInitgraph3d(VM* vm, int arg_count, Value* args) {
 #if SDL_VERSION_ATLEAST(2,0,5)
     SDL_SetWindowInputFocus(gSdlWindow);
 #endif
+    sdlEnsureInputWatch();
 
     return makeVoid();
 }


### PR DESCRIPTION
## Summary
- cache SDL keyboard state through an event watch so IsKeyDown stays responsive during heavy rendering
- extend GetMouseState to report window focus/inside status and register the watch from both 2D and 3D initializers
- update the landscape demo to ignore mouse motion outside the window and normalize forward movement against the view direction

## Testing
- cmake -S . -B build -DSDL=ON *(fails: missing SDL2 development package in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d49d0bd7a483299bc26fc09867a944