### PR TITLE
Normalize console color at start of library tests

### DIFF
--- a/etc/tests/rea/library_tests.rea
+++ b/etc/tests/rea/library_tests.rea
@@ -476,6 +476,15 @@ void testHttp() {
 }
 
 int main() {
+    int startingAttr = CRT.TextAttr;
+    bool changedStartingAttr = startingAttr != CRT.LightGray;
+    if (changedStartingAttr) {
+        CRT.TextAttr = CRT.LightGray;
+        applyTextAttrToTerminal(CRT.LightGray);
+    } else {
+        applyTextAttrToTerminal(startingAttr);
+    }
+
     writeln("Rea standard library test suite");
     testCRT();
     testStrings();
@@ -487,10 +496,18 @@ int main() {
     writeln("TOTAL ", executedTests);
     writeln("FAILED ", failedTests);
     writeln("SKIPPED ", skippedTests);
+    int exitCode = 0;
     if (failedTests == 0) {
         writeln("OVERALL PASS");
-        return 0;
+    } else {
+        writeln("OVERALL FAIL");
+        exitCode = 1;
     }
-    writeln("OVERALL FAIL");
-    return 1;
+
+    if (changedStartingAttr) {
+        CRT.TextAttr = startingAttr;
+        applyTextAttrToTerminal(startingAttr);
+    }
+
+    return exitCode;
 }


### PR DESCRIPTION
## Summary
- ensure the Rea library test runner sets the console text attribute to light gray when it begins
- restore the console text attribute to its original value after reporting results

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d9325a37288329bfeb0a82bc5faf0c