### PR TITLE
Fix DateTime module self-references

### DIFF
--- a/lib/rea/datetime
+++ b/lib/rea/datetime
@@ -16,7 +16,7 @@ module DateTime {
         }
         int hours = absSeconds / 3600;
         int minutes = (absSeconds % 3600) / 60;
-        return sign + DateTime.pad2(hours) + ":" + DateTime.pad2(minutes);
+        return sign + pad2(hours) + ":" + pad2(minutes);
     }
 
     export str formatUnix(int epochSeconds, int offsetSeconds) {
@@ -53,8 +53,8 @@ module DateTime {
             year = year + 1;
         }
 
-        str date = inttostr(year) + "-" + DateTime.pad2(month) + "-" + DateTime.pad2(day);
-        str time = DateTime.pad2(hour) + ":" + DateTime.pad2(minute) + ":" + DateTime.pad2(second);
+        str date = inttostr(year) + "-" + pad2(month) + "-" + pad2(day);
+        str time = pad2(hour) + ":" + pad2(minute) + ":" + pad2(second);
         return date + " " + time;
     }
 
@@ -92,9 +92,9 @@ module DateTime {
             year = year + 1;
         }
 
-        str date = inttostr(year) + "-" + DateTime.pad2(month) + "-" + DateTime.pad2(day);
-        str time = DateTime.pad2(hour) + ":" + DateTime.pad2(minute) + ":" + DateTime.pad2(second);
-        return date + "T" + time + DateTime.formatUtcOffset(offsetSeconds);
+        str date = inttostr(year) + "-" + pad2(month) + "-" + pad2(day);
+        str time = pad2(hour) + ":" + pad2(minute) + ":" + pad2(second);
+        return date + "T" + time + formatUtcOffset(offsetSeconds);
     }
 
     export int startOfDay(int epochSeconds, int offsetSeconds) {
@@ -109,7 +109,7 @@ module DateTime {
     }
 
     export int endOfDay(int epochSeconds, int offsetSeconds) {
-        int start = DateTime.startOfDay(epochSeconds, offsetSeconds);
+        int start = startOfDay(epochSeconds, offsetSeconds);
         return start + 86399;
     }
 


### PR DESCRIPTION
## Summary
- remove redundant DateTime qualifier when calling helper functions inside the datetime module
- ensure functions reuse local exports directly to satisfy compiler expectations

## Testing
- python3 etc/tests/rea/run_tests.py *(fails: Rea executable not found. Build the project or set REA_BIN to a valid executable path.)*

------
https://chatgpt.com/codex/tasks/task_b_68d8828334048329b6a4352e3749e7e2