### PR TITLE
Fix variable_format demo entrypoint

### DIFF
--- a/Examples/rea/variable_format
+++ b/Examples/rea/variable_format
@@ -3,10 +3,10 @@
    It can span across multiple lines.
 */
 
-// The Main class contains the entry point for the program.
-class Main {
+// The demo class holds the logic for showcasing variables and formatting.
+class VariableFormatDemo {
   // A simple method to demonstrate variable declaration and operations.
-  void main() {
+  void run() {
     // Variable declarations with different data types
     int int_var = 10;
     float float_var = 5.5;
@@ -32,7 +32,7 @@ class Main {
 }
 
 int main() {
-    Main m = new Main();  // allocate the object
-    m.main();
+    VariableFormatDemo demo = new VariableFormatDemo();  // allocate the object
+    demo.run();
     return 0;
 }


### PR DESCRIPTION
## Summary
- rename the demo class in `variable_format` to avoid the VM entrypoint name collision
- adjust the helper method name and call site so the example runs without argument arity errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d57d1ac5048329a06812f295be3d11