### PR TITLE
Clamp lighting values in multi bouncing balls 3D demo

### DIFF
--- a/Examples/rea/sdl_multibouncingballs_3d
+++ b/Examples/rea/sdl_multibouncingballs_3d
@@ -498,8 +498,17 @@ class BallSystem extends Renderable {
         float rim = myself.rimIntensity[index];
         float highlight = myself.highlightStrength[index];
 
+        if (lit < 0.0) lit = 0.0;
+        if (lit > 1.0) lit = 1.0;
+        if (rim < 0.0) rim = 0.0;
+        if (rim > 1.0) rim = 1.0;
+        if (highlight < 0.0) highlight = 0.0;
+        if (highlight > 1.0) highlight = 1.0;
+
         ColorRGB color = new ColorRGB(baseR, baseG, baseB);
-        color.scale(0.28 + 0.62 * lit);
+        float brightness = 0.28 + 0.62 * lit;
+        if (brightness < 0.06) brightness = 0.06;
+        color.scale(brightness);
 
         ColorRGB rimColor = new ColorRGB(0.08, 0.10, 0.16);
         rimColor.scale(rim * 1.75);


### PR DESCRIPTION
## Summary
- clamp lighting outputs from BouncingBalls3D to keep values in a visible range
- add a floor brightness floor when scaling ball colors to prevent them from turning black

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d724cee3d08329a7be4e24613bc29a