### PR TITLE
Add array literal support to Rea parser

### DIFF
--- a/Tests/rea/array_literal_init.args
+++ b/Tests/rea/array_literal_init.args
@@ -1,0 +1,1 @@
+--dump-ast-json

--- a/Tests/rea/array_literal_init.out
+++ b/Tests/rea/array_literal_init.out
@@ -1,0 +1,383 @@
+{
+
+  "node_type": "PROGRAM",
+  "var_type_annotated": "VOID",
+  "main_block": 
+  {
+
+    "node_type": "BLOCK",
+    "var_type_annotated": "VOID",
+    "is_global_scope": false,
+    "declarations": 
+    {
+
+      "node_type": "COMPOUND",
+      "var_type_annotated": "VOID",
+      "children": [
+        {
+
+          "node_type": "FUNCTION_DECL",
+          "token": {
+              "type": "IDENTIFIER",
+              "value": "main"
+          },
+          "var_type_annotated": "INT64",
+          "is_inline": false,
+          "right": 
+          {
+
+            "node_type": "TYPE_IDENTIFIER",
+            "token": {
+                "type": "IDENTIFIER",
+                "value": "int"
+            },
+            "var_type_annotated": "INT64"
+          }
+,
+          "extra": 
+          {
+
+            "node_type": "COMPOUND",
+            "var_type_annotated": "VOID",
+            "children": [
+              {
+
+                "node_type": "VAR_DECL",
+                "var_type_annotated": "ARRAY",
+                "left": 
+                {
+
+                  "node_type": "ARRAY_LITERAL",
+                  "var_type_annotated": "ARRAY",
+                  "children": [
+                    {
+
+                      "node_type": "NUMBER",
+                      "token": {
+                          "type": "INTEGER_CONST",
+                          "value": "1"
+                      },
+                      "var_type_annotated": "INT64",
+                      "i_val": 0
+                    },
+                    {
+
+                      "node_type": "NUMBER",
+                      "token": {
+                          "type": "INTEGER_CONST",
+                          "value": "2"
+                      },
+                      "var_type_annotated": "INT64",
+                      "i_val": 0
+                    },
+                    {
+
+                      "node_type": "NUMBER",
+                      "token": {
+                          "type": "INTEGER_CONST",
+                          "value": "3"
+                      },
+                      "var_type_annotated": "INT64",
+                      "i_val": 0
+                    }
+                  ]
+                }
+,
+                "right": 
+                {
+
+                  "node_type": "ARRAY_TYPE",
+                  "var_type_annotated": "ARRAY",
+                  "right": 
+                  {
+
+                    "node_type": "TYPE_IDENTIFIER",
+                    "token": {
+                        "type": "IDENTIFIER",
+                        "value": "int"
+                    },
+                    "var_type_annotated": "INT64"
+                  }
+,
+                  "children": [
+                    {
+
+                      "node_type": "SUBRANGE",
+                      "var_type_annotated": "INT64",
+                      "left": 
+                      {
+
+                        "node_type": "NUMBER",
+                        "token": {
+                            "type": "INTEGER_CONST",
+                            "value": "0"
+                        },
+                        "var_type_annotated": "INT64",
+                        "i_val": 0
+                      }
+,
+                      "right": 
+                      {
+
+                        "node_type": "NUMBER",
+                        "token": {
+                            "type": "INTEGER_CONST",
+                            "value": "2"
+                        },
+                        "var_type_annotated": "INT64",
+                        "i_val": 2
+                      }
+
+                    }
+                  ]
+                }
+,
+                "children": [
+                  {
+
+                    "node_type": "VARIABLE",
+                    "token": {
+                        "type": "IDENTIFIER",
+                        "value": "numbers"
+                    },
+                    "var_type_annotated": "ARRAY"
+                  }
+                ]
+              },
+              {
+
+                "node_type": "VAR_DECL",
+                "var_type_annotated": "ARRAY",
+                "left": 
+                {
+
+                  "node_type": "ARRAY_LITERAL",
+                  "var_type_annotated": "ARRAY",
+                  "children": [
+                    {
+
+                      "node_type": "STRING",
+                      "token": {
+                          "type": "STRING_CONST",
+                          "value": "alpha"
+                      },
+                      "var_type_annotated": "STRING"
+                    },
+                    {
+
+                      "node_type": "STRING",
+                      "token": {
+                          "type": "STRING_CONST",
+                          "value": "beta"
+                      },
+                      "var_type_annotated": "STRING"
+                    }
+                  ]
+                }
+,
+                "right": 
+                {
+
+                  "node_type": "ARRAY_TYPE",
+                  "var_type_annotated": "ARRAY",
+                  "right": 
+                  {
+
+                    "node_type": "TYPE_IDENTIFIER",
+                    "token": {
+                        "type": "IDENTIFIER",
+                        "value": "str"
+                    },
+                    "var_type_annotated": "STRING"
+                  }
+,
+                  "children": [
+                    {
+
+                      "node_type": "SUBRANGE",
+                      "var_type_annotated": "INT64",
+                      "left": 
+                      {
+
+                        "node_type": "NUMBER",
+                        "token": {
+                            "type": "INTEGER_CONST",
+                            "value": "0"
+                        },
+                        "var_type_annotated": "INT64",
+                        "i_val": 0
+                      }
+,
+                      "right": 
+                      {
+
+                        "node_type": "NUMBER",
+                        "token": {
+                            "type": "INTEGER_CONST",
+                            "value": "1"
+                        },
+                        "var_type_annotated": "INT64",
+                        "i_val": 1
+                      }
+
+                    }
+                  ]
+                }
+,
+                "children": [
+                  {
+
+                    "node_type": "VARIABLE",
+                    "token": {
+                        "type": "IDENTIFIER",
+                        "value": "labels"
+                    },
+                    "var_type_annotated": "ARRAY"
+                  }
+                ]
+              },
+              {
+
+                "node_type": "EXPR_STMT",
+                "var_type_annotated": "VOID",
+                "left": 
+                {
+
+                  "node_type": "WRITELN",
+                  "var_type_annotated": "UNKNOWN_VAR_TYPE",
+                  "children": [
+                    {
+
+                      "node_type": "ARRAY_ACCESS",
+                      "var_type_annotated": "INT64",
+                      "left": 
+                      {
+
+                        "node_type": "VARIABLE",
+                        "token": {
+                            "type": "IDENTIFIER",
+                            "value": "numbers"
+                        },
+                        "var_type_annotated": "ARRAY"
+                      }
+,
+                      "children": [
+                        {
+
+                          "node_type": "NUMBER",
+                          "token": {
+                              "type": "INTEGER_CONST",
+                              "value": "1"
+                          },
+                          "var_type_annotated": "INT64",
+                          "i_val": 0
+                        }
+                      ]
+                    }
+                  ]
+                }
+
+              },
+              {
+
+                "node_type": "EXPR_STMT",
+                "var_type_annotated": "VOID",
+                "left": 
+                {
+
+                  "node_type": "WRITELN",
+                  "var_type_annotated": "UNKNOWN_VAR_TYPE",
+                  "children": [
+                    {
+
+                      "node_type": "ARRAY_ACCESS",
+                      "var_type_annotated": "STRING",
+                      "left": 
+                      {
+
+                        "node_type": "VARIABLE",
+                        "token": {
+                            "type": "IDENTIFIER",
+                            "value": "labels"
+                        },
+                        "var_type_annotated": "ARRAY"
+                      }
+,
+                      "children": [
+                        {
+
+                          "node_type": "NUMBER",
+                          "token": {
+                              "type": "INTEGER_CONST",
+                              "value": "0"
+                          },
+                          "var_type_annotated": "INT64",
+                          "i_val": 0
+                        }
+                      ]
+                    }
+                  ]
+                }
+
+              },
+              {
+
+                "node_type": "RETURN",
+                "token": {
+                    "type": "RETURN",
+                    "value": "return"
+                },
+                "var_type_annotated": "INT64",
+                "left": 
+                {
+
+                  "node_type": "NUMBER",
+                  "token": {
+                      "type": "INTEGER_CONST",
+                      "value": "0"
+                  },
+                  "var_type_annotated": "INT64",
+                  "i_val": 0
+                }
+
+              }
+            ]
+          }
+
+        }
+      ]
+    }
+,
+    "body": 
+    {
+
+      "node_type": "COMPOUND",
+      "var_type_annotated": "VOID",
+      "children": [
+        {
+
+          "node_type": "EXPR_STMT",
+          "token": {
+              "type": "IDENTIFIER",
+              "value": "main"
+          },
+          "var_type_annotated": "VOID",
+          "left": 
+          {
+
+            "node_type": "PROCEDURE_CALL",
+            "token": {
+                "type": "IDENTIFIER",
+                "value": "main"
+            },
+            "var_type_annotated": "INT64"
+          }
+
+        }
+      ]
+    }
+
+  }
+
+}
+

--- a/Tests/rea/array_literal_init.rea
+++ b/Tests/rea/array_literal_init.rea
@@ -1,0 +1,9 @@
+int main() {
+  int numbers[3] = [1, 2, 3];
+  str labels[2] = ["alpha", "beta"];
+  writeln(numbers[1]);
+  writeln(labels[0]);
+  return 0;
+}
+
+main();

--- a/src/rea/parser.c
+++ b/src/rea/parser.c
@@ -1020,6 +1020,45 @@ static AST *parseFactor(ReaParser *p) {
         }
         return node;
     }
+    if (p->current.type == REA_TOKEN_LEFT_BRACKET) {
+        int line = p->current.line;
+        reaAdvance(p); // consume '['
+        AST *literal = newASTNode(AST_ARRAY_LITERAL, NULL);
+        setTypeAST(literal, TYPE_ARRAY);
+
+        bool expectElement = true;
+        while (p->current.type != REA_TOKEN_RIGHT_BRACKET &&
+               p->current.type != REA_TOKEN_EOF) {
+            AST *element = parseExpression(p);
+            if (!element) {
+                expectElement = false;
+                break;
+            }
+            addChild(literal, element);
+            if (p->current.type == REA_TOKEN_COMMA) {
+                reaAdvance(p);
+                if (p->current.type == REA_TOKEN_RIGHT_BRACKET) {
+                    // Trailing comma; allow and break after consuming ']'
+                    break;
+                }
+                continue;
+            }
+            break;
+        }
+
+        if (p->current.type != REA_TOKEN_RIGHT_BRACKET) {
+            fprintf(stderr, "L%d: Expected ']' to close array literal.\n", line);
+            p->hadError = true;
+        } else {
+            reaAdvance(p);
+        }
+
+        if (!expectElement && literal->child_count == 0) {
+            freeAST(literal);
+            return NULL;
+        }
+        return literal;
+    }
     if (p->current.type == REA_TOKEN_NUMBER) {
         size_t len = p->current.length;
         const char *start = p->current.start;


### PR DESCRIPTION
## Summary
- teach the Rea parser to recognize bracketed array literals and emit AST_ARRAY_LITERAL nodes
- add a regression fixture that exercises array literal initialization in the AST dump

## Testing
- REA_SKIP_TESTS="$(cd Tests/rea && for f in *.rea; do base=${f%.rea}; if [ "$base" != "array_literal_init" ]; then printf "%s " "$base"; fi; done)" Tests/run_rea_tests.sh

------
https://chatgpt.com/codex/tasks/task_b_68d984a424c08329bb757700bf46b123