### PR TITLE
Fix clike printf formatting

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -3161,6 +3161,8 @@ Value vmBuiltinWrite(VM* vm, int arg_count, Value* args) {
             }
         } else if (val.type == TYPE_CHAR) {
             fputc(val.c_val, output_stream);
+        } else if (suppress_spacing && val.type == TYPE_BOOLEAN) {
+            fputc(val.i_val ? '1' : '0', output_stream);
         } else {
             printValueToStream(val, output_stream);
         }

--- a/src/clike/codegen.c
+++ b/src/clike/codegen.c
@@ -10,6 +10,7 @@
 #include "Pascal/globals.h"
 #include "compiler/compiler.h"
 #include "vm/string_sentinels.h"
+#include "vm/vm.h"
 #include <string.h>
 #include <strings.h>
 #include <stdlib.h>
@@ -1260,7 +1261,7 @@ static void compileExpressionWithResult(ASTNodeClike *node, BytecodeChunk *chunk
             if (strcasecmp(name, "printf") == 0) {
                 int arg_index = 0;
                 int write_arg_count = 0;
-                Value nl = makeInt(0);
+                Value nl = makeInt(VM_WRITE_FLAG_SUPPRESS_SPACING);
                 int nlidx = addConstantToChunk(chunk, &nl);
                 freeValue(&nl);
                 writeBytecodeChunk(chunk, CONSTANT, node->token.line);


### PR DESCRIPTION
## Summary
- suppress automatic spacing when lowering clike printf calls to the VM write builtin
- render boolean arguments as 0/1 under the suppress spacing mode so %d matches expectations

## Testing
- Tests/run_clike_tests.sh
- python3 scope_verify/clike/clike_scope_test_harness.py --manifest scope_verify/clike/tests/manifest.json

------
https://chatgpt.com/codex/tasks/task_b_68d5687e3908832980f141a4f9367dd8