### PR TITLE
Update bytecode cache location to ~/.pscal/bc_cache

### DIFF
--- a/Docs/rea_tutorial.md
+++ b/Docs/rea_tutorial.md
@@ -343,5 +343,5 @@ bytecode disassembly.
   build/bin/rea --no-cache Examples/rea/sdl_multibouncingballs
   ```
 
-  The Rea front end caches compiled chunks under `~/.pscal_cache`. Use `--no-cache`
+  The Rea front end caches compiled chunks under `~/.pscal/bc_cache`. Use `--no-cache`
   during iteration or delete the cache directory to force a fresh compile.

--- a/Tests/run_pascal_tests.sh
+++ b/Tests/run_pascal_tests.sh
@@ -375,7 +375,7 @@ if [ $status1 -eq 0 ] && grep -q 'first' "$tmp_home/out1"; then
     EXIT_CODE=1
   fi
 
-  cache_file=$(find "$tmp_home/.pscal_cache" -name '*.bc' | head -n 1)
+  cache_file=$(find "$tmp_home/.pscal/bc_cache" -name '*.bc' | head -n 1)
 
   src_real=$(realpath "$src_file")
   if ! python3 - "$cache_file" "$src_real" <<'PY'

--- a/tools/dpc
+++ b/tools/dpc
@@ -65,8 +65,8 @@ def main() -> None:
     )
     parser.add_argument(
         "--cache-dir",
-        default="~/.pscal_cache",
-        help="Cache directory (default: ~/.pscal_cache)",
+        default="~/.pscal/bc_cache",
+        help="Cache directory (default: ~/.pscal/bc_cache)",
     )
     root_dir = str(Path("/").resolve())
     parser.add_argument(

--- a/tools/find_cache_name
+++ b/tools/find_cache_name
@@ -46,7 +46,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Find source file(s) matching a Pscal cache file."
     )
-    parser.add_argument("cache_file", help="Path to a file in ~/.pscal_cache")
+    parser.add_argument("cache_file", help="Path to a file in ~/.pscal/bc_cache")
 
     root_dir = str(Path("/").resolve())
     parser.add_argument(


### PR DESCRIPTION
## Summary
- update the runtime cache builder to place bytecode under ~/.pscal/bc_cache and create intermediate directories when needed
- adjust tools, tests, and documentation to reference the new cache location
- enforce 0700 permissions on the ~/.pscal cache root to keep bytecode private

## Testing
- cmake -S . -B build
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_b_68d57824e5388329952e05f98cff464d