### PR TITLE
Fix CRT TextAttr default and REA test mod issue

### DIFF
--- a/etc/tests/rea/library_tests.rea
+++ b/etc/tests/rea/library_tests.rea
@@ -91,6 +91,20 @@ str charToString(char value) {
     return result;
 }
 
+int safeDivInt(int numerator, int denominator) {
+    if (denominator == 0) {
+        return 0;
+    }
+    float numeratorFloat = numerator * 1.0;
+    float denominatorFloat = denominator * 1.0;
+    float quotient = numeratorFloat / denominatorFloat;
+    int truncated = int(quotient);
+    if (quotient < 0 && quotient != truncated) {
+        return truncated - 1;
+    }
+    return truncated;
+}
+
 int mapPscalColorToAnsiBase(int color) {
     int normalized = color % 8;
     if (normalized < 0) {
@@ -113,11 +127,11 @@ str buildAnsiSequenceForAttr(int attr) {
     }
     bool isBright = fg >= 8;
     int fgBase = fg % 8;
-    int bg = (attr / 16) % 8;
+    int bg = safeDivInt(attr, 16) % 8;
     if (bg < 0) {
         bg = bg + 8;
     }
-    bool isBlink = (attr / 128) % 2 == 1;
+    bool isBlink = safeDivInt(attr, 128) % 2 == 1;
 
     int fgCode = (isBright ? 90 : 30) + mapPscalColorToAnsiBase(fgBase);
     int bgCode = 40 + mapPscalColorToAnsiBase(bg);
@@ -163,7 +177,7 @@ void testCRT() {
     assertEqualInt("CRT.Yellow", 14, CRT.Yellow);
     assertEqualInt("CRT.White", 15, CRT.White);
     assertEqualInt("CRT.Blink", 128, CRT.Blink);
-    assertEqualInt("CRT.TextAttr default", 0, CRT.TextAttr);
+    assertEqualInt("CRT.TextAttr default", CRT.LightGray, CRT.TextAttr);
     CRT.TextAttr = CRT.Green;
     assertEqualInt("CRT.TextAttr assignment", CRT.Green, CRT.TextAttr);
     CRT.TextAttr = 0;

--- a/lib/rea/crt
+++ b/lib/rea/crt
@@ -17,5 +17,5 @@ module CRT {
   export const int White = 15;
   export const int Blink = 128;
 
-  export int TextAttr = 0;
+  export int TextAttr = LightGray;
 }

--- a/src/Pascal/globals.c
+++ b/src/Pascal/globals.c
@@ -46,6 +46,7 @@ bool gCurrentTextUnderline = false;   // Default underline state.
 bool gCurrentTextBlink     = false;   // Default blink state.
 bool gConsoleAttrDirty     = false;   // Start with host terminal colors.
 bool gConsoleAttrDirtyFromReset = false; // Track resets that need a reapply of custom colors.
+bool gTextAttrInitialized  = false;   // Tracks if CRT.TextAttr has been explicitly set.
 int gWindowLeft            = 1;
 int gWindowTop             = 1;
 int gWindowRight           = 80;

--- a/src/Pascal/globals.h
+++ b/src/Pascal/globals.h
@@ -57,6 +57,7 @@ extern bool gCurrentTextUnderline;
 extern bool gCurrentTextBlink;
 extern bool gConsoleAttrDirty;
 extern bool gConsoleAttrDirtyFromReset;
+extern bool gTextAttrInitialized;
 extern int gWindowLeft;
 extern int gWindowTop;
 extern int gWindowRight;

--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -2431,6 +2431,7 @@ void setCurrentTextAttrFromByte(uint8_t attr) {
     gCurrentTextBackground = bg;
     gCurrentBgIsExt = false;
     gCurrentTextBlink = blink;
+    gTextAttrInitialized = true;
 
     markTextAttrDirty();
     syncTextAttrSymbol();

--- a/src/symbol/symbol.c
+++ b/src/symbol/symbol.c
@@ -824,6 +824,28 @@ void updateSymbol(const char *name, Value val) {
     // --- End Type Compatibility Check ---
 
 
+    bool isTextAttrSymbol = false;
+    if (sym->name) {
+        if (strcasecmp(sym->name, "crt.textattr") == 0) {
+            isTextAttrSymbol = true;
+        }
+    }
+    if (!isTextAttrSymbol && name) {
+        if (strcasecmp(name, "crt.textattr") == 0) {
+            isTextAttrSymbol = true;
+        }
+    }
+    if (isTextAttrSymbol && !gTextAttrInitialized) {
+        gTextAttrInitialized = true;
+        if (isIntlikeType(val.type) && asI64(val) == 0) {
+            freeValue(sym->value);
+            SET_INT_VALUE(sym->value, 7);
+            setCurrentTextAttrFromByte(7);
+            freeValue(&val);
+            return;
+        }
+    }
+
     // --- Free Old Value Contents (if necessary) ---
     // **CRITICAL EXCEPTION**: Do NOT free the buffer for a fixed-length string,
     // as we are about to write into it. For all other types, freeing the
@@ -987,7 +1009,7 @@ void updateSymbol(const char *name, Value val) {
             break;
     }
 
-    if (sym->name && strcmp(sym->name, "textattr") == 0) {
+    if (isTextAttrSymbol) {
         uint8_t attr_byte = (uint8_t)(sym->value->i_val & 0xFF);
         setCurrentTextAttrFromByte(attr_byte);
     }

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1362,6 +1362,9 @@ static Symbol* createSymbolForVM(const char* name, VarType type, AST* type_def_f
 
     // Call makeValueForType with the (now potentially non-NULL) type_def_for_value_init
     *(sym->value) = makeValueForType(type, type_def_for_value_init, sym);
+    if (sym->name && strcmp(sym->name, "textattr") == 0) {
+        SET_INT_VALUE(sym->value, 7);
+    }
     // (debug logging removed)
 
     sym->is_alias = false;
@@ -3452,6 +3455,15 @@ comparison_error_label:
                 if (!sym || !sym->value) {
                     runtimeError(vm, "Runtime Error: Undefined global variable '%s'.", name_val->s_val);
                     return INTERPRET_RUNTIME_ERROR;
+                }
+
+                if (!gTextAttrInitialized && name_val->s_val &&
+                    (strcasecmp(name_val->s_val, "CRT.TextAttr") == 0 ||
+                     strcasecmp(name_val->s_val, "TextAttr") == 0 ||
+                     strcasecmp(name_val->s_val, "crt.textattr") == 0 ||
+                     strcasecmp(name_val->s_val, "textattr") == 0)) {
+                    gTextAttrInitialized = true;
+                    SET_INT_VALUE(sym->value, 7);
                 }
 
                 push(vm, copyValueForStack(sym->value));


### PR DESCRIPTION
## Summary
- fix REA library tests so integer division for ANSI attribute decoding uses a helper that preserves integer semantics
- default `CRT.TextAttr` to LightGray and ensure runtime state synchronizes TextAttr before first access via new initialization tracking
- update runtime to prevent the first TextAttr read or module initialization from forcing the value back to black

## Testing
- build/bin/rea etc/tests/rea/library_tests.rea

------
https://chatgpt.com/codex/tasks/task_b_68d8bb8af880832994606895e34e4547