### PR TITLE
Add CLike equivalents for Rea standard library modules

### DIFF
--- a/lib/clike/README.md
+++ b/lib/clike/README.md
@@ -1,0 +1,29 @@
+# CLike Standard Library
+
+This directory provides reusable helper modules for the CLike front end. The
+files mirror the modules that ship with the Rea standard library so that mixed
+projects can share similar utility helpers regardless of the front end in use.
+
+The helpers are plain `.cl` modules that can be imported with `import`. The
+following modules are available:
+
+* `crt.cl` – legacy Turbo Pascal style color constants and the mutable
+  `CRT_TextAttr` value for applications that emulate text consoles.
+* `strings.cl` – substring checks, trimming, padding, casing, repetition, and a
+  simple character sorter implemented with only core string primitives.
+* `filesystem.cl` – helpers for reading and writing whole files, joining paths,
+  expanding `~`, and retrieving the first line from a file while tracking the
+  last read/write status codes.
+* `json.cl` – thin wrappers around the optional `yyjson` extended built-ins that
+  gate usage on availability, default lookups, and automatically free temporary
+  handles.
+* `http.cl` – small wrappers around the synchronous HTTP built-ins for common
+  GET/POST/PUT requests, tracking the last response status, and downloading
+  responses to disk.
+* `datetime.cl` – utilities for formatting Unix timestamps, computing day
+  boundaries, performing simple arithmetic, and rendering human-friendly
+  duration descriptions.
+
+Each module is self-contained and relies only on core VM built-ins, so they can
+be copied into standalone projects or accessed through `CLIKE_LIB_DIR` once
+installed with `install.sh`.

--- a/lib/clike/crt.cl
+++ b/lib/clike/crt.cl
@@ -1,0 +1,21 @@
+// CLike equivalent of the Rea CRT module.
+
+const int CRT_BLACK = 0;
+const int CRT_BLUE = 1;
+const int CRT_GREEN = 2;
+const int CRT_CYAN = 3;
+const int CRT_RED = 4;
+const int CRT_MAGENTA = 5;
+const int CRT_BROWN = 6;
+const int CRT_LIGHT_GRAY = 7;
+const int CRT_DARK_GRAY = 8;
+const int CRT_LIGHT_BLUE = 9;
+const int CRT_LIGHT_GREEN = 10;
+const int CRT_LIGHT_CYAN = 11;
+const int CRT_LIGHT_RED = 12;
+const int CRT_LIGHT_MAGENTA = 13;
+const int CRT_YELLOW = 14;
+const int CRT_WHITE = 15;
+const int CRT_BLINK = 128;
+
+int CRT_TextAttr = CRT_LIGHT_GRAY;

--- a/lib/clike/datetime.cl
+++ b/lib/clike/datetime.cl
@@ -1,0 +1,186 @@
+// Date/time helpers mirroring lib/rea/datetime.
+
+str datetime_pad2(int value) {
+    if (value < 10 && value >= 0) {
+        return "0" + inttostr(value);
+    }
+    return inttostr(value);
+}
+
+int datetime_divInt(int numerator, int denominator) {
+    if (denominator == 0) {
+        return 0;
+    }
+    float n = numerator * 1.0;
+    float d = denominator * 1.0;
+    float q = n / d;
+    int truncated = toint(q);
+    if (q < 0.0 && q != truncated) {
+        return truncated - 1;
+    }
+    return truncated;
+}
+
+str datetime_formatUtcOffset(int offsetSeconds) {
+    int absSeconds = offsetSeconds;
+    str sign = "+";
+    if (absSeconds < 0) {
+        sign = "-";
+        absSeconds = -absSeconds;
+    }
+    int hours = datetime_divInt(absSeconds, 3600);
+    int minutes = datetime_divInt(absSeconds % 3600, 60);
+    return sign + datetime_pad2(hours) + ":" + datetime_pad2(minutes);
+}
+
+str datetime_formatUnix(int epochSeconds, int offsetSeconds) {
+    int total = epochSeconds + offsetSeconds;
+    if (total < 0) {
+        total = 0;
+    }
+    int days = datetime_divInt(total, 86400);
+    int secondsOfDay = total % 86400;
+    int hour = datetime_divInt(secondsOfDay, 3600);
+    int minute = datetime_divInt(secondsOfDay % 3600, 60);
+    int second = secondsOfDay % 60;
+
+    int z = days + 719468;
+    int era;
+    if (z >= 0) {
+        era = datetime_divInt(z, 146097);
+    } else {
+        era = datetime_divInt(z - 146096, 146097);
+    }
+    int doe = z - era * 146097;
+    int yoe = datetime_divInt(doe - datetime_divInt(doe, 1460) + datetime_divInt(doe, 36524) - datetime_divInt(doe, 146096), 365);
+    int year = yoe + era * 400;
+    int doy = doe - (365 * yoe + datetime_divInt(yoe, 4) - datetime_divInt(yoe, 100));
+    int mp = datetime_divInt(5 * doy + 2, 153);
+    int day = doy - datetime_divInt(153 * mp + 2, 5) + 1;
+    int month;
+    if (mp < 10) {
+        month = mp + 3;
+    } else {
+        month = mp - 9;
+    }
+    if (month <= 2) {
+        year = year + 1;
+    }
+
+    str date = inttostr(year) + "-" + datetime_pad2(month) + "-" + datetime_pad2(day);
+    str time = datetime_pad2(hour) + ":" + datetime_pad2(minute) + ":" + datetime_pad2(second);
+    return date + " " + time;
+}
+
+str datetime_iso8601(int epochSeconds, int offsetSeconds) {
+    int total = epochSeconds + offsetSeconds;
+    if (total < 0) {
+        total = 0;
+    }
+    int days = datetime_divInt(total, 86400);
+    int secondsOfDay = total % 86400;
+    int hour = datetime_divInt(secondsOfDay, 3600);
+    int minute = datetime_divInt(secondsOfDay % 3600, 60);
+    int second = secondsOfDay % 60;
+
+    int z = days + 719468;
+    int era;
+    if (z >= 0) {
+        era = datetime_divInt(z, 146097);
+    } else {
+        era = datetime_divInt(z - 146096, 146097);
+    }
+    int doe = z - era * 146097;
+    int yoe = datetime_divInt(doe - datetime_divInt(doe, 1460) + datetime_divInt(doe, 36524) - datetime_divInt(doe, 146096), 365);
+    int year = yoe + era * 400;
+    int doy = doe - (365 * yoe + datetime_divInt(yoe, 4) - datetime_divInt(yoe, 100));
+    int mp = datetime_divInt(5 * doy + 2, 153);
+    int day = doy - datetime_divInt(153 * mp + 2, 5) + 1;
+    int month;
+    if (mp < 10) {
+        month = mp + 3;
+    } else {
+        month = mp - 9;
+    }
+    if (month <= 2) {
+        year = year + 1;
+    }
+
+    str date = inttostr(year) + "-" + datetime_pad2(month) + "-" + datetime_pad2(day);
+    str time = datetime_pad2(hour) + ":" + datetime_pad2(minute) + ":" + datetime_pad2(second);
+    return date + "T" + time + datetime_formatUtcOffset(offsetSeconds);
+}
+
+int datetime_startOfDay(int epochSeconds, int offsetSeconds) {
+    int total = epochSeconds + offsetSeconds;
+    int days = datetime_divInt(total, 86400);
+    return days * 86400 - offsetSeconds;
+}
+
+int datetime_endOfDay(int epochSeconds, int offsetSeconds) {
+    int start = datetime_startOfDay(epochSeconds, offsetSeconds);
+    return start + 86399;
+}
+
+int datetime_addDays(int epochSeconds, int days) {
+    return epochSeconds + days * 86400;
+}
+
+int datetime_addHours(int epochSeconds, int hours) {
+    return epochSeconds + hours * 3600;
+}
+
+int datetime_addMinutes(int epochSeconds, int minutes) {
+    return epochSeconds + minutes * 60;
+}
+
+int datetime_daysBetween(int startEpoch, int endEpoch) {
+    int diff = endEpoch - startEpoch;
+    if (diff >= 0) {
+        return datetime_divInt(diff, 86400);
+    }
+    int positive = -diff;
+    return -datetime_divInt(positive + 86399, 86400);
+}
+
+str datetime_describeDifference(int startEpoch, int endEpoch) {
+    int diff = endEpoch - startEpoch;
+    int sign = 1;
+    if (diff < 0) {
+        sign = -1;
+        diff = -diff;
+    }
+    int days = datetime_divInt(diff, 86400);
+    int remainder = diff % 86400;
+    int hours = datetime_divInt(remainder, 3600);
+    remainder = remainder % 3600;
+    int minutes = datetime_divInt(remainder, 60);
+    int seconds = remainder % 60;
+
+    str buffer = "";
+    if (days > 0) {
+        buffer = buffer + inttostr(days) + "d";
+    }
+    if (hours > 0 || (days > 0 && (minutes > 0 || seconds > 0))) {
+        if (length(buffer) > 0) {
+            buffer = buffer + " ";
+        }
+        buffer = buffer + inttostr(hours) + "h";
+    }
+    if (minutes > 0 || (length(buffer) > 0 && seconds > 0)) {
+        if (length(buffer) > 0) {
+            buffer = buffer + " ";
+        }
+        buffer = buffer + inttostr(minutes) + "m";
+    }
+    if (seconds > 0 || length(buffer) == 0) {
+        if (length(buffer) > 0) {
+            buffer = buffer + " ";
+        }
+        buffer = buffer + inttostr(seconds) + "s";
+    }
+    if (sign < 0) {
+        buffer = "-" + buffer;
+    }
+    return buffer;
+}

--- a/lib/clike/filesystem.cl
+++ b/lib/clike/filesystem.cl
@@ -1,0 +1,209 @@
+// Filesystem helpers modeled after lib/rea/filesystem.
+
+int FS_LastReadOk = 0;
+int FS_LastReadError = 0;
+int FS_LastWriteError = 0;
+
+void filesystem_markReadFailure(int code) {
+    FS_LastReadOk = 0;
+    FS_LastReadError = code;
+}
+
+void filesystem_markReadSuccess() {
+    FS_LastReadOk = 1;
+    FS_LastReadError = 0;
+}
+
+int filesystem_lastReadSucceeded() {
+    return FS_LastReadOk;
+}
+
+int filesystem_lastReadErrorCode() {
+    return FS_LastReadError;
+}
+
+int filesystem_lastWriteErrorCode() {
+    return FS_LastWriteError;
+}
+
+str filesystem_readAllText(str path) {
+    str contents = "";
+    text f;
+    int firstLine = 1;
+
+    assign(f, path);
+    reset(f);
+    int err = ioresult();
+    if (err != 0) {
+        filesystem_markReadFailure(err);
+        return "";
+    }
+
+    while (!eof(f)) {
+        str line;
+        readln(f, line);
+        if (firstLine) {
+            contents = line;
+            firstLine = 0;
+        } else {
+            contents = contents + "\n" + line;
+        }
+    }
+
+    close(f);
+    err = ioresult();
+    if (err != 0) {
+        filesystem_markReadFailure(err);
+        return contents;
+    }
+
+    filesystem_markReadSuccess();
+    return contents;
+}
+
+int filesystem_writeAllText(str path, str contents) {
+    text f;
+
+    assign(f, path);
+    rewrite(f);
+    int err = ioresult();
+    if (err != 0) {
+        FS_LastWriteError = err;
+        return 0;
+    }
+
+    write(f, contents);
+    err = ioresult();
+    if (err != 0) {
+        FS_LastWriteError = err;
+        close(f);
+        ioresult();
+        return 0;
+    }
+
+    close(f);
+    err = ioresult();
+    if (err != 0) {
+        FS_LastWriteError = err;
+        return 0;
+    }
+
+    FS_LastWriteError = 0;
+    return 1;
+}
+
+str filesystem_joinPath(str left, str right) {
+    if (length(left) == 0) {
+        return right;
+    }
+    if (length(right) == 0) {
+        return left;
+    }
+
+    int leftEndsSlash = 0;
+    str lastChar = copy(left, length(left), 1);
+    if (lastChar == "/" || lastChar == "\\") {
+        leftEndsSlash = 1;
+    }
+
+    int rightStartsSlash = 0;
+    str firstChar = copy(right, 1, 1);
+    if (firstChar == "/" || firstChar == "\\") {
+        rightStartsSlash = 1;
+    }
+
+    if (leftEndsSlash && rightStartsSlash) {
+        int rightLen = length(right);
+        if (rightLen <= 1) {
+            return left;
+        }
+        return left + copy(right, 2, rightLen - 1);
+    }
+
+    if (!leftEndsSlash && !rightStartsSlash) {
+        return left + "/" + right;
+    }
+
+    return left + right;
+}
+
+str filesystem_expandUser(str path) {
+    if (length(path) == 0) {
+        return path;
+    }
+    if (path[1] != '~') {
+        return path;
+    }
+
+    str home = getenv("HOME");
+    if (length(home) == 0) {
+        home = getenv("USERPROFILE");
+    }
+    if (length(home) == 0) {
+        return path;
+    }
+
+    int pathLen = length(path);
+    if (pathLen == 1) {
+        return home;
+    }
+
+    str next = copy(path, 2, 1);
+    if (next != "/" && next != "\\") {
+        return path;
+    }
+
+    int homeEndsSlash = 0;
+    str homeLast = copy(home, length(home), 1);
+    if (homeLast == "/" || homeLast == "\\") {
+        homeEndsSlash = 1;
+    }
+
+    int remainderLen = pathLen - 1;
+    str remainder = copy(path, 2, remainderLen);
+
+    if (homeEndsSlash) {
+        if (remainderLen == 0) {
+            return home;
+        }
+        if (remainder[1] == '/' || remainder[1] == '\\') {
+            if (remainderLen <= 1) {
+                return home;
+            }
+            return home + copy(remainder, 2, remainderLen - 1);
+        }
+        return home + remainder;
+    }
+
+    if (remainderLen == 0) {
+        return home;
+    }
+
+    if (remainder[1] == '/' || remainder[1] == '\\') {
+        if (remainderLen <= 1) {
+            return home;
+        }
+        return home + copy(remainder, 2, remainderLen - 1);
+    }
+
+    return home + "/" + remainder;
+}
+
+str filesystem_readFirstLine(str path) {
+    str contents = filesystem_readAllText(path);
+    if (!filesystem_lastReadSucceeded()) {
+        return "";
+    }
+    int len = length(contents);
+    int i = 1;
+    while (i <= len) {
+        if (contents[i] == '\n' || contents[i] == '\r') {
+            if (i <= 1) {
+                return "";
+            }
+            return copy(contents, 1, i - 1);
+        }
+        i = i + 1;
+    }
+    return contents;
+}

--- a/lib/clike/http.cl
+++ b/lib/clike/http.cl
@@ -1,0 +1,117 @@
+// HTTP helpers matching lib/rea/http.
+
+int HTTP_LastStatus = 0;
+
+void http_resetStatus(int status) {
+    HTTP_LastStatus = status;
+}
+
+str http_requestWithBody(str method, str url, int hasBody, str body, str contentType, str accept) {
+    mstream out;
+    out = mstreamcreate();
+    str response = "";
+    int session = httpsession();
+    if (session < 0) {
+        http_resetStatus(-1);
+        mstreamfree(&out);
+        return response;
+    }
+
+    if (length(contentType) > 0) {
+        httpsetheader(session, "Content-Type", contentType);
+    }
+    if (length(accept) > 0) {
+        httpsetheader(session, "Accept", accept);
+    }
+
+    int status;
+    if (hasBody) {
+        status = httprequest(session, method, url, body, out);
+    } else {
+        status = httprequest(session, method, url, NULL, out);
+    }
+    http_resetStatus(status);
+
+    if (status >= 0) {
+        response = mstreambuffer(out);
+    }
+
+    httpclose(session);
+    mstreamfree(&out);
+    return response;
+}
+
+int http_lastResponseStatus() {
+    return HTTP_LastStatus;
+}
+
+str http_get(str url) {
+    return http_requestWithBody("GET", url, 0, "", "", "");
+}
+
+str http_getJson(str url) {
+    return http_requestWithBody("GET", url, 0, "", "", "application/json");
+}
+
+str http_post(str url, str body, str contentType) {
+    return http_requestWithBody("POST", url, 1, body, contentType, "");
+}
+
+str http_postJson(str url, str body) {
+    return http_requestWithBody("POST", url, 1, body, "application/json", "application/json");
+}
+
+str http_put(str url, str body, str contentType) {
+    return http_requestWithBody("PUT", url, 1, body, contentType, "");
+}
+
+int http_wasSuccessful() {
+    if (HTTP_LastStatus >= 200 && HTTP_LastStatus < 300) {
+        return 1;
+    }
+    return 0;
+}
+
+int http_downloadToFile(str url, str path) {
+    mstream out;
+    out = mstreamcreate();
+    int session = httpsession();
+    if (session < 0) {
+        http_resetStatus(-1);
+        mstreamfree(&out);
+        return 0;
+    }
+
+    int status = httprequest(session, "GET", url, NULL, out);
+    http_resetStatus(status);
+    if (status < 0) {
+        httpclose(session);
+        mstreamfree(&out);
+        return 0;
+    }
+
+    str body = mstreambuffer(out);
+    httpclose(session);
+    mstreamfree(&out);
+
+    text f;
+    assign(f, path);
+    rewrite(f);
+    int err = ioresult();
+    if (err != 0) {
+        return 0;
+    }
+    write(f, body);
+    err = ioresult();
+    if (err != 0) {
+        close(f);
+        ioresult();
+        return 0;
+    }
+    close(f);
+    err = ioresult();
+    if (err != 0) {
+        return 0;
+    }
+    return 1;
+}

--- a/lib/clike/json.cl
+++ b/lib/clike/json.cl
@@ -1,0 +1,172 @@
+// JSON helpers wrapping yyjson built-ins similar to lib/rea/json.
+
+int json_isAvailable() {
+    return hasextbuiltin("yyjson", "YyjsonRead") ? 1 : 0;
+}
+
+int json_parse(str source) {
+    if (!json_isAvailable()) {
+        return -1;
+    }
+    return YyjsonRead(source);
+}
+
+int json_parseFile(str path) {
+    if (!json_isAvailable()) {
+        return -1;
+    }
+    return YyjsonReadFile(path);
+}
+
+void json_closeDocument(int doc) {
+    if (doc >= 0) {
+        YyjsonDocFree(doc);
+    }
+}
+
+int json_root(int doc) {
+    if (doc < 0) {
+        return -1;
+    }
+    return YyjsonGetRoot(doc);
+}
+
+void json_free(int valueHandle) {
+    if (valueHandle >= 0) {
+        YyjsonFreeValue(valueHandle);
+    }
+}
+
+int json_hasKey(int objectHandle, str key) {
+    if (objectHandle < 0) {
+        return 0;
+    }
+    int handle = YyjsonGetKey(objectHandle, key);
+    if (handle >= 0) {
+        YyjsonFreeValue(handle);
+        return 1;
+    }
+    return 0;
+}
+
+str json_getString(int objectHandle, str key, str fallback) {
+    if (objectHandle < 0) {
+        return fallback;
+    }
+    int handle = YyjsonGetKey(objectHandle, key);
+    if (handle < 0) {
+        return fallback;
+    }
+    str value = YyjsonGetString(handle);
+    YyjsonFreeValue(handle);
+    return value;
+}
+
+int json_getInt(int objectHandle, str key, int fallback) {
+    if (objectHandle < 0) {
+        return fallback;
+    }
+    int handle = YyjsonGetKey(objectHandle, key);
+    if (handle < 0) {
+        return fallback;
+    }
+    int result = (int)YyjsonGetInt(handle);
+    YyjsonFreeValue(handle);
+    return result;
+}
+
+float json_getNumber(int objectHandle, str key, float fallback) {
+    if (objectHandle < 0) {
+        return fallback;
+    }
+    int handle = YyjsonGetKey(objectHandle, key);
+    if (handle < 0) {
+        return fallback;
+    }
+    float result = (float)YyjsonGetNumber(handle);
+    YyjsonFreeValue(handle);
+    return result;
+}
+
+int json_getBool(int objectHandle, str key, int fallback) {
+    if (objectHandle < 0) {
+        return fallback;
+    }
+    int handle = YyjsonGetKey(objectHandle, key);
+    if (handle < 0) {
+        return fallback;
+    }
+    int value = YyjsonGetBool(handle);
+    YyjsonFreeValue(handle);
+    return value != 0 ? 1 : 0;
+}
+
+int json_isNull(int objectHandle, str key) {
+    if (objectHandle < 0) {
+        return 1;
+    }
+    int handle = YyjsonGetKey(objectHandle, key);
+    if (handle < 0) {
+        return 1;
+    }
+    int result = YyjsonIsNull(handle);
+    YyjsonFreeValue(handle);
+    return result != 0 ? 1 : 0;
+}
+
+int json_arrayLength(int arrayHandle) {
+    if (arrayHandle < 0) {
+        return 0;
+    }
+    return YyjsonGetLength(arrayHandle);
+}
+
+int json_arrayIndex(int arrayHandle, int index) {
+    if (arrayHandle < 0) {
+        return -1;
+    }
+    if (index < 0) {
+        return -1;
+    }
+    return YyjsonGetIndex(arrayHandle, index);
+}
+
+str json_getStringAt(int arrayHandle, int index, str fallback) {
+    int handle = json_arrayIndex(arrayHandle, index);
+    if (handle < 0) {
+        return fallback;
+    }
+    str value = YyjsonGetString(handle);
+    YyjsonFreeValue(handle);
+    return value;
+}
+
+int json_getIntAt(int arrayHandle, int index, int fallback) {
+    int handle = json_arrayIndex(arrayHandle, index);
+    if (handle < 0) {
+        return fallback;
+    }
+    int result = (int)YyjsonGetInt(handle);
+    YyjsonFreeValue(handle);
+    return result;
+}
+
+float json_getNumberAt(int arrayHandle, int index, float fallback) {
+    int handle = json_arrayIndex(arrayHandle, index);
+    if (handle < 0) {
+        return fallback;
+    }
+    float result = (float)YyjsonGetNumber(handle);
+    YyjsonFreeValue(handle);
+    return result;
+}
+
+int json_getBoolAt(int arrayHandle, int index, int fallback) {
+    int handle = json_arrayIndex(arrayHandle, index);
+    if (handle < 0) {
+        return fallback;
+    }
+    int value = YyjsonGetBool(handle);
+    YyjsonFreeValue(handle);
+    return value != 0 ? 1 : 0;
+}

--- a/lib/clike/strings.cl
+++ b/lib/clike/strings.cl
@@ -1,0 +1,205 @@
+// String helpers that parallel lib/rea/strings.
+
+int strings_isWhitespace(str ch) {
+    if (ch == " " || ch == "\t" || ch == "\n" || ch == "\r") {
+        return 1;
+    }
+    return 0;
+}
+
+str strings_resolvePadChar(str padding) {
+    if (length(padding) == 0) {
+        return " ";
+    }
+    return copy(padding, 1, 1);
+}
+
+int strings_contains(str haystack, str needle) {
+    int needleLen = length(needle);
+    if (needleLen == 0) {
+        return 1;
+    }
+    int haystackLen = length(haystack);
+    if (haystackLen == 0 || needleLen > haystackLen) {
+        return 0;
+    }
+    int i = 1;
+    int limit = haystackLen - needleLen + 1;
+    while (i <= limit) {
+        if (copy(haystack, i, needleLen) == needle) {
+            return 1;
+        }
+        i = i + 1;
+    }
+    return 0;
+}
+
+int strings_startsWith(str value, str prefix) {
+    int prefixLen = length(prefix);
+    if (prefixLen == 0) {
+        return 1;
+    }
+    if (length(value) < prefixLen) {
+        return 0;
+    }
+    return copy(value, 1, prefixLen) == prefix ? 1 : 0;
+}
+
+int strings_endsWith(str value, str suffix) {
+    int suffixLen = length(suffix);
+    if (suffixLen == 0) {
+        return 1;
+    }
+    int valueLen = length(value);
+    if (valueLen < suffixLen) {
+        return 0;
+    }
+    return copy(value, valueLen - suffixLen + 1, suffixLen) == suffix ? 1 : 0;
+}
+
+str strings_trimLeft(str value) {
+    int len = length(value);
+    int i = 1;
+    while (i <= len && strings_isWhitespace(copy(value, i, 1))) {
+        i = i + 1;
+    }
+    if (i > len) {
+        return "";
+    }
+    return copy(value, i, len - i + 1);
+}
+
+str strings_trimRight(str value) {
+    int len = length(value);
+    int i = len;
+    while (i >= 1 && strings_isWhitespace(copy(value, i, 1))) {
+        i = i - 1;
+    }
+    if (i <= 0) {
+        return "";
+    }
+    return copy(value, 1, i);
+}
+
+str strings_trim(str value) {
+    return strings_trimRight(strings_trimLeft(value));
+}
+
+str strings_padLeft(str value, int width, str padding) {
+    int valueLen = length(value);
+    if (width <= valueLen) {
+        return value;
+    }
+    int padLen = width - valueLen;
+    str padChar = strings_resolvePadChar(padding);
+    str result = "";
+    int i = 0;
+    while (i < padLen) {
+        result = result + padChar;
+        i = i + 1;
+    }
+    result = result + value;
+    return result;
+}
+
+str strings_padRight(str value, int width, str padding) {
+    int valueLen = length(value);
+    if (width <= valueLen) {
+        return value;
+    }
+    int padLen = width - valueLen;
+    str padChar = strings_resolvePadChar(padding);
+    str result = value;
+    int i = 0;
+    while (i < padLen) {
+        result = result + padChar;
+        i = i + 1;
+    }
+    return result;
+}
+
+str strings_toUpper(str value) {
+    int len = length(value);
+    if (len == 0) {
+        return value;
+    }
+    str result = "";
+    int i = 1;
+    while (i <= len) {
+        str ch = copy(value, i, 1);
+        int code = ord(ch);
+        if (code >= ord("a") && code <= ord("z")) {
+            code = code - 32;
+        }
+        result = result + tochar(code);
+        i = i + 1;
+    }
+    return result;
+}
+
+str strings_toLower(str value) {
+    int len = length(value);
+    if (len == 0) {
+        return value;
+    }
+    str result = "";
+    int i = 1;
+    while (i <= len) {
+        str ch = copy(value, i, 1);
+        int code = ord(ch);
+        if (code >= ord("A") && code <= ord("Z")) {
+            code = code + 32;
+        }
+        result = result + tochar(code);
+        i = i + 1;
+    }
+    return result;
+}
+
+str strings_sortCharacters(str value) {
+    int len = length(value);
+    if (len <= 1) {
+        return value;
+    }
+    str remaining = value;
+    str result = "";
+    while (length(remaining) > 0) {
+        str minChar = copy(remaining, 1, 1);
+        int minIndex = 1;
+        int i = 2;
+        int remLen = length(remaining);
+        while (i <= remLen) {
+            str current = copy(remaining, i, 1);
+            if (current < minChar) {
+                minChar = current;
+                minIndex = i;
+            }
+            i = i + 1;
+        }
+        result = result + minChar;
+        remLen = length(remaining);
+        if (minIndex == 1) {
+            remaining = copy(remaining, 2, remLen - 1);
+        } else if (minIndex == remLen) {
+            remaining = copy(remaining, 1, remLen - 1);
+        } else {
+            str left = copy(remaining, 1, minIndex - 1);
+            str right = copy(remaining, minIndex + 1, remLen - minIndex);
+            remaining = left + right;
+        }
+    }
+    return result;
+}
+
+str strings_repeat(str value, int count) {
+    if (count <= 0 || length(value) == 0) {
+        return "";
+    }
+    str result = "";
+    int i = 0;
+    while (i < count) {
+        result = result + value;
+        i = i + 1;
+    }
+    return result;
+}


### PR DESCRIPTION
## Summary
- add CRT color constants and mutable attribute state for CLike consumers
- port the Rea string, filesystem, HTTP, JSON, and datetime helpers to `.cl` modules
- document the new modules in `lib/clike/README.md`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d93568d00083299c0e3209426d61c7