### PR TITLE
Add formatfloat builtin for numeric string formatting

### DIFF
--- a/Docs/pascal_overview.md
+++ b/Docs/pascal_overview.md
@@ -68,7 +68,7 @@ end.
 Builtins are implemented in C and exposed to Pascal through a lookup table【F:src/backend_ast/builtin.c†L35-L176】. They cover:
 
 * **Math** – `abs`, `cos`, `sin`, `tan`, `exp`, `ln`, `sqrt`, `sqr`, `round`, `trunc`.
-* **Strings** – `length`, `copy`, `pos`, `chr`, `ord`, `inttostr`, `realtostr`, `upcase`.
+* **Strings** – `length`, `copy`, `pos`, `chr`, `ord`, `inttostr`, `formatfloat`, `realtostr`, `upcase`.
 * **I/O** – `readln`, `writeln`, `readkey` (optional char parameter), `halt`, `gotoxy`, `whereX`, `textcolor`.
 * **Files & streams** – `assign`, `reset`, `rewrite`, `close`, `eof`, memory stream helpers (`mstreamcreate`, `mstreamloadfromfile`, etc.).
 * **Random numbers** – `randomize`, `random`.

--- a/Docs/pscal_vm_builtins.md
+++ b/Docs/pscal_vm_builtins.md
@@ -9,6 +9,7 @@ VM. For instructions on adding your own routines, see
 | Name | Parameters | Returns | Description |
 | ---- | ---------- | ------- | ----------- |
 | inttostr | (i: Integer) | String | Convert integer to string. |
+| formatfloat | (x: Numeric [, precision: Integer]) | String | Convert numeric value to string with fixed decimal precision. |
 | realtostr | (r: Real) | String | Convert real to string. |
 | real | (x: Ordinal or Real) | Real | Convert value to real. |
 | length | (s: String or Array) | Integer | Length of string or array. |

--- a/Examples/clike/builtins.h
+++ b/Examples/clike/builtins.h
@@ -145,6 +145,7 @@ int read();
 int readkey();
 int readln();
 int real();
+int formatfloat();
 int realtostr();
 int rename();
 int rendercopy();

--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -1277,7 +1277,8 @@ VarType getBuiltinReturnType(const char* name) {
     }
 
     /* String producing helpers */
-    if (strcasecmp(name, "inttostr")  == 0 ||
+    if (strcasecmp(name, "formatfloat") == 0 ||
+        strcasecmp(name, "inttostr")  == 0 ||
         strcasecmp(name, "realtostr") == 0 ||
         strcasecmp(name, "paramstr")  == 0 ||
         strcasecmp(name, "copy")      == 0 ||

--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -60,6 +60,7 @@ Value vmBuiltinFclose(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinCopy(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinSetlength(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinRealtostr(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinFormatfloat(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinStr(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinParamcount(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinParamstr(struct VM_s* vm, int arg_count, Value* args);


### PR DESCRIPTION
## Summary
- add a vm builtin that formats numeric values with a fixed decimal precision and expose it to the dispatcher
- teach the compiler and CLike front-end about the new builtin and document it alongside the other string helpers
- register FormatFloat with the shared builtin registry so Pascal and Rea front ends resolve it as a function

## Testing
- cmake -S . -B build
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_b_68d5b5b96364832993b371035724c0f4