### PR TITLE
Add optimized BouncingBalls3D builtins

### DIFF
--- a/Docs/rea_tutorial.md
+++ b/Docs/rea_tutorial.md
@@ -5,7 +5,7 @@ building the compiler, running the SDL multi bouncing balls sample located at
 `Examples/rea/sdl_multibouncingballs`, and understanding every part of the
 program. Once you are comfortable with the 2D version, check out the
 `Examples/rea/sdl_multibouncingballs_3d` variant that renders a 3D boxed arena
-and now leans on the `BouncingBalls3DStepAdvanced` extended builtin for fast
+and now leans on the `BouncingBalls3DStepUltraAdvanced` extended builtin for fast
 physics, projection, and lighting hints.
 
 ## Build the compiler

--- a/Examples/rea/sdl_multibouncingballs_3d
+++ b/Examples/rea/sdl_multibouncingballs_3d
@@ -266,7 +266,7 @@ void drawScene() {
 
 void updateSimulation(float deltaTime) {
     if (paused) return;
-    BouncingBalls3DStep(NumBalls, deltaTime, BoxWidth, BoxHeight, BoxDepth,
+    BouncingBalls3DStepUltra(NumBalls, deltaTime, BoxWidth, BoxHeight, BoxDepth,
         WallElasticity, MinSpeed, MaxSpeed, VelocityDrag,
         CameraDistance, WindowWidth, WindowHeight,
         posX, posY, posZ, velX, velY, velZ, radii,

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -5191,8 +5191,12 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
                     /* BouncingBalls3D builtins write simulation data back via VAR arrays */
                     ((strcasecmp(calleeName, "bouncingballs3dstep") == 0 ||
                       strcasecmp(calleeName, "BouncingBalls3DStep") == 0) && param_index >= 12) ||
+                    ((strcasecmp(calleeName, "bouncingballs3dstepultra") == 0 ||
+                      strcasecmp(calleeName, "BouncingBalls3DStepUltra") == 0) && param_index >= 12) ||
                     ((strcasecmp(calleeName, "bouncingballs3dstepadvanced") == 0 ||
-                      strcasecmp(calleeName, "BouncingBalls3DStepAdvanced") == 0) && param_index >= 15)
+                      strcasecmp(calleeName, "BouncingBalls3DStepAdvanced") == 0) && param_index >= 15) ||
+                    ((strcasecmp(calleeName, "bouncingballs3dstepultraadvanced") == 0 ||
+                      strcasecmp(calleeName, "BouncingBalls3DStepUltraAdvanced") == 0) && param_index >= 15)
                     || ((strcasecmp(calleeName, "bouncingballs3daccelerate") == 0 ||
                          strcasecmp(calleeName, "BouncingBalls3DAccelerate") == 0) && param_index <= 5)
                 )) {

--- a/src/ext_builtins/user/register.c
+++ b/src/ext_builtins/user/register.c
@@ -11,7 +11,9 @@ void registerUserBuiltins(void) {
     extBuiltinRegisterFunction("user", "LandscapePrecomputeWorldCoords");
     extBuiltinRegisterFunction("user", "LandscapePrecomputeWaterOffsets");
     extBuiltinRegisterFunction("user", "BouncingBalls3DStep");
+    extBuiltinRegisterFunction("user", "BouncingBalls3DStepUltra");
     extBuiltinRegisterFunction("user", "BouncingBalls3DStepAdvanced");
+    extBuiltinRegisterFunction("user", "BouncingBalls3DStepUltraAdvanced");
     extBuiltinRegisterFunction("user", "BouncingBalls3DAccelerate");
 
     registerLandscapeBuiltins();


### PR DESCRIPTION
## Summary
- add reusable work buffers and an optimized BouncingBalls3DStepUltra implementation
- extend builtin registration/compiler plumbing so the new routines are available to Rea code
- switch the SDL multibouncing balls demo and tutorial docs to the faster builtins

## Testing
- cmake --build build --target rea

------
https://chatgpt.com/codex/tasks/task_b_68d6e15162888329a87cb48ad353941b