### PR TITLE
Fix grid interpolation cast in 3D bouncing balls demo

### DIFF
--- a/Examples/rea/sdl_multibouncingballs_3d
+++ b/Examples/rea/sdl_multibouncingballs_3d
@@ -197,7 +197,7 @@ void drawGlassBox() {
     GLColor4f(0.18, 0.26, 0.38, 0.30);
     GLBegin("lines");
         while (i <= gridSteps) {
-            float t = (float)i / gridSteps;
+            float t = (i * 1.0) / gridSteps;
             float x = -halfWidth + t * BoxWidth;
             GLVertex3f(x, -halfHeight + 0.2, frontZ);
             GLVertex3f(x, -halfHeight + 0.2, backZ);


### PR DESCRIPTION
## Summary
- avoid using a C-style cast when computing the grid interpolation factor in `sdl_multibouncingballs_3d`
- ensure the interpolation scalar is computed as a floating-point value to prevent nil multiplications at runtime

## Testing
- not run (SDL/OpenGL demo not available in CI container)


------
https://chatgpt.com/codex/tasks/task_b_68d6c35173948329b75de916d6463734