### PR TITLE
Fix SQLite HTTP import demo price handling

### DIFF
--- a/Examples/clike/sqlite_http_import_demo
+++ b/Examples/clike/sqlite_http_import_demo
@@ -28,7 +28,7 @@ int importStocksCsv(int db, str csv) {
     int lineNo;
     int inserted;
 
-    insertStmt = SqlitePrepare(db, "INSERT INTO quotes(symbol, trade_date, close_price) VALUES (?1, ?2, ?3);");
+    insertStmt = SqlitePrepare(db, "INSERT INTO quotes(symbol, trade_date, close_price) VALUES (?1, ?2, CAST(?3 AS REAL));");
     if (insertStmt < 0) {
         printf("prepare_insert_failed=%s\n", SqliteErrMsg(db));
         return 0;
@@ -97,10 +97,9 @@ int importStocksCsv(int db, str csv) {
             continue;
         }
 
-        double price = tofloat(priceText);
         SqliteBindText(insertStmt, 1, symbol);
         SqliteBindText(insertStmt, 2, tradeDate);
-        SqliteBindDouble(insertStmt, 3, price);
+        SqliteBindText(insertStmt, 3, priceText);
         int stepRc = SqliteStep(insertStmt);
         if (stepRc == 101) {
             inserted = inserted + 1;


### PR DESCRIPTION
## Summary
- ensure the SQLite import demo stores price values as real numbers by casting the bound parameter
- bind the price column as text so SQLite performs numeric conversion instead of relying on unavailable string-to-float helpers

## Testing
- not run (clike interpreter is not available in this environment)


------
https://chatgpt.com/codex/tasks/task_b_68d96b8d7a1483298e8a38c0f2f3d60b