### PR TITLE
Fix import semantic duplication when analyzing modules

### DIFF
--- a/src/clike/codegen.c
+++ b/src/clike/codegen.c
@@ -1733,7 +1733,7 @@ void clikeCompile(ASTNodeClike *program, BytecodeChunk *chunk) {
             return;
         }
 
-        analyzeSemanticsClike(modProg);
+        analyzeSemanticsClike(modProg, orig_path);
 
         if (!verifyASTClikeLinks(modProg, NULL)) {
             fprintf(stderr, "AST verification failed for module '%s' after semantic analysis.\n", path);

--- a/src/clike/main.c
+++ b/src/clike/main.c
@@ -199,7 +199,7 @@ int main(int argc, char **argv) {
 
     initSymbolSystemClike();
     clikeRegisterBuiltins();
-    analyzeSemanticsClike(prog);
+    analyzeSemanticsClike(prog, path);
 
     if (!verifyASTClikeLinks(prog, NULL)) {
         fprintf(stderr, "AST verification failed after semantic analysis.\n");

--- a/src/clike/repl.c
+++ b/src/clike/repl.c
@@ -113,7 +113,7 @@ int main(void) {
         }
         initSymbolSystemClike();
         clikeRegisterBuiltins();
-        analyzeSemanticsClike(prog);
+        analyzeSemanticsClike(prog, NULL);
 
         if (!verifyASTClikeLinks(prog, NULL)) {
             fprintf(stderr, "AST verification failed after semantic analysis.\n");

--- a/src/clike/semantics.c
+++ b/src/clike/semantics.c
@@ -1074,7 +1074,7 @@ static void analyzeFunction(ASTNodeClike *func) {
     while (scopes.depth > 0) ssPop(&scopes);
 }
 
-void analyzeSemanticsClike(ASTNodeClike *program) {
+void analyzeSemanticsClike(ASTNodeClike *program, const char *current_path) {
     if (!program) return;
     functionCount = 0;
     registerBuiltinFunctions();
@@ -1092,6 +1092,12 @@ void analyzeSemanticsClike(ASTNodeClike *program) {
 
     for (int i = 0; i < clike_import_count; ++i) {
         const char *orig_path = clike_imports[i];
+        if (current_path && strcmp(orig_path, current_path) == 0) {
+            modules[i].prog = NULL;
+            modules[i].source = NULL;
+            modules[i].allocated_path = NULL;
+            continue;
+        }
         const char *path = orig_path;
         char *allocated_path = NULL;
         FILE *f = fopen(path, "rb");

--- a/src/clike/semantics.h
+++ b/src/clike/semantics.h
@@ -3,6 +3,6 @@
 
 #include "clike/ast.h"
 
-void analyzeSemanticsClike(ASTNodeClike *program);
+void analyzeSemanticsClike(ASTNodeClike *program, const char *current_path);
 
 #endif


### PR DESCRIPTION
## Summary
- have analyzeSemanticsClike skip import entries that refer to the current translation unit to avoid duplicate definitions
- thread the current source path through the clike front-end so semantics can filter matching imports when invoked from the main compiler, codegen, and REPL

## Testing
- Tests/run_clike_tests.sh
- python3 scope_verify/clike/clike_scope_test_harness.py --manifest scope_verify/clike/tests/manifest.json

------
https://chatgpt.com/codex/tasks/task_b_68d5709c546083298d3304adc89a481a