### PR TITLE
Fix printf formatting spacing and detect duplicate functions

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -3111,19 +3111,20 @@ Value vmBuiltinWrite(VM* vm, int arg_count, Value* args) {
         Value val = args[i];
         if (has_prev) {
             bool add_space = true;
+            const char *no_space_after = "=,.;:?!-)]}>)\"'";
             if (prev.type == TYPE_STRING && prev.s_val) {
                 size_t len = strlen(prev.s_val);
                 if (len == 0) {
                     add_space = false;
                 } else {
                     char last = prev.s_val[len - 1];
-                    if (isspace((unsigned char)last) || strchr("=:?!-", last)) {
+                    if (isspace((unsigned char)last) || strchr(no_space_after, last)) {
                         add_space = false;
                     }
                 }
             } else if (prev.type == TYPE_CHAR) {
                 char last = (char)prev.c_val;
-                if (isspace((unsigned char)last) || strchr("=:?!-", last)) {
+                if (isspace((unsigned char)last) || strchr(no_space_after, last)) {
                     add_space = false;
                 }
             }


### PR DESCRIPTION
## Summary
- ensure vm write builtin avoids inserting spaces after punctuation when lowering printf
- track function definitions in the CLike semantic pass and emit duplicate-definition errors

## Testing
- python3 scope_verify/clike/clike_scope_test_harness.py --manifest scope_verify/clike/tests/manifest.json

------
https://chatgpt.com/codex/tasks/task_b_68d5347abb88832992db4af1d317811c