### PR TITLE
Fix install layout for library assets

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -103,16 +103,34 @@ else
 fi
 
 # Shared libraries and assets
-copy_dir_contents "$REPO_ROOT/lib/sounds" "$PS_PREFIX/lib/sounds" "sound library"
-copy_dir_contents "$REPO_ROOT/lib/pascal" "$PS_PREFIX/pascal/lib" "Pascal library"
-copy_dir_contents "$REPO_ROOT/lib/clike" "$PS_PREFIX/clike/lib" "C-like library"
-copy_dir_contents "$REPO_ROOT/lib/rea" "$PS_PREFIX/rea/lib" "Rea library"
+copy_dir_contents "$REPO_ROOT/lib" "$PS_PREFIX/lib" "library files"
 copy_dir_contents "$REPO_ROOT/lib/rea" "$PREFIX/lib/rea" "Rea import library"
-copy_dir_contents "$REPO_ROOT/lib/misc" "$PS_PREFIX/misc" "miscellaneous library"
 copy_dir_contents "$REPO_ROOT/fonts" "$PS_PREFIX/fonts" "fonts"
 copy_dir_contents "$REPO_ROOT/etc" "$PS_PREFIX/etc" "configuration files"
 copy_dir_contents "$REPO_ROOT/etc/tests" "$PS_PREFIX/etc/tests" "test configuration files"
-copy_dir_contents "$REPO_ROOT/lib/misc/simple_web_server/htdocs" "$PS_PREFIX/misc/htdocs" "web server htdocs"
+
+# Backwards compatibility shims for legacy layouts
+create_compat_link() {
+    target=$1
+    link=$2
+
+    if [ ! -e "$target" ] && [ ! -L "$target" ]; then
+        return
+    fi
+
+    if [ -e "$link" ] || [ -L "$link" ]; then
+        return
+    fi
+
+    parent_dir=$(dirname "$link")
+    mkdir -p "$parent_dir"
+    ln -s "$target" "$link"
+}
+
+create_compat_link "$PS_PREFIX/lib/pascal" "$PS_PREFIX/pascal/lib"
+create_compat_link "$PS_PREFIX/lib/clike" "$PS_PREFIX/clike/lib"
+create_compat_link "$PS_PREFIX/lib/rea" "$PS_PREFIX/rea/lib"
+create_compat_link "$PS_PREFIX/lib/misc" "$PS_PREFIX/misc"
 
 # Ensure expected binaries are executable when installed
 for bin in clike clike-repl dascal pascal pscalvm rea pscaljson2bc pscald; do


### PR DESCRIPTION
## Summary
- install the full library directory under the pscal prefix so language libraries are available
- add compatibility symlinks for legacy pascal, clike, rea, and misc layouts

## Testing
- Not run (shellcheck not available in environment)


------
https://chatgpt.com/codex/tasks/task_b_68d85ba04a58832989ac036349274fa4