### PR TITLE
Fix SDL event watch install build error

### DIFF
--- a/src/backend_ast/sdl.c
+++ b/src/backend_ast/sdl.c
@@ -88,9 +88,8 @@ static int sdlInputEventWatch(void* userdata, SDL_Event* event) {
 void sdlEnsureInputWatch(void) {
     if (!gSdlInputWatchInstalled) {
         sdlResetCachedKeyState();
-        if (SDL_AddEventWatch(sdlInputEventWatch, NULL) == 0) {
-            gSdlInputWatchInstalled = true;
-        }
+        SDL_AddEventWatch(sdlInputEventWatch, NULL);
+        gSdlInputWatchInstalled = true;
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure the SDL input event watcher install call matches SDL2's void return type
- always mark the watch as installed after invoking SDL_AddEventWatch

## Testing
- cmake -S . -B build
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_b_68d4a1aaf0d0832988a6c5838dd0dc97