### PR TITLE
Implement Balls3D cleanup to fix SDL build linking

### DIFF
--- a/src/ext_builtins/user/balls3d.c
+++ b/src/ext_builtins/user/balls3d.c
@@ -1563,6 +1563,21 @@ static Value vmBuiltinBouncingBalls3DAccelerate(VM* vm, int arg_count,
     return makeVoid();
 }
 
+void cleanupBalls3DRenderingResources(void) {
+#ifdef SDL
+    if (gSphereDisplayListCache.initialized) {
+        if (gSdlGLContext) {
+            destroySphereDisplayList();
+        } else {
+            gSphereDisplayListCache.displayListId = 0;
+            gSphereDisplayListCache.initialized = false;
+        }
+    }
+    gSphereDisplayListSupported = true;
+#endif
+    freeBalls3DWorkBuffers(&balls3dWorkBuffers);
+}
+
 void registerBalls3DBuiltins(void) {
     registerVmBuiltin("bouncingballs3dstep", vmBuiltinBouncingBalls3DStep,
                       BUILTIN_TYPE_PROCEDURE, "BouncingBalls3DStep");


### PR DESCRIPTION
## Summary
- add the missing cleanupBalls3DRenderingResources definition used by the SDL backend
- reset cached OpenGL display lists when a context is available and release the Balls3D work buffers

## Testing
- cmake -S . -B build
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_b_68d7db5ab97c8329883b44e9f775c37d