### PR TITLE
Restore four-argument getmousestate support

### DIFF
--- a/Docs/pscal_vm_builtins.md
+++ b/Docs/pscal_vm_builtins.md
@@ -267,7 +267,7 @@ imported from each front end (Pascal, CLike, and Rea).
 | issoundplaying | (sound: Sound) | Boolean | Query if sound playing. |
 | inittextsystem | (fontPath: String, fontSize: Integer) | void | Initialize text subsystem with a TTF font. |
 | quittextsystem | () | void | Shut down text subsystem. |
-| getmousestate | (var x: Integer, var y: Integer, var buttons: Integer) | void | Query mouse position and buttons. |
+| getmousestate | (var x: Integer, var y: Integer, var buttons: Integer [, var insideWindow: Integer]) | void | Query mouse position and button state. When the optional `insideWindow` VAR parameter is supplied it receives `1` if the cursor is inside the focused window, otherwise `0`. |
 | getticks | () | Integer | Milliseconds since start. |
 | pollkey | () | Integer | Poll for key press. |
 | iskeydown | (key: String\|Integer) | Boolean | Return `true` while the requested key is held down (uses SDL scancodes/key names). |

--- a/Examples/clike/builtins.h
+++ b/Examples/clike/builtins.h
@@ -73,7 +73,7 @@ int freesound();
 int getenv();
 int getmaxx();
 int getmaxy();
-void getmousestate(int* x, int* y, int* buttons);
+void getmousestate(int* x, int* y, int* buttons, int* insideWindow);
 int getpixelcolor();
 int gettextsize();
 int getticks();

--- a/Examples/clike/sdl_getmousestate
+++ b/Examples/clike/sdl_getmousestate
@@ -7,22 +7,27 @@
 
 int main() {
 #ifdef SDL_ENABLED
-    int x, y, buttons;
+    int x, y, buttons, inside;
     int prevX = -1;
     int prevY = -1;
     int prevButtons = 0;
+    int prevInside = 0;
 
     printf("Move the mouse inside the window. Press Q to quit.\n");
     initgraph(800, 600, "getmousestate demo");
 
     while (1) {
         graphloop(1);
-        getmousestate(&x, &y, &buttons);
-        if (x != prevX || y != prevY || buttons != prevButtons) {
-            printf("Mouse: x=%d y=%d buttons=%d\n", x, y, buttons);
+        getmousestate(&x, &y, &buttons, &inside);
+        if (!inside) {
+            buttons = 0;
+        }
+        if (x != prevX || y != prevY || buttons != prevButtons || inside != prevInside) {
+            printf("Mouse: x=%d y=%d buttons=%d inside=%d\n", x, y, buttons, inside);
             prevX = x;
             prevY = y;
             prevButtons = buttons;
+            prevInside = inside;
         }
         if (keypressed()) {
             char c = readkey();

--- a/Examples/clike/sdl_mandelbrot_interactive
+++ b/Examples/clike/sdl_mandelbrot_interactive
@@ -89,9 +89,14 @@ int tryInitFont(str path, int fontSize) {
  * Sets (clickButton, clickX, clickY) when a new click is found.
  */
 void pollMouse() {
-    int x = 0, y = 0, b = 0;
+    int x = 0, y = 0, b = 0, insideWindow = 0;
     graphloop(1);           /* Pump events */
-    getmousestate(&x, &y, &b);
+    getmousestate(&x, &y, &b, &insideWindow);
+
+    if (!insideWindow) {
+        prevButtons = b;
+        return;
+    }
 
     /* Fresh press detection: bit goes from 0 -> 1 */
     int freshLeft  = ((b & ButtonLeft)  != 0) && ((prevButtons & ButtonLeft)  == 0);

--- a/Examples/rea/sdl_landscape_simple
+++ b/Examples/rea/sdl_landscape_simple
@@ -315,10 +315,15 @@ class LandscapeDemo {
     int mouseX = 0;
     int mouseY = 0;
     int mouseButtons = 0;
-    getmousestate(mouseX, mouseY, mouseButtons);
-    my.lastMouseX = mouseX;
-    my.lastMouseY = mouseY;
-    my.hasMouseSample = true;
+    int mouseInside = 0;
+    getmousestate(mouseX, mouseY, mouseButtons, mouseInside);
+    if (mouseInside != 0) {
+      my.lastMouseX = mouseX;
+      my.lastMouseY = mouseY;
+      my.hasMouseSample = true;
+    } else {
+      my.hasMouseSample = false;
+    }
   }
 
   void regenerate(int newSeed) {
@@ -379,8 +384,11 @@ class LandscapeDemo {
     int mouseX = 0;
     int mouseY = 0;
     int mouseButtons = 0;
-    getmousestate(mouseX, mouseY, mouseButtons);
-    if (!my.hasMouseSample) {
+    int mouseInside = 0;
+    getmousestate(mouseX, mouseY, mouseButtons, mouseInside);
+    if (mouseInside == 0) {
+      my.hasMouseSample = false;
+    } else if (!my.hasMouseSample) {
       my.lastMouseX = mouseX;
       my.lastMouseY = mouseY;
       my.hasMouseSample = true;

--- a/Examples/rea/sdl_mandelbrot_interactive
+++ b/Examples/rea/sdl_mandelbrot_interactive
@@ -248,7 +248,11 @@ class MandelbrotApp {
     int x = 0;
     int y = 0;
     int b = 0;
-    getmousestate(x, y, b);
+    int inside = 0;
+    getmousestate(x, y, b, inside);
+    if (inside == 0) {
+      b = 0;
+    }
     int winW = getmaxx() + 1;
     int winH = getmaxy() + 1;
     if (winW > 0 && winH > 0) {

--- a/Examples/rea/sdl_mandelbrot_interactive_ext
+++ b/Examples/rea/sdl_mandelbrot_interactive_ext
@@ -220,7 +220,11 @@ class MandelbrotApp {
     int x = 0;
     int y = 0;
     int b = 0;
-    getmousestate(x, y, b);
+    int inside = 0;
+    getmousestate(x, y, b, inside);
+    if (inside == 0) {
+      b = 0;
+    }
     int winW = getmaxx() + 1;
     int winH = getmaxy() + 1;
     if (winW > 0 && winH > 0) {

--- a/src/backend_ast/sdl.c
+++ b/src/backend_ast/sdl.c
@@ -529,8 +529,8 @@ Value vmBuiltinGettextsize(VM* vm, int arg_count, Value* args) {
 }
 
 Value vmBuiltinGetmousestate(VM* vm, int arg_count, Value* args) {
-    if (arg_count != 3) {
-        runtimeError(vm, "GetMouseState expects 3 arguments.");
+    if (arg_count != 3 && arg_count != 4) {
+        runtimeError(vm, "GetMouseState expects 3 or 4 arguments.");
         return makeVoid();
     }
 
@@ -543,6 +543,19 @@ Value vmBuiltinGetmousestate(VM* vm, int arg_count, Value* args) {
     Value* x_ptr = (Value*)args[0].ptr_val;
     Value* y_ptr = (Value*)args[1].ptr_val;
     Value* buttons_ptr = (Value*)args[2].ptr_val;
+    Value* inside_ptr = NULL;
+
+    if (arg_count == 4) {
+        if (args[3].type != TYPE_POINTER) {
+            runtimeError(vm, "GetMouseState requires VAR parameters, but a non-pointer type was received.");
+            return makeVoid();
+        }
+        inside_ptr = (Value*)args[3].ptr_val;
+        if (!inside_ptr) {
+            runtimeError(vm, "GetMouseState received a NIL pointer for a VAR parameter.");
+            return makeVoid();
+        }
+    }
 
     if (!x_ptr || !y_ptr || !buttons_ptr) {
         runtimeError(vm, "GetMouseState received a NIL pointer for a VAR parameter.");
@@ -647,6 +660,11 @@ Value vmBuiltinGetmousestate(VM* vm, int arg_count, Value* args) {
 
     freeValue(buttons_ptr);
     *buttons_ptr = makeInt(pscal_buttons);
+
+    if (inside_ptr) {
+        freeValue(inside_ptr);
+        *inside_ptr = makeInt((inside_window && has_focus) ? 1 : 0);
+    }
 
     return makeVoid();
 }


### PR DESCRIPTION
## Summary
- restore the SDL getmousestate builtin's optional fourth VAR parameter and return the inside-window flag again
- update the documentation and C/Rea SDL samples to request the inside-window value and ignore mouse deltas while outside

## Testing
- cmake -S . -B build
- cmake --build build


------
https://chatgpt.com/codex/tasks/task_b_68d4bf6b06dc8329a89a8ba96ee754ee