### PR TITLE
Define local bar helper for SDL multibouncing balls 3D demo

### DIFF
--- a/Examples/rea/sdl_multibouncingballs_3d
+++ b/Examples/rea/sdl_multibouncingballs_3d
@@ -42,6 +42,24 @@ float randomUnit() {
   return random(10000) / 10000.0;
 }
 
+void bar(int left, int top, int right, int bottom) {
+  if (left > right) {
+    int temp = left;
+    left = right;
+    right = temp;
+  }
+  if (top > bottom) {
+    int temp = top;
+    top = bottom;
+    bottom = temp;
+  }
+  int y = top;
+  while (y <= bottom) {
+    line(left, y, right, y);
+    y = y + 1;
+  }
+}
+
 void initBalls() {
   int i = 0;
   float halfWidth = BoxWidth * 0.5;


### PR DESCRIPTION
## Summary
- add a local bar function to the SDL multi bouncing balls 3D example so it can fill rectangles without relying on an undefined builtin

## Testing
- not run (SDL demo requires a built runtime and display, unavailable in container)

------
https://chatgpt.com/codex/tasks/task_b_68d5a7f310788329995691e1c1ef359c