### PR TITLE
Fix DateTime module exports to include parameter metadata

### DIFF
--- a/lib/rea/datetime
+++ b/lib/rea/datetime
@@ -1,16 +1,5 @@
 module DateTime {
 
-    export str formatUtcOffset(int offsetSeconds);
-    export str formatUnix(int epochSeconds, int offsetSeconds);
-    export str iso8601(int epochSeconds, int offsetSeconds);
-    export int startOfDay(int epochSeconds, int offsetSeconds);
-    export int endOfDay(int epochSeconds, int offsetSeconds);
-    export int addDays(int epochSeconds, int days);
-    export int addHours(int epochSeconds, int hours);
-    export int addMinutes(int epochSeconds, int minutes);
-    export int daysBetween(int startEpoch, int endEpoch);
-    export str describeDifference(int startEpoch, int endEpoch);
-
     str pad2(int value) {
         if (value < 10 && value >= 0) {
             return "0" + inttostr(value);
@@ -18,7 +7,7 @@ module DateTime {
         return inttostr(value);
     }
 
-    str formatUtcOffset(int offsetSeconds) {
+    export str formatUtcOffset(int offsetSeconds) {
         int absSeconds = offsetSeconds;
         str sign = "+";
         if (absSeconds < 0) {
@@ -30,7 +19,7 @@ module DateTime {
         return sign + pad2(hours) + ":" + pad2(minutes);
     }
 
-    str formatUnix(int epochSeconds, int offsetSeconds) {
+    export str formatUnix(int epochSeconds, int offsetSeconds) {
         int total = epochSeconds + offsetSeconds;
         if (total < 0) {
             total = 0;
@@ -69,7 +58,7 @@ module DateTime {
         return date + " " + time;
     }
 
-    str iso8601(int epochSeconds, int offsetSeconds) {
+    export str iso8601(int epochSeconds, int offsetSeconds) {
         int total = epochSeconds + offsetSeconds;
         if (total < 0) {
             total = 0;
@@ -108,7 +97,7 @@ module DateTime {
         return date + "T" + time + formatUtcOffset(offsetSeconds);
     }
 
-    int startOfDay(int epochSeconds, int offsetSeconds) {
+    export int startOfDay(int epochSeconds, int offsetSeconds) {
         int total = epochSeconds + offsetSeconds;
         int days;
         if (total >= 0) {
@@ -119,24 +108,24 @@ module DateTime {
         return days * 86400 - offsetSeconds;
     }
 
-    int endOfDay(int epochSeconds, int offsetSeconds) {
+    export int endOfDay(int epochSeconds, int offsetSeconds) {
         int start = startOfDay(epochSeconds, offsetSeconds);
         return start + 86399;
     }
 
-    int addDays(int epochSeconds, int days) {
+    export int addDays(int epochSeconds, int days) {
         return epochSeconds + days * 86400;
     }
 
-    int addHours(int epochSeconds, int hours) {
+    export int addHours(int epochSeconds, int hours) {
         return epochSeconds + hours * 3600;
     }
 
-    int addMinutes(int epochSeconds, int minutes) {
+    export int addMinutes(int epochSeconds, int minutes) {
         return epochSeconds + minutes * 60;
     }
 
-    int daysBetween(int startEpoch, int endEpoch) {
+    export int daysBetween(int startEpoch, int endEpoch) {
         int diff = endEpoch - startEpoch;
         if (diff >= 0) {
             return diff / 86400;
@@ -145,7 +134,7 @@ module DateTime {
         return -((positive + 86399) / 86400);
     }
 
-    str describeDifference(int startEpoch, int endEpoch) {
+    export str describeDifference(int startEpoch, int endEpoch) {
         int diff = endEpoch - startEpoch;
         int sign = 1;
         if (diff < 0) {

--- a/lib/rea/datetime
+++ b/lib/rea/datetime
@@ -1,13 +1,24 @@
 module DateTime {
 
-    export str pad2(int value) {
+    export str formatUtcOffset(int offsetSeconds);
+    export str formatUnix(int epochSeconds, int offsetSeconds);
+    export str iso8601(int epochSeconds, int offsetSeconds);
+    export int startOfDay(int epochSeconds, int offsetSeconds);
+    export int endOfDay(int epochSeconds, int offsetSeconds);
+    export int addDays(int epochSeconds, int days);
+    export int addHours(int epochSeconds, int hours);
+    export int addMinutes(int epochSeconds, int minutes);
+    export int daysBetween(int startEpoch, int endEpoch);
+    export str describeDifference(int startEpoch, int endEpoch);
+
+    str pad2(int value) {
         if (value < 10 && value >= 0) {
             return "0" + inttostr(value);
         }
         return inttostr(value);
     }
 
-    export str formatUtcOffset(int offsetSeconds) {
+    str formatUtcOffset(int offsetSeconds) {
         int absSeconds = offsetSeconds;
         str sign = "+";
         if (absSeconds < 0) {
@@ -19,7 +30,7 @@ module DateTime {
         return sign + pad2(hours) + ":" + pad2(minutes);
     }
 
-    export str formatUnix(int epochSeconds, int offsetSeconds) {
+    str formatUnix(int epochSeconds, int offsetSeconds) {
         int total = epochSeconds + offsetSeconds;
         if (total < 0) {
             total = 0;
@@ -58,7 +69,7 @@ module DateTime {
         return date + " " + time;
     }
 
-    export str iso8601(int epochSeconds, int offsetSeconds) {
+    str iso8601(int epochSeconds, int offsetSeconds) {
         int total = epochSeconds + offsetSeconds;
         if (total < 0) {
             total = 0;
@@ -97,7 +108,7 @@ module DateTime {
         return date + "T" + time + formatUtcOffset(offsetSeconds);
     }
 
-    export int startOfDay(int epochSeconds, int offsetSeconds) {
+    int startOfDay(int epochSeconds, int offsetSeconds) {
         int total = epochSeconds + offsetSeconds;
         int days;
         if (total >= 0) {
@@ -108,24 +119,24 @@ module DateTime {
         return days * 86400 - offsetSeconds;
     }
 
-    export int endOfDay(int epochSeconds, int offsetSeconds) {
+    int endOfDay(int epochSeconds, int offsetSeconds) {
         int start = startOfDay(epochSeconds, offsetSeconds);
         return start + 86399;
     }
 
-    export int addDays(int epochSeconds, int days) {
+    int addDays(int epochSeconds, int days) {
         return epochSeconds + days * 86400;
     }
 
-    export int addHours(int epochSeconds, int hours) {
+    int addHours(int epochSeconds, int hours) {
         return epochSeconds + hours * 3600;
     }
 
-    export int addMinutes(int epochSeconds, int minutes) {
+    int addMinutes(int epochSeconds, int minutes) {
         return epochSeconds + minutes * 60;
     }
 
-    export int daysBetween(int startEpoch, int endEpoch) {
+    int daysBetween(int startEpoch, int endEpoch) {
         int diff = endEpoch - startEpoch;
         if (diff >= 0) {
             return diff / 86400;
@@ -134,7 +145,7 @@ module DateTime {
         return -((positive + 86399) / 86400);
     }
 
-    export str describeDifference(int startEpoch, int endEpoch) {
+    str describeDifference(int startEpoch, int endEpoch) {
         int diff = endEpoch - startEpoch;
         int sign = 1;
         if (diff < 0) {


### PR DESCRIPTION
## Summary
- add explicit export declarations for the DateTime module API
- keep the pad2 helper internal while leaving function definitions unchanged

## Testing
- not run (rea executable unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68d8858fa69c83298bfaa68db0861a74