### PR TITLE
Fix REA module resolution and JSON int handling

### DIFF
--- a/lib/rea/json
+++ b/lib/rea/json
@@ -70,7 +70,7 @@ module Json {
         if (handle < 0) {
             return fallback;
         }
-        int result = (int)YyjsonGetInt(handle);
+        int result = YyjsonGetInt(handle);
         YyjsonFreeValue(handle);
         return result;
     }
@@ -149,7 +149,7 @@ module Json {
         if (handle < 0) {
             return fallback;
         }
-        int result = (int)YyjsonGetInt(handle);
+        int result = YyjsonGetInt(handle);
         YyjsonFreeValue(handle);
         return result;
     }

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -3747,6 +3747,10 @@ Value vmBuiltinLength(VM* vm, int arg_count, Value* args) {
         return makeInt(args[0].s_val ? (long long)strlen(args[0].s_val) : 0);
     }
 
+    if (args[0].type == TYPE_CHAR) {
+        return makeInt(1);
+    }
+
     if (args[0].type == TYPE_ARRAY) {
         long long len = 0;
         if (args[0].dimensions > 0 && args[0].upper_bounds && args[0].lower_bounds) {


### PR DESCRIPTION
## Summary
- keep track of the current module name so exported functions resolve with fully-qualified symbols and infer string results when concatenating with chars
- allow the VM length builtin to report a length of 1 for TYPE_CHAR values
- remove invalid casts in Json.getInt helpers so they return numeric fallbacks instead of nil

## Testing
- build/bin/rea etc/tests/rea/library_tests.rea


------
https://chatgpt.com/codex/tasks/task_b_68d89baf22b883298e14c158770243a7