### PR TITLE
Add standard utility modules for Rea

### DIFF
--- a/lib/rea/README.md
+++ b/lib/rea/README.md
@@ -6,3 +6,21 @@ front end.  The `crt` module contains the core runtime that is installed to
 looks for modules in `/usr/local/lib/rea` by default, and you can override the
 search list by setting the `REA_IMPORT_PATH` environment variable to a
 colon-separated (or semicolon-separated on Windows) list of directories.
+
+Additional library modules provide higher-level utilities that are not covered
+by the core or extended VM built-ins:
+
+* `strings` – trimming, padding, case conversion, substring helpers, and a
+  simple character sorter to avoid reimplementing common text utilities.
+* `filesystem` – convenience routines for reading and writing whole files,
+  joining paths, expanding `~`, and extracting the first line from a file while
+  tracking the most recent I/O status codes.
+* `json` – thin wrappers around the optional `yyjson` extended built-ins that
+  add availability checks, defaulting lookups, and automatic handle cleanup for
+  both objects and arrays.
+* `http` – opinionated helpers built on the synchronous HTTP built-ins to issue
+  simple GET/POST/PUT requests, track the last status code, and download
+  responses directly to disk.
+* `datetime` – reusable routines for formatting Unix timestamps with timezone
+  offsets, computing day boundaries, performing simple arithmetic, and creating
+  human-friendly duration descriptions.

--- a/lib/rea/datetime
+++ b/lib/rea/datetime
@@ -1,0 +1,178 @@
+module DateTime {
+
+    str pad2(int value) {
+        if (value < 10 && value >= 0) {
+            return "0" + inttostr(value);
+        }
+        return inttostr(value);
+    }
+
+    export str formatUtcOffset(int offsetSeconds) {
+        int absSeconds = offsetSeconds;
+        str sign = "+";
+        if (absSeconds < 0) {
+            sign = "-";
+            absSeconds = -absSeconds;
+        }
+        int hours = absSeconds / 3600;
+        int minutes = (absSeconds % 3600) / 60;
+        return sign + pad2(hours) + ":" + pad2(minutes);
+    }
+
+    export str formatUnix(int epochSeconds, int offsetSeconds) {
+        int total = epochSeconds + offsetSeconds;
+        if (total < 0) {
+            total = 0;
+        }
+        int days = total / 86400;
+        int secondsOfDay = total % 86400;
+        int hour = secondsOfDay / 3600;
+        int minute = (secondsOfDay % 3600) / 60;
+        int second = secondsOfDay % 60;
+
+        int z = days + 719468;
+        int era;
+        if (z >= 0) {
+            era = z / 146097;
+        } else {
+            era = (z - 146096) / 146097;
+        }
+        int doe = z - era * 146097;
+        int yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+        int year = yoe + era * 400;
+        int doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+        int mp = (5 * doy + 2) / 153;
+        int day = doy - (153 * mp + 2) / 5 + 1;
+        int month;
+        if (mp < 10) {
+            month = mp + 3;
+        } else {
+            month = mp - 9;
+        }
+        if (month <= 2) {
+            year = year + 1;
+        }
+
+        str date = inttostr(year) + "-" + pad2(month) + "-" + pad2(day);
+        str time = pad2(hour) + ":" + pad2(minute) + ":" + pad2(second);
+        return date + " " + time;
+    }
+
+    export str iso8601(int epochSeconds, int offsetSeconds) {
+        int total = epochSeconds + offsetSeconds;
+        if (total < 0) {
+            total = 0;
+        }
+        int days = total / 86400;
+        int secondsOfDay = total % 86400;
+        int hour = secondsOfDay / 3600;
+        int minute = (secondsOfDay % 3600) / 60;
+        int second = secondsOfDay % 60;
+
+        int z = days + 719468;
+        int era;
+        if (z >= 0) {
+            era = z / 146097;
+        } else {
+            era = (z - 146096) / 146097;
+        }
+        int doe = z - era * 146097;
+        int yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+        int year = yoe + era * 400;
+        int doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+        int mp = (5 * doy + 2) / 153;
+        int day = doy - (153 * mp + 2) / 5 + 1;
+        int month;
+        if (mp < 10) {
+            month = mp + 3;
+        } else {
+            month = mp - 9;
+        }
+        if (month <= 2) {
+            year = year + 1;
+        }
+
+        str date = inttostr(year) + "-" + pad2(month) + "-" + pad2(day);
+        str time = pad2(hour) + ":" + pad2(minute) + ":" + pad2(second);
+        return date + "T" + time + formatUtcOffset(offsetSeconds);
+    }
+
+    export int startOfDay(int epochSeconds, int offsetSeconds) {
+        int total = epochSeconds + offsetSeconds;
+        int days;
+        if (total >= 0) {
+            days = total / 86400;
+        } else {
+            days = (total - 86399) / 86400;
+        }
+        return days * 86400 - offsetSeconds;
+    }
+
+    export int endOfDay(int epochSeconds, int offsetSeconds) {
+        int start = startOfDay(epochSeconds, offsetSeconds);
+        return start + 86399;
+    }
+
+    export int addDays(int epochSeconds, int days) {
+        return epochSeconds + days * 86400;
+    }
+
+    export int addHours(int epochSeconds, int hours) {
+        return epochSeconds + hours * 3600;
+    }
+
+    export int addMinutes(int epochSeconds, int minutes) {
+        return epochSeconds + minutes * 60;
+    }
+
+    export int daysBetween(int startEpoch, int endEpoch) {
+        int diff = endEpoch - startEpoch;
+        if (diff >= 0) {
+            return diff / 86400;
+        }
+        int positive = -diff;
+        return -((positive + 86399) / 86400);
+    }
+
+    export str describeDifference(int startEpoch, int endEpoch) {
+        int diff = endEpoch - startEpoch;
+        int sign = 1;
+        if (diff < 0) {
+            sign = -1;
+            diff = -diff;
+        }
+        int days = diff / 86400;
+        int remainder = diff % 86400;
+        int hours = remainder / 3600;
+        remainder = remainder % 3600;
+        int minutes = remainder / 60;
+        int seconds = remainder % 60;
+
+        str result = "";
+        if (days > 0) {
+            result = inttostr(days) + "d";
+        }
+        if (hours > 0 || (days > 0 && (minutes > 0 || seconds > 0))) {
+            if (result != "") {
+                result = result + " ";
+            }
+            result = result + inttostr(hours) + "h";
+        }
+        if (minutes > 0 || (result != "" && seconds > 0)) {
+            if (result != "") {
+                result = result + " ";
+            }
+            result = result + inttostr(minutes) + "m";
+        }
+        if (seconds > 0 || result == "") {
+            if (result != "") {
+                result = result + " ";
+            }
+            result = result + inttostr(seconds) + "s";
+        }
+        if (sign < 0) {
+            result = "-" + result;
+        }
+        return result;
+    }
+}

--- a/lib/rea/filesystem
+++ b/lib/rea/filesystem
@@ -1,0 +1,229 @@
+module Filesystem {
+
+    bool lastReadOk = false;
+    int lastReadError = 0;
+    int lastWriteError = 0;
+
+    void markReadFailure(int code) {
+        lastReadOk = false;
+        lastReadError = code;
+    }
+
+    void markReadSuccess() {
+        lastReadOk = true;
+        lastReadError = 0;
+    }
+
+    export bool lastReadSucceeded() {
+        return lastReadOk;
+    }
+
+    export int lastReadErrorCode() {
+        return lastReadError;
+    }
+
+    export int lastWriteErrorCode() {
+        return lastWriteError;
+    }
+
+    export str readAllText(str path) {
+        str result = "";
+        text f;
+        bool firstLine = true;
+
+        assign(f, path);
+        reset(f);
+        int err = ioresult();
+        if (err != 0) {
+            markReadFailure(err);
+            return "";
+        }
+
+        while (!eof(f)) {
+            str line;
+            readln(f, line);
+            if (firstLine) {
+                result = line;
+                firstLine = false;
+            } else {
+                result = result + "\n" + line;
+            }
+        }
+
+        close(f);
+        err = ioresult();
+        if (err != 0) {
+            markReadFailure(err);
+            return result;
+        }
+
+        markReadSuccess();
+        return result;
+    }
+
+    export bool writeAllText(str path, str contents) {
+        text f;
+
+        assign(f, path);
+        rewrite(f);
+        int err = ioresult();
+        if (err != 0) {
+            lastWriteError = err;
+            return false;
+        }
+
+        write(f, contents);
+        err = ioresult();
+        if (err != 0) {
+            lastWriteError = err;
+            close(f);
+            ioresult();
+            return false;
+        }
+
+        close(f);
+        err = ioresult();
+        if (err != 0) {
+            lastWriteError = err;
+            return false;
+        }
+
+        lastWriteError = 0;
+        return true;
+    }
+
+    export str joinPath(str left, str right) {
+        if (left == "") {
+            return right;
+        }
+        if (right == "") {
+            return left;
+        }
+
+        bool leftEndsSlash = false;
+        char lastChar = left[length(left)];
+        if (lastChar == '/' || lastChar == '\\') {
+            leftEndsSlash = true;
+        }
+
+        bool rightStartsSlash = false;
+        char firstChar = right[1];
+        if (firstChar == '/' || firstChar == '\\') {
+            rightStartsSlash = true;
+        }
+
+        if (leftEndsSlash && rightStartsSlash) {
+            int rightLen = length(right);
+            if (rightLen <= 1) {
+                return left;
+            }
+            str trimmed;
+            setlength(trimmed, rightLen - 1);
+            int i = 2;
+            while (i <= rightLen) {
+                trimmed[i - 1] = right[i];
+                i = i + 1;
+            }
+            return left + trimmed;
+        }
+
+        if (!leftEndsSlash && !rightStartsSlash) {
+            return left + "/" + right;
+        }
+
+        return left + right;
+    }
+
+    export str expandUser(str path) {
+        if (path == "") {
+            return path;
+        }
+        if (path[1] != '~') {
+            return path;
+        }
+
+        str home = getenv("HOME");
+        if (home == "") {
+            home = getenv("USERPROFILE");
+        }
+        if (home == "") {
+            return path;
+        }
+
+        int pathLen = length(path);
+        if (pathLen == 1) {
+            return home;
+        }
+
+        char next = path[2];
+        if (next != '/' && next != '\\') {
+            return path;
+        }
+
+        bool homeEndsSlash = false;
+        char homeLast = home[length(home)];
+        if (homeLast == '/' || homeLast == '\\') {
+            homeEndsSlash = true;
+        }
+
+        str remainder;
+        int remainderLen = pathLen - 1;
+        setlength(remainder, remainderLen);
+        int i = 2;
+        while (i <= pathLen) {
+            remainder[i - 1] = path[i];
+            i = i + 1;
+        }
+
+        if (homeEndsSlash) {
+            if (remainderLen == 0) {
+                return home;
+            }
+            if (remainder[1] == '/' || remainder[1] == '\\') {
+                int trimmedLen = remainderLen - 1;
+                str trimmed;
+                setlength(trimmed, trimmedLen);
+                int j = 2;
+                while (j <= remainderLen) {
+                    trimmed[j - 1] = remainder[j];
+                    j = j + 1;
+                }
+                return home + trimmed;
+            }
+            return home + remainder;
+        }
+
+        if (remainderLen == 0) {
+            return home;
+        }
+
+        if (remainder[1] == '/' || remainder[1] == '\\') {
+            return home + remainder;
+        }
+
+        return home + "/" + remainder;
+    }
+
+    export str readFirstLine(str path) {
+        str contents = readAllText(path);
+        if (!lastReadSucceeded()) {
+            return "";
+        }
+        int len = length(contents);
+        int i = 1;
+        while (i <= len) {
+            if (contents[i] == '\n' || contents[i] == '\r') {
+                str line;
+                setlength(line, i - 1);
+                int j = 1;
+                while (j < i) {
+                    line[j] = contents[j];
+                    j = j + 1;
+                }
+                return line;
+            }
+            i = i + 1;
+        }
+        return contents;
+    }
+}

--- a/lib/rea/http
+++ b/lib/rea/http
@@ -1,0 +1,116 @@
+module Http {
+
+    int lastStatus = 0;
+
+    void resetStatus(int status) {
+        lastStatus = status;
+    }
+
+    str requestWithBody(str method, str url, bool hasBody, str body, str contentType, str accept) {
+        mstream out = mstreamcreate();
+        str response = "";
+        int session = httpsession();
+        if (session < 0) {
+            resetStatus(-1);
+            mstreamfree(out);
+            return "";
+        }
+
+        if (contentType != "") {
+            httpsetheader(session, "Content-Type", contentType);
+        }
+        if (accept != "") {
+            httpsetheader(session, "Accept", accept);
+        }
+
+        int status;
+        if (hasBody) {
+            status = httprequest(session, method, url, body, out);
+        } else {
+            status = httprequest(session, method, url, nil, out);
+        }
+        resetStatus(status);
+
+        if (status >= 0) {
+            response = mstreambuffer(out);
+        }
+
+        httpclose(session);
+        mstreamfree(out);
+        return response;
+    }
+
+    export int lastResponseStatus() {
+        return lastStatus;
+    }
+
+    export str get(str url) {
+        return requestWithBody("GET", url, false, "", "", "");
+    }
+
+    export str getJson(str url) {
+        return requestWithBody("GET", url, false, "", "", "application/json");
+    }
+
+    export str post(str url, str body, str contentType) {
+        return requestWithBody("POST", url, true, body, contentType, "");
+    }
+
+    export str postJson(str url, str body) {
+        return requestWithBody("POST", url, true, body, "application/json", "application/json");
+    }
+
+    export str put(str url, str body, str contentType) {
+        return requestWithBody("PUT", url, true, body, contentType, "");
+    }
+
+    export bool wasSuccessful() {
+        if (lastStatus >= 200 && lastStatus < 300) {
+            return true;
+        }
+        return false;
+    }
+
+    export bool downloadToFile(str url, str path) {
+        mstream out = mstreamcreate();
+        int session = httpsession();
+        if (session < 0) {
+            resetStatus(-1);
+            mstreamfree(out);
+            return false;
+        }
+
+        int status = httprequest(session, "GET", url, nil, out);
+        resetStatus(status);
+        if (status < 0) {
+            httpclose(session);
+            mstreamfree(out);
+            return false;
+        }
+
+        str body = mstreambuffer(out);
+        httpclose(session);
+        mstreamfree(out);
+
+        text f;
+        assign(f, path);
+        rewrite(f);
+        int err = ioresult();
+        if (err != 0) {
+            return false;
+        }
+        write(f, body);
+        err = ioresult();
+        if (err != 0) {
+            close(f);
+            ioresult();
+            return false;
+        }
+        close(f);
+        err = ioresult();
+        if (err != 0) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/lib/rea/json
+++ b/lib/rea/json
@@ -1,0 +1,179 @@
+module Json {
+
+    export bool isAvailable() {
+        return hasextbuiltin("yyjson", "YyjsonRead");
+    }
+
+    export int parse(str source) {
+        if (!isAvailable()) {
+            return -1;
+        }
+        return YyjsonRead(source);
+    }
+
+    export int parseFile(str path) {
+        if (!isAvailable()) {
+            return -1;
+        }
+        return YyjsonReadFile(path);
+    }
+
+    export void closeDocument(int doc) {
+        if (doc >= 0) {
+            YyjsonDocFree(doc);
+        }
+    }
+
+    export int root(int doc) {
+        if (doc < 0) {
+            return -1;
+        }
+        return YyjsonGetRoot(doc);
+    }
+
+    export void free(int valueHandle) {
+        if (valueHandle >= 0) {
+            YyjsonFreeValue(valueHandle);
+        }
+    }
+
+    export bool hasKey(int objectHandle, str key) {
+        if (objectHandle < 0) {
+            return false;
+        }
+        int handle = YyjsonGetKey(objectHandle, key);
+        if (handle >= 0) {
+            YyjsonFreeValue(handle);
+            return true;
+        }
+        return false;
+    }
+
+    export str getString(int objectHandle, str key, str fallback) {
+        if (objectHandle < 0) {
+            return fallback;
+        }
+        int handle = YyjsonGetKey(objectHandle, key);
+        if (handle < 0) {
+            return fallback;
+        }
+        str value = YyjsonGetString(handle);
+        YyjsonFreeValue(handle);
+        return value;
+    }
+
+    export int getInt(int objectHandle, str key, int fallback) {
+        if (objectHandle < 0) {
+            return fallback;
+        }
+        int handle = YyjsonGetKey(objectHandle, key);
+        if (handle < 0) {
+            return fallback;
+        }
+        int result = (int)YyjsonGetInt(handle);
+        YyjsonFreeValue(handle);
+        return result;
+    }
+
+    export float getNumber(int objectHandle, str key, float fallback) {
+        if (objectHandle < 0) {
+            return fallback;
+        }
+        int handle = YyjsonGetKey(objectHandle, key);
+        if (handle < 0) {
+            return fallback;
+        }
+        float result = YyjsonGetNumber(handle);
+        YyjsonFreeValue(handle);
+        return result;
+    }
+
+    export bool getBool(int objectHandle, str key, bool fallback) {
+        if (objectHandle < 0) {
+            return fallback;
+        }
+        int handle = YyjsonGetKey(objectHandle, key);
+        if (handle < 0) {
+            return fallback;
+        }
+        int value = YyjsonGetBool(handle);
+        YyjsonFreeValue(handle);
+        if (value != 0) {
+            return true;
+        }
+        return false;
+    }
+
+    export bool isNull(int objectHandle, str key) {
+        if (objectHandle < 0) {
+            return true;
+        }
+        int handle = YyjsonGetKey(objectHandle, key);
+        if (handle < 0) {
+            return true;
+        }
+        int result = YyjsonIsNull(handle);
+        YyjsonFreeValue(handle);
+        return result != 0;
+    }
+
+    export int arrayLength(int arrayHandle) {
+        if (arrayHandle < 0) {
+            return 0;
+        }
+        return YyjsonGetLength(arrayHandle);
+    }
+
+    export int arrayIndex(int arrayHandle, int index) {
+        if (arrayHandle < 0) {
+            return -1;
+        }
+        if (index < 0) {
+            return -1;
+        }
+        return YyjsonGetIndex(arrayHandle, index);
+    }
+
+    export str getStringAt(int arrayHandle, int index, str fallback) {
+        int handle = arrayIndex(arrayHandle, index);
+        if (handle < 0) {
+            return fallback;
+        }
+        str value = YyjsonGetString(handle);
+        YyjsonFreeValue(handle);
+        return value;
+    }
+
+    export int getIntAt(int arrayHandle, int index, int fallback) {
+        int handle = arrayIndex(arrayHandle, index);
+        if (handle < 0) {
+            return fallback;
+        }
+        int result = (int)YyjsonGetInt(handle);
+        YyjsonFreeValue(handle);
+        return result;
+    }
+
+    export float getNumberAt(int arrayHandle, int index, float fallback) {
+        int handle = arrayIndex(arrayHandle, index);
+        if (handle < 0) {
+            return fallback;
+        }
+        float result = YyjsonGetNumber(handle);
+        YyjsonFreeValue(handle);
+        return result;
+    }
+
+    export bool getBoolAt(int arrayHandle, int index, bool fallback) {
+        int handle = arrayIndex(arrayHandle, index);
+        if (handle < 0) {
+            return fallback;
+        }
+        int value = YyjsonGetBool(handle);
+        YyjsonFreeValue(handle);
+        if (value != 0) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/lib/rea/strings
+++ b/lib/rea/strings
@@ -1,0 +1,242 @@
+module Strings {
+
+    export bool contains(str haystack, str needle) {
+        if (needle == "") {
+            return true;
+        }
+        if (haystack == "") {
+            return false;
+        }
+        return pos(needle, haystack) > 0;
+    }
+
+    export bool startsWith(str value, str prefix) {
+        int prefixLen = length(prefix);
+        if (prefixLen == 0) {
+            return true;
+        }
+        if (length(value) < prefixLen) {
+            return false;
+        }
+        int i = 1;
+        while (i <= prefixLen) {
+            if (value[i] != prefix[i]) {
+                return false;
+            }
+            i = i + 1;
+        }
+        return true;
+    }
+
+    export bool endsWith(str value, str suffix) {
+        int suffixLen = length(suffix);
+        if (suffixLen == 0) {
+            return true;
+        }
+        int valueLen = length(value);
+        if (valueLen < suffixLen) {
+            return false;
+        }
+        int offset = valueLen - suffixLen;
+        int i = 1;
+        while (i <= suffixLen) {
+            if (value[offset + i] != suffix[i]) {
+                return false;
+            }
+            i = i + 1;
+        }
+        return true;
+    }
+
+    export str trimLeft(str value) {
+        int left = 1;
+        int len = length(value);
+        while (left <= len) {
+            char ch = value[left];
+            if (ch != ' ' && ch != '\t' && ch != '\n' && ch != '\r') {
+                break;
+            }
+            left = left + 1;
+        }
+        if (left > len) {
+            return "";
+        }
+        int newLen = len - left + 1;
+        str result;
+        setlength(result, newLen);
+        int i = 0;
+        while (i < newLen) {
+            result[i + 1] = value[left + i];
+            i = i + 1;
+        }
+        return result;
+    }
+
+    export str trimRight(str value) {
+        int right = length(value);
+        while (right >= 1) {
+            char ch = value[right];
+            if (ch != ' ' && ch != '\t' && ch != '\n' && ch != '\r') {
+                break;
+            }
+            right = right - 1;
+        }
+        if (right <= 0) {
+            return "";
+        }
+        str result;
+        setlength(result, right);
+        int i = 1;
+        while (i <= right) {
+            result[i] = value[i];
+            i = i + 1;
+        }
+        return result;
+    }
+
+    export str trim(str value) {
+        return trimRight(trimLeft(value));
+    }
+
+    char resolvePadChar(str padding) {
+        if (padding == "") {
+            return ' ';
+        }
+        return padding[1];
+    }
+
+    export str padLeft(str value, int width, str padding) {
+        int valueLen = length(value);
+        if (width <= valueLen) {
+            return value;
+        }
+        int padLen = width - valueLen;
+        char padChar = resolvePadChar(padding);
+        str result;
+        setlength(result, width);
+        int i = 1;
+        while (i <= padLen) {
+            result[i] = padChar;
+            i = i + 1;
+        }
+        int j = 1;
+        while (j <= valueLen) {
+            result[padLen + j] = value[j];
+            j = j + 1;
+        }
+        return result;
+    }
+
+    export str padRight(str value, int width, str padding) {
+        int valueLen = length(value);
+        if (width <= valueLen) {
+            return value;
+        }
+        int padLen = width - valueLen;
+        char padChar = resolvePadChar(padding);
+        str result;
+        setlength(result, width);
+        int i = 1;
+        while (i <= valueLen) {
+            result[i] = value[i];
+            i = i + 1;
+        }
+        int j = 1;
+        while (j <= padLen) {
+            result[valueLen + j] = padChar;
+            j = j + 1;
+        }
+        return result;
+    }
+
+    export str toUpper(str value) {
+        int len = length(value);
+        if (len == 0) {
+            return value;
+        }
+        str result;
+        setlength(result, len);
+        int i = 1;
+        while (i <= len) {
+            char ch = value[i];
+            int code = ord(ch);
+            if (code >= ord('a') && code <= ord('z')) {
+                code = code - 32;
+            }
+            result[i] = chr(code);
+            i = i + 1;
+        }
+        return result;
+    }
+
+    export str toLower(str value) {
+        int len = length(value);
+        if (len == 0) {
+            return value;
+        }
+        str result;
+        setlength(result, len);
+        int i = 1;
+        while (i <= len) {
+            char ch = value[i];
+            int code = ord(ch);
+            if (code >= ord('A') && code <= ord('Z')) {
+                code = code + 32;
+            }
+            result[i] = chr(code);
+            i = i + 1;
+        }
+        return result;
+    }
+
+    export str sortCharacters(str value) {
+        int len = length(value);
+        if (len <= 1) {
+            return value;
+        }
+        str result;
+        setlength(result, len);
+        int i = 1;
+        while (i <= len) {
+            result[i] = value[i];
+            i = i + 1;
+        }
+        int j = 1;
+        while (j <= len) {
+            int minIndex = j;
+            int k = j + 1;
+            while (k <= len) {
+                if (result[k] < result[minIndex]) {
+                    minIndex = k;
+                }
+                k = k + 1;
+            }
+            if (minIndex != j) {
+                char temp = result[j];
+                result[j] = result[minIndex];
+                result[minIndex] = temp;
+            }
+            j = j + 1;
+        }
+        return result;
+    }
+
+    export str repeat(str value, int count) {
+        if (count <= 0 || value == "") {
+            return "";
+        }
+        int valueLen = length(value);
+        str result;
+        setlength(result, valueLen * count);
+        int i = 0;
+        while (i < count) {
+            int j = 1;
+            while (j <= valueLen) {
+                result[i * valueLen + j] = value[j];
+                j = j + 1;
+            }
+            i = i + 1;
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary
- add a `strings` module with trimming, padding, case conversion, substring helpers, and repetition utilities
- add a `filesystem` module for whole-file I/O, path joining, and `~` expansion with status tracking helpers
- add a `json` module that wraps the optional yyjson built-ins with availability checks and defaulting accessors
- add an `http` module for one-shot requests, status tracking, and streaming downloads
- add a `datetime` module that formats Unix timestamps, computes day ranges, and summarizes durations, and document the new modules in the library README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d84bbacb9483299095056bbb076c8d