### PR TITLE
Fix X11 display pointer retrieval for SDL syswm events

### DIFF
--- a/src/backend_ast/sdl.c
+++ b/src/backend_ast/sdl.c
@@ -79,9 +79,13 @@ static void handleSysWmEvent(const SDL_Event* event) {
         return;
     }
 
-    Display* display = msg->msg.x11.display;
     XEvent* xevent = &msg->msg.x11.event;
-    if (!display || !xevent || xevent->type != ClientMessage) {
+    if (!xevent || xevent->type != ClientMessage) {
+        return;
+    }
+
+    Display* display = xevent->xclient.display;
+    if (!display) {
         return;
     }
 


### PR DESCRIPTION
## Summary
- adjust the SDL syswm handler to retrieve the X11 display from the client message event when responding to _NET_WM_PING

## Testing
- cmake --build build --target pscalvm -- -j8

------
https://chatgpt.com/codex/tasks/task_b_68d6dc3fcdd88329a06b03071b809d1a