### PR TITLE
Handle ES index limits in balls3d sphere cache

### DIFF
--- a/Examples/rea/sdl_multibouncingballs_3d
+++ b/Examples/rea/sdl_multibouncingballs_3d
@@ -692,6 +692,8 @@ class DemoApp extends Renderable {
     void init() {
         randomize();
         myself.configureGraphics();
+        // Prime the unit-sphere cache once the GL context is alive so the first frame stays smooth.
+        BouncingBalls3DDrawUnitSphereFast(SphereStacks, SphereSlices);
         float fpsBoost = 1.7;
         float speedBoost = 2.45;
         float cameraPull = 0.66;

--- a/src/backend_ast/sdl.c
+++ b/src/backend_ast/sdl.c
@@ -23,6 +23,8 @@
 #include <string.h>
 #include <strings.h>
 
+extern void cleanupBalls3DRenderingResources(void);
+
 #ifdef SDL_VIDEO_DRIVER_X11
 #include <X11/Xlib.h>
 #include <X11/Xatom.h>
@@ -298,6 +300,7 @@ void cleanupSdlWindowResources(void) {
     resetPendingKeycodes();
 
     if (gSdlGLContext) {
+        cleanupBalls3DRenderingResources();
         SDL_GL_DeleteContext(gSdlGLContext);
         gSdlGLContext = NULL;
         #ifdef DEBUG


### PR DESCRIPTION
## Summary
- gate large tessellations and prefer 16-bit indices when possible so the sphere cache works on OpenGL ES profiles
- store the index element type alongside the cached VBO/EBOs and reset ES detection during teardown
- warm the sphere cache during the multi bouncing balls demo init to avoid first-frame stalls on new contexts

## Testing
- not run (OpenGL core/ES context not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68d751b82c14832981d9f1139802da19