### PR TITLE
Fix highlight coordinate space in Rea 3D balls demo

### DIFF
--- a/Examples/rea/sdl_multibouncingballs_3d
+++ b/Examples/rea/sdl_multibouncingballs_3d
@@ -519,12 +519,18 @@ class BallSystem extends Renderable {
     }
 
     void drawSpecularHighlight(int index) {
-        float radiusScale = myself.highlightRadius[index];
+        float sr = myself.screenRadius[index];
+        if (sr <= 0.001) return;
+
+        float radiusScale = myself.highlightRadius[index] / sr;
         if (radiusScale <= 0.001) return;
+
         float strength = myself.highlightStrength[index];
         if (strength <= 0.001) return;
-        float hx = myself.highlightX[index];
-        float hy = myself.highlightY[index];
+
+        float hx = (myself.highlightX[index] - myself.screenX[index]) / sr;
+        float hy = (myself.highlightY[index] - myself.screenY[index]) / sr;
+
         GLDisable("lighting");
         GLEnable("blend");
         GLBlendFunc("src_alpha", "one_minus_src_alpha");


### PR DESCRIPTION
## Summary
- normalise the specular highlight coordinates returned by the balls3d builtin so they align with the scaled sphere mesh
- guard against missing screen radius data before attempting to render a highlight

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d719ad002083298fbb98d48ba79361