### PR TITLE
Ensure GraphLoop pumps SDL events even when behind schedule

### DIFF
--- a/src/backend_ast/sdl.c
+++ b/src/backend_ast/sdl.c
@@ -1401,7 +1401,13 @@ Value vmBuiltinGraphloop(VM* vm, int arg_count, Value* args) {
         Uint32 targetTime = startTime + (Uint32)ms;
         SDL_Event event;
 
-        while (SDL_GetTicks() < targetTime) {
+        /*
+         * Always process at least one batch of window events.  Some window
+         * managers (e.g. GNOME on Linux) show an "application is not
+         * responding" dialog if we miss several compositor pings, which
+         * happens whenever the frame takes longer than the requested delay.
+         */
+        for (;;) {
             SDL_PumpEvents();
 
             while (SDL_PollEvent(&event)) {
@@ -1424,7 +1430,19 @@ Value vmBuiltinGraphloop(VM* vm, int arg_count, Value* args) {
                 return makeVoid();
             }
 
-            SDL_Delay(1); // Prevent 100% CPU usage
+            Uint32 now = SDL_GetTicks();
+            if (now >= targetTime) {
+                break;
+            }
+
+            Uint32 remaining = targetTime - now;
+            if (remaining > 10) {
+                remaining = 10;
+            }
+
+            if (remaining > 0) {
+                SDL_Delay(remaining);
+            }
         }
     }
     return makeVoid();


### PR DESCRIPTION
## Summary
- always pump SDL events at least once per GraphLoop invocation so compositor pings are answered
- throttle the sleep interval based on the remaining frame budget to avoid busy waiting

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d6d48bae688329833071a8e5020559