### PR TITLE
Pump SDL events before sampling landscape movement keys

### DIFF
--- a/Examples/rea/sdl_landscape
+++ b/Examples/rea/sdl_landscape
@@ -781,12 +781,10 @@ class LandscapeDemo {
   }
 
   void handleDiscreteInput() {
-    // Refresh the cached movement keys before draining the SDL event queue.
-    // This guarantees the input watch has been installed (via IsKeyDown)
-    // ahead of any key events we consume with pollkey(), so held keys such as
-    // W/S remain latched even if their initial press happens this frame.
-    my.forwardKeyDown = IsKeyDown(ScanCodeW);
-    my.backwardKeyDown = IsKeyDown(ScanCodeS);
+    // Prime the SDL key watcher before draining the queue so it sees any new
+    // keydown events we are about to consume with pollkey().
+    IsKeyDown(ScanCodeW);
+    IsKeyDown(ScanCodeS);
 
     int key = pollkey();
     while (key != 0) {
@@ -804,6 +802,12 @@ class LandscapeDemo {
       }
       key = pollkey();
     }
+
+    // Sample the movement keys after pumping events so their latched state
+    // reflects the latest SDL keyboard state even while the mouse is inside
+    // the window.
+    my.forwardKeyDown = IsKeyDown(ScanCodeW);
+    my.backwardKeyDown = IsKeyDown(ScanCodeS);
   }
 
   void drawTerrain() {
@@ -1026,6 +1030,10 @@ class LandscapeDemo {
     my.initGraphics();
     my.lastTicks = getticks();
     while (my.running) {
+      // Pump SDL events before sampling keyboard state so IsKeyDown observes
+      // the latest key transitions. SDL_GetKeyboardState (used by IsKeyDown)
+      // only reflects new input after SDL_PumpEvents or a polling helper runs.
+      GraphLoop(0);
       my.handleDiscreteInput();
       if (QuitRequested()) break;
       int now = getticks();

--- a/src/backend_ast/sdl.c
+++ b/src/backend_ast/sdl.c
@@ -1016,6 +1016,10 @@ class LandscapeDemo {
     my.initGraphics();
     my.lastTicks = getticks();
     while (my.running) {
+      // Pump SDL events before sampling keyboard state so IsKeyDown observes
+      // the latest key transitions. SDL_GetKeyboardState (used by IsKeyDown)
+      // only reflects new input after SDL_PumpEvents or a polling helper runs.
+      GraphLoop(0);
       my.handleDiscreteInput();
       if (QuitRequested()) break;
       int now = getticks();


### PR DESCRIPTION
## Summary
- pump the SDL event queue at the start of each frame before sampling keyboard state in the landscape demo
- document the reason so the IsKeyDown helper observes freshly latched key transitions

## Testing
- not run (SDL example change only)


------
https://chatgpt.com/codex/tasks/task_b_68d4b3e56ba08329857fb763d7566a7d