### PR TITLE
Update weather examples to load OpenWeather API key from home config

### DIFF
--- a/Examples/Pascal/weather
+++ b/Examples/Pascal/weather
@@ -4,7 +4,7 @@ program DisplayWeather;
 uses CRT, SysUtils; // Assuming CRT for file ops, SysUtils for ParamStr etc.
 
 const
-  API_KEY_FILENAME = '/usr/local/pscal/lib/openweathermap.key';       // Filename for key
+  DEFAULT_API_KEY_PATH = '/usr/local/pscal/lib/openweathermap.key';   // Legacy fallback
   MAX_SUBSTR_LEN = 1024;                         // Max length for copy/pos substrings
 
 type
@@ -23,48 +23,78 @@ var
   valCode : integer;        // Error code for StrToReal
 
 // --- Function to read API key from file ---
-function ReadApiKeyFromFile(filename: string): string;
+function TryReadApiKeyFromFile(filename: string): string;
 var
   keyFile: Text;
   keyRead: string;
 begin
-  keyRead := ''; // Default to empty string
+  TryReadApiKeyFromFile := '';
   assign(keyFile, filename);
-  {$I-} // Disable IO checking
+  {$I-}
   reset(keyFile);
-  {$I+} // Re-enable IO checking
+  {$I+}
 
   if IOResult <> 0 then
+    exit;
+
+  if eof(keyFile) then
   begin
-    writeln('Error: Could not open API key file: "', filename, '"');
-    writeln('Please create this file in the same directory and put your OpenWeatherMap API key in it.');
-    halt(1); // Stop execution
+    close(keyFile);
+    exit;
+  end;
+
+  readln(keyFile, keyRead);
+  close(keyFile);
+
+  keyRead := Trim(keyRead);
+  if keyRead <> '' then
+    TryReadApiKeyFromFile := keyRead;
+end;
+// --- END TryReadApiKeyFromFile ---
+
+// --- Function to obtain API key ---
+function LoadApiKey(): string;
+var
+  envKey, homeDir, keyPath, keyFromFile: string;
+begin
+  envKey := GetEnv('OPENWEATHER_API_KEY');
+  if envKey <> '' then
+  begin
+    LoadApiKey := envKey;
+    exit;
+  end;
+
+  homeDir := GetEnv('HOME');
+  if homeDir <> '' then
+  begin
+    if homeDir[length(homeDir)] = '/' then
+      keyPath := homeDir + '.pscal/etc/openweathermap.key'
+    else
+      keyPath := homeDir + '/.pscal/etc/openweathermap.key';
+
+    keyFromFile := TryReadApiKeyFromFile(keyPath);
+    if keyFromFile <> '' then
+    begin
+      LoadApiKey := keyFromFile;
+      exit;
+    end;
   end
   else
+    keyPath := '~/.pscal/etc/openweathermap.key';
+
+  keyFromFile := TryReadApiKeyFromFile(DEFAULT_API_KEY_PATH);
+  if keyFromFile <> '' then
   begin
-    if eof(keyFile) then
-    begin
-      writeln('Error: API key file "', filename, '" is empty.');
-      close(keyFile);
-      halt(1);
-    end
-    else
-    begin
-      readln(keyFile, keyRead); // Read the first line
-      close(keyFile);
-      // NOTE: No trimming implemented here, assumes key file is clean.
-    end;
+    LoadApiKey := keyFromFile;
+    exit;
   end;
 
-  if keyRead = '' then // Check if key was actually read
-  begin
-      writeln('Error: Failed to read API key from file "', filename, '".');
-      halt(1);
-  end;
-
-  ReadApiKeyFromFile := keyRead; // Return the key
+  writeln('Error: Unable to determine OpenWeather API key.');
+  writeln('Set the OPENWEATHER_API_KEY environment variable or create ', keyPath,
+          ' with your OpenWeather API key.');
+  halt(1);
 end;
-// --- END ReadApiKeyFromFile ---
+// --- END LoadApiKey ---
 
 
 // --- Helper function ExtractStringValue ---
@@ -244,7 +274,7 @@ end;
 begin
 
   // --- Read API Key ---
-  apiKeyFromFile := ReadApiKeyFromFile(API_KEY_FILENAME);
+  apiKeyFromFile := LoadApiKey();
   // { DEBUG: Key debug lines removed }
 
   // --- Check for command-line argument for Zip Code ---

--- a/Examples/Pascal/weather_json
+++ b/Examples/Pascal/weather_json
@@ -4,7 +4,7 @@ program DisplayWeatherJson;
 uses CRT, SysUtils;
 
 const
-  API_KEY_FILENAME = '/usr/local/pscal/lib/openweathermap.key';
+  DEFAULT_API_KEY_PATH = '/usr/local/pscal/lib/openweathermap.key';
 
 function ParseIntOrDefault(value: string; defaultValue: longint): longint;
 var
@@ -152,41 +152,74 @@ var
   timezoneFound, observationFound, sunriseFound, sunsetFound: boolean;
   statusOk: boolean;
 
-function ReadApiKeyFromFile(filename: string): string;
+function TryReadApiKeyFromFile(filename: string): string;
 var
   keyFile: Text;
   keyRead: string;
 begin
-  keyRead := '';
+  TryReadApiKeyFromFile := '';
   assign(keyFile, filename);
   {$I-}
   reset(keyFile);
   {$I+}
 
   if IOResult <> 0 then
-  begin
-    writeln('Error: Could not open API key file: "', filename, '"');
-    writeln('Please create this file and put your OpenWeatherMap API key in it.');
-    halt(1);
-  end;
+    exit;
 
   if eof(keyFile) then
   begin
-    writeln('Error: API key file "', filename, '" is empty.');
     close(keyFile);
-    halt(1);
+    exit;
   end;
 
   readln(keyFile, keyRead);
   close(keyFile);
 
-  if keyRead = '' then
+  keyRead := Trim(keyRead);
+  if keyRead <> '' then
+    TryReadApiKeyFromFile := keyRead;
+end;
+
+function LoadApiKey(): string;
+var
+  envKey, homeDir, keyPath, keyFromFile: string;
+begin
+  envKey := GetEnv('OPENWEATHER_API_KEY');
+  if envKey <> '' then
   begin
-    writeln('Error: Failed to read API key from file "', filename, '".');
-    halt(1);
+    LoadApiKey := envKey;
+    exit;
   end;
 
-  ReadApiKeyFromFile := keyRead;
+  homeDir := GetEnv('HOME');
+  if homeDir <> '' then
+  begin
+    if homeDir[length(homeDir)] = '/' then
+      keyPath := homeDir + '.pscal/etc/openweathermap.key'
+    else
+      keyPath := homeDir + '/.pscal/etc/openweathermap.key';
+
+    keyFromFile := TryReadApiKeyFromFile(keyPath);
+    if keyFromFile <> '' then
+    begin
+      LoadApiKey := keyFromFile;
+      exit;
+    end;
+  end
+  else
+    keyPath := '~/.pscal/etc/openweathermap.key';
+
+  keyFromFile := TryReadApiKeyFromFile(DEFAULT_API_KEY_PATH);
+  if keyFromFile <> '' then
+  begin
+    LoadApiKey := keyFromFile;
+    exit;
+  end;
+
+  writeln('Error: Unable to determine OpenWeather API key.');
+  writeln('Set the OPENWEATHER_API_KEY environment variable or create ', keyPath,
+          ' with your OpenWeather API key.');
+  halt(1);
 end;
 
 begin
@@ -197,7 +230,7 @@ begin
     halt(1);
   end;
 
-  apiKeyFromFile := ReadApiKeyFromFile(API_KEY_FILENAME);
+  apiKeyFromFile := LoadApiKey();
 
   if ParamCount >= 1 then
   begin

--- a/Examples/rea/openweather_forecast
+++ b/Examples/rea/openweather_forecast
@@ -59,6 +59,78 @@ str formatDateTime(int epochSeconds, int offsetSeconds) {
   return date + " " + pad2(hour) + ":" + pad2(minute);
 }
 
+str trimWhitespace(str value) {
+  int left = 1;
+  int right = length(value);
+  while (left <= right && (value[left] == ' ' || value[left] == '\t' ||
+         value[left] == '\n' || value[left] == '\r')) {
+    left = left + 1;
+  }
+  while (right >= left && (value[right] == ' ' || value[right] == '\t' ||
+         value[right] == '\n' || value[right] == '\r')) {
+    right = right - 1;
+  }
+  if (right < left) {
+    return "";
+  }
+  int resultLen = right - left + 1;
+  str trimmed;
+  setlength(trimmed, resultLen);
+  int i = 0;
+  while (i < resultLen) {
+    trimmed[i + 1] = value[left + i];
+    i = i + 1;
+  }
+  return trimmed;
+}
+
+str tryReadApiKeyFromFile(str path) {
+  if (!fileexists(path)) {
+    return "";
+  }
+  text f;
+  assign(f, path);
+  reset(f);
+  if (eof(f)) {
+    close(f);
+    return "";
+  }
+  str line;
+  readln(f, line);
+  close(f);
+  return trimWhitespace(line);
+}
+
+str resolveApiKey() {
+  str envKey = getenv("OPENWEATHER_API_KEY");
+  if (envKey != "") {
+    return envKey;
+  }
+
+  str home = getenv("HOME");
+  str desiredPath = "~/.pscal/etc/openweathermap.key";
+  if (home != "") {
+    if (home[length(home)] == '/') {
+      desiredPath = home + ".pscal/etc/openweathermap.key";
+    } else {
+      desiredPath = home + "/.pscal/etc/openweathermap.key";
+    }
+    str fileKey = tryReadApiKeyFromFile(desiredPath);
+    if (fileKey != "") {
+      return fileKey;
+    }
+  }
+
+  str legacyKey = tryReadApiKeyFromFile("/usr/local/pscal/lib/openweathermap.key");
+  if (legacyKey != "") {
+    return legacyKey;
+  }
+
+  writeln("Error: Unable to determine OpenWeather API key.");
+  writeln("Set the OPENWEATHER_API_KEY environment variable or create ~/.pscal/etc/openweathermap.key with your key.");
+  return "";
+}
+
 void printCurrentConditions(int currentHandle, str tempUnitSymbol) {
   float currentTemp = 0.0;
   int humidity = -1;
@@ -268,9 +340,8 @@ int main() {
     return 1;
   }
 
-  str apiKey = getenv("OPENWEATHER_API_KEY");
+  str apiKey = resolveApiKey();
   if (apiKey == "") {
-    writeln("Error: Please set the OPENWEATHER_API_KEY environment variable with your OpenWeather API key.");
     return 1;
   }
 


### PR DESCRIPTION
## Summary
- add shared helpers in the Pascal weather demos to fetch the OpenWeather key from OPENWEATHER_API_KEY or ~/.pscal/etc/openweathermap.key
- fall back to the legacy /usr/local/pscal path while emitting clear guidance when no key is found
- mirror the same lookup logic in the REA forecast example with small string helpers

## Testing
- not run (examples only)


------
https://chatgpt.com/codex/tasks/task_b_68d597b0d1d8832994f676b7b46d5ce0