### PR TITLE
Fix SDL 3D multibouncing balls shading

### DIFF
--- a/Examples/rea/sdl_multibouncingballs_3d
+++ b/Examples/rea/sdl_multibouncingballs_3d
@@ -51,6 +51,12 @@ float randomUnit() {
     return random(10000) / 10000.0;
 }
 
+float clamp01(float value) {
+    if (value < 0.0) return 0.0;
+    if (value > 1.0) return 1.0;
+    return value;
+}
+
 class Vec3 {
     float x;
     float y;
@@ -100,6 +106,15 @@ class ColorRGB {
         myself.r = myself.r + other.r;
         myself.g = myself.g + other.g;
         myself.b = myself.b + other.b;
+    }
+
+    void clamp01() {
+        if (myself.r < 0.0) myself.r = 0.0;
+        if (myself.r > 1.0) myself.r = 1.0;
+        if (myself.g < 0.0) myself.g = 0.0;
+        if (myself.g > 1.0) myself.g = 1.0;
+        if (myself.b < 0.0) myself.b = 0.0;
+        if (myself.b > 1.0) myself.b = 1.0;
     }
 }
 
@@ -494,20 +509,30 @@ class BallSystem extends Renderable {
         float baseR = myself.colorR[index] / 255.0;
         float baseG = myself.colorG[index] / 255.0;
         float baseB = myself.colorB[index] / 255.0;
-        float lit = myself.lightIntensity[index];
-        float rim = myself.rimIntensity[index];
-        float highlight = myself.highlightStrength[index];
+        float lit = clamp01(myself.lightIntensity[index]);
+        float rim = clamp01(myself.rimIntensity[index]);
+        float highlight = clamp01(myself.highlightStrength[index]);
+        float depth = myself.depthShade[index];
+        if (depth < 0.0) depth = 0.5;
+        depth = clamp01(depth);
 
         ColorRGB color = new ColorRGB(baseR, baseG, baseB);
-        color.scale(0.28 + 0.62 * lit);
+        float ambientFactor = 0.32 + 0.36 * depth;
+        color.scale(ambientFactor);
 
-        ColorRGB rimColor = new ColorRGB(0.08, 0.10, 0.16);
-        rimColor.scale(rim * 1.75);
+        ColorRGB diffuseBoost = new ColorRGB(baseR, baseG, baseB);
+        diffuseBoost.scale(0.42 * lit);
+        color.add(diffuseBoost);
+
+        ColorRGB rimColor = new ColorRGB(0.18, 0.22, 0.30);
+        rimColor.scale(rim * 0.9);
         color.add(rimColor);
 
-        ColorRGB specColor = new ColorRGB(0.90, 0.92, 0.95);
-        specColor.scale(highlight * 0.85);
+        ColorRGB specColor = new ColorRGB(0.92, 0.95, 0.99);
+        specColor.scale(highlight * 0.75);
         color.add(specColor);
+
+        color.clamp01();
 
         GLPushMatrix();
         GLTranslatef(myself.posX[index], myself.posY[index], myself.posZ[index]);


### PR DESCRIPTION
## Summary
- add clamp helpers for color calculations in the SDL multibouncing balls 3D demo
- rebalance the ambient, diffuse, rim, and highlight mixes so the spheres render with visible color

## Testing
- not run (demo requires SDL output)


------
https://chatgpt.com/codex/tasks/task_b_68d7202744cc8329ac3ab16519ff4502