### PR TITLE
Update SDL landscape demo for new mouse API

### DIFF
--- a/Examples/rea/sdl_landscape
+++ b/Examples/rea/sdl_landscape
@@ -757,15 +757,10 @@ class LandscapeDemo {
     int mouseX = 0;
     int mouseY = 0;
     int mouseButtons = 0;
-    int mouseInside = 0;
-    getmousestate(mouseX, mouseY, mouseButtons, mouseInside);
-    if (mouseInside != 0) {
-      my.lastMouseX = mouseX;
-      my.lastMouseY = mouseY;
-      my.hasMouseSample = true;
-    } else {
-      my.hasMouseSample = false;
-    }
+    getmousestate(mouseX, mouseY, mouseButtons);
+    my.lastMouseX = mouseX;
+    my.lastMouseY = mouseY;
+    my.hasMouseSample = true;
   }
 
   void regenerate(int newSeed) {
@@ -936,12 +931,8 @@ class LandscapeDemo {
     int mouseX = 0;
     int mouseY = 0;
     int mouseButtons = 0;
-    int mouseInside = 0;
-    getmousestate(mouseX, mouseY, mouseButtons, mouseInside);
-    bool insideWindow = mouseInside != 0;
-    if (!insideWindow) {
-      my.hasMouseSample = false;
-    } else if (!my.hasMouseSample) {
+    getmousestate(mouseX, mouseY, mouseButtons);
+    if (!my.hasMouseSample) {
       my.lastMouseX = mouseX;
       my.lastMouseY = mouseY;
       my.hasMouseSample = true;
@@ -953,8 +944,11 @@ class LandscapeDemo {
       if (deltaX != 0 || deltaY != 0) {
         int maxDeltaX = WindowWidth / 2;
         int maxDeltaY = WindowHeight / 2;
-        if (deltaX >= -maxDeltaX && deltaX <= maxDeltaX &&
-            deltaY >= -maxDeltaY && deltaY <= maxDeltaY) {
+        bool largeDelta = (deltaX < -maxDeltaX || deltaX > maxDeltaX ||
+                           deltaY < -maxDeltaY || deltaY > maxDeltaY);
+        if (largeDelta) {
+          my.hasMouseSample = false;
+        } else {
           my.yaw = my.yaw - deltaX * MouseYawSensitivity;
           my.pitch = my.pitch - deltaY * MousePitchSensitivity;
         }


### PR DESCRIPTION
## Summary
- update the Rea SDL landscape example to call the 3-argument `getmousestate`
- reset mouse sampling when large deltas suggest the cursor left and re-entered the window

## Testing
- not run (example-only change)


------
https://chatgpt.com/codex/tasks/task_b_68d4bf6b06dc8329a89a8ba96ee754ee