### PR TITLE
Add writeln builtin support to CLike scope analysis

### DIFF
--- a/src/clike/builtins.c
+++ b/src/clike/builtins.c
@@ -52,6 +52,7 @@ void clikeRegisterBuiltins(void) {
     registerBuiltinFunction("mstreamsavetofile", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("mstreamfree", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("mstreambuffer", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunction("writeln", AST_PROCEDURE_DECL, NULL);
 
     /* DOS/OS helpers */
     registerBuiltinFunction("exec", AST_FUNCTION_DECL, NULL);

--- a/src/clike/codegen.c
+++ b/src/clike/codegen.c
@@ -1257,7 +1257,22 @@ static void compileExpressionWithResult(ASTNodeClike *node, BytecodeChunk *chunk
                 writeBytecodeChunk(chunk, MUTEX_DESTROY, node->token.line);
                 break;
             }
-            if (strcasecmp(name, "printf") == 0) {
+            if (strcasecmp(name, "writeln") == 0) {
+                int write_arg_count = 0;
+                Value nl = makeInt(1);
+                int nlidx = addConstantToChunk(chunk, &nl);
+                freeValue(&nl);
+                writeBytecodeChunk(chunk, CONSTANT, node->token.line);
+                writeBytecodeChunk(chunk, (uint8_t)nlidx, node->token.line);
+                write_arg_count++;
+                for (int i = 0; i < node->child_count; ++i) {
+                    compileExpression(node->children[i], chunk, ctx);
+                    write_arg_count++;
+                }
+                emitBuiltinProcedureCall(chunk, "write",
+                                         (uint8_t)write_arg_count,
+                                         node->token.line);
+            } else if (strcasecmp(name, "printf") == 0) {
                 int arg_index = 0;
                 int write_arg_count = 0;
                 Value nl = makeInt(0);

--- a/src/clike/semantics.c
+++ b/src/clike/semantics.c
@@ -93,6 +93,11 @@ static VarType builtinReturnType(const char* name) {
         return TYPE_INT64;
     }
 
+    static const char *const voidFuncs[] = { "writeln" };
+    if (builtinMatches(name, voidFuncs, sizeof(voidFuncs) / sizeof(voidFuncs[0]))) {
+        return TYPE_VOID;
+    }
+
     return TYPE_VOID;
 }
 
@@ -285,6 +290,7 @@ static void registerBuiltinFunctions(void) {
     registerFunctionSignature(strdup("mstreamsavetofile"), TYPE_VOID, 0, 0, 0);
     registerFunctionSignature(strdup("mstreamfree"), TYPE_VOID, 0, 0, 0);
     registerFunctionSignature(strdup("mstreambuffer"), TYPE_STRING, 0, 0, 0);
+    registerFunctionSignature(strdup("writeln"), TYPE_VOID, 0, 0, 0);
     registerFunctionSignature(strdup("hasextbuiltin"), TYPE_INT32, 0, 0, 0);
     registerFunctionSignature(strdup("extbuiltincategorycount"), TYPE_INT32, 0, 0, 0);
     registerFunctionSignature(strdup("extbuiltincategoryname"), TYPE_STRING, 0, 0, 0);
@@ -341,7 +347,7 @@ static VarType analyzeExpr(ASTNodeClike *node, ScopeStack *scopes) {
             node->var_type = t;
             if (t == TYPE_UNKNOWN) {
                 fprintf(stderr,
-                        "Type error: undefined variable '%s' at line %d, column %d\n",
+                        "Type error: undefined variable '%s' (not in scope) at line %d, column %d\n",
                         name,
                         node->token.line,
                         node->token.column);


### PR DESCRIPTION
## Summary
- register the Pascal-style `writeln` builtin for the CLike front end and treat it as a void-returning routine
- lower `writeln` calls to the VM's `write` builtin with an automatic newline flag so generated programs can print successfully
- clarify undefined identifier diagnostics to mention missing scope while preserving existing wording

## Testing
- python3 scope_verify/clike/clike_scope_test_harness.py --manifest scope_verify/rea/tests/manifest.json
- python3 scope_verify/clike/clike_scope_test_harness.py --manifest scope_verify/clike/tests/manifest.json

------
https://chatgpt.com/codex/tasks/task_b_68d5583e118883299e865039e3a73abd