### PR TITLE
Preserve legacy ID for write builtin

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -362,12 +362,12 @@ static const VmBuiltinMapping vmBuiltinDispatchTable[] = {
     {"pos", vmBuiltinPos},
     {"power", vmBuiltinPower},
     {"printf", vmBuiltinPrintf},
-    {"fprintf", vmBuiltinFprintf},
     {"fopen", vmBuiltinFopen},
     {"fclose", vmBuiltinFclose},
     {"pushscreen", vmBuiltinPushscreen},
     {"putpixel", SDL_HANDLER(vmBuiltinPutpixel)},
     {"write", vmBuiltinWrite}, // Preserve legacy builtin id for write
+    {"fprintf", vmBuiltinFprintf}, // Registered after write to avoid shifting legacy id 176
     {"quitsoundsystem", SDL_HANDLER(vmBuiltinQuitsoundsystem)},
     {"quittextsystem", SDL_HANDLER(vmBuiltinQuittextsystem)},
     {"random", vmBuiltinRandom},


### PR DESCRIPTION
## Summary
- ensure the write built-in remains at its legacy ID slot by moving the new fprintf registration after it
- document the ordering so adding fprintf no longer shifts existing Pascal bytecode indices

## Testing
- ./Tests/run_all_tests > /tmp/tests.log

------
https://chatgpt.com/codex/tasks/task_b_68d5e16f68c48329b2d82527940a5bbc