### PR TITLE
Add BouncingBalls3DAccelerate builtin and retune SDL demo

### DIFF
--- a/Examples/rea/sdl_multibouncingballs_3d
+++ b/Examples/rea/sdl_multibouncingballs_3d
@@ -5,18 +5,19 @@
 
 const int WindowWidth = 1280;
 const int WindowHeight = 720;
-const int TargetFPS = 60;
+
+float TargetFPS = 60.0;
 
 const int NumBalls = 90;
 const float BoxWidth = 720.0;
 const float BoxHeight = 420.0;
 const float BoxDepth = 300.0;
 const float WallElasticity = 1.08;
-const float MinSpeed = 90.0;
-const float MaxSpeed = 360.0;
+float MinSpeed = 90.0;
+float MaxSpeed = 360.0;
 const float VelocityDrag = 0.995;
 
-const float CameraDistance = 1150.0;
+float CameraDistance = 1150.0;
 const float CameraPitch = -12.0;
 const float CameraOrbitSpeed = 10.0;
 
@@ -47,6 +48,7 @@ int colorB[NumBalls];
 bool quit;
 bool paused;
 int FrameDelay;
+float DeltaTime;
 float elapsedSeconds;
 float cameraYaw;
 
@@ -293,10 +295,19 @@ void initApp() {
     GLSetSwapInterval(1);
     setupLighting();
 
+    FrameDelay = trunc(1000 / TargetFPS);
+    DeltaTime = 1.0 / TargetFPS;
+
+    float fpsBoost = 1.6;
+    float speedBoost = 2.3;
+    float cameraPull = 0.7;
+    BouncingBalls3DAccelerate(TargetFPS, FrameDelay, DeltaTime,
+        MinSpeed, MaxSpeed, CameraDistance,
+        fpsBoost, speedBoost, cameraPull);
+
     randomize();
     initBalls();
 
-    FrameDelay = trunc(1000 / TargetFPS);
     quit = false;
     paused = false;
     elapsedSeconds = 0.0;
@@ -306,10 +317,9 @@ void initApp() {
 void run() {
     initApp();
     writeln("Multi Bouncing Balls 3D (OpenGL) ... Press Q to quit, Space to pause.");
-    float deltaTime = 1.0 / TargetFPS;
     while (!quit) {
         handleInput();
-        updateSimulation(deltaTime);
+        updateSimulation(DeltaTime);
         drawScene();
         GraphLoop(FrameDelay);
     }

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -5193,6 +5193,8 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
                       strcasecmp(calleeName, "BouncingBalls3DStep") == 0) && param_index >= 12) ||
                     ((strcasecmp(calleeName, "bouncingballs3dstepadvanced") == 0 ||
                       strcasecmp(calleeName, "BouncingBalls3DStepAdvanced") == 0) && param_index >= 15)
+                    || ((strcasecmp(calleeName, "bouncingballs3daccelerate") == 0 ||
+                         strcasecmp(calleeName, "BouncingBalls3DAccelerate") == 0) && param_index <= 5)
                 )) {
                     is_var_param = true;
                 }

--- a/src/ext_builtins/user/register.c
+++ b/src/ext_builtins/user/register.c
@@ -12,6 +12,7 @@ void registerUserBuiltins(void) {
     extBuiltinRegisterFunction("user", "LandscapePrecomputeWaterOffsets");
     extBuiltinRegisterFunction("user", "BouncingBalls3DStep");
     extBuiltinRegisterFunction("user", "BouncingBalls3DStepAdvanced");
+    extBuiltinRegisterFunction("user", "BouncingBalls3DAccelerate");
 
     registerLandscapeBuiltins();
     registerBalls3DBuiltins();


### PR DESCRIPTION
## Summary
- add the BouncingBalls3DAccelerate extended builtin that rescales FPS, delta time, min/max speed, and camera distance via VAR parameters
- register the new builtin with the compiler and runtime so its first six parameters are treated as references
- retune the sdl_multibouncingballs_3d demo to call the builtin, speeding up motion and pulling the camera closer

## Testing
- cmake -S . -B build
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_b_68d6c64549988329b08964c93e50167a