### PR TITLE
Restore CRT text color after tests

### DIFF
--- a/etc/tests/rea/library_tests.rea
+++ b/etc/tests/rea/library_tests.rea
@@ -87,6 +87,7 @@ void assertFloatNear(str name, float expected, float actual, float tolerance) {
 void testCRT() {
     writeln();
     writeln("-- CRT --");
+    int originalAttr = CRT.TextAttr;
     assertEqualInt("CRT.Black", 0, CRT.Black);
     assertEqualInt("CRT.Blue", 1, CRT.Blue);
     assertEqualInt("CRT.Green", 2, CRT.Green);
@@ -108,6 +109,11 @@ void testCRT() {
     CRT.TextAttr = CRT.Green;
     assertEqualInt("CRT.TextAttr assignment", CRT.Green, CRT.TextAttr);
     CRT.TextAttr = 0;
+    if (originalAttr == CRT.Black) {
+        CRT.TextAttr = CRT.LightGray;
+    } else {
+        CRT.TextAttr = originalAttr;
+    }
 }
 
 void testStrings() {


### PR DESCRIPTION
## Summary
- capture the original CRT text attribute at the start of the test suite
- ensure the test restores a readable text color instead of leaving the console black

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d8a7223e4483298753874ca3d36b2a