### PR TITLE
Fix REA lexer handling of dot before non-exponent

### DIFF
--- a/Tests/rea/scientific_number.out
+++ b/Tests/rea/scientific_number.out
@@ -91,6 +91,123 @@
               "var_type_annotated": "REAL"
             }
           ]
+        },
+        {
+
+          "node_type": "VAR_DECL",
+          "var_type_annotated": "REAL",
+          "left": 
+          {
+
+            "node_type": "NUMBER",
+            "token": {
+                "type": "REAL_CONST",
+                "value": "3."
+            },
+            "var_type_annotated": "REAL",
+            "i_val": 0
+          }
+,
+          "right": 
+          {
+
+            "node_type": "TYPE_IDENTIFIER",
+            "token": {
+                "type": "IDENTIFIER",
+                "value": "float"
+            },
+            "var_type_annotated": "REAL"
+          }
+,
+          "children": [
+            {
+
+              "node_type": "VARIABLE",
+              "token": {
+                  "type": "IDENTIFIER",
+                  "value": "trailingPoint"
+              },
+              "var_type_annotated": "REAL"
+            }
+          ]
+        },
+        {
+
+          "node_type": "VAR_DECL",
+          "var_type_annotated": "REAL",
+          "left": 
+          {
+
+            "node_type": "NUMBER",
+            "token": {
+                "type": "REAL_CONST",
+                "value": ".75"
+            },
+            "var_type_annotated": "REAL",
+            "i_val": 0
+          }
+,
+          "right": 
+          {
+
+            "node_type": "TYPE_IDENTIFIER",
+            "token": {
+                "type": "IDENTIFIER",
+                "value": "float"
+            },
+            "var_type_annotated": "REAL"
+          }
+,
+          "children": [
+            {
+
+              "node_type": "VARIABLE",
+              "token": {
+                  "type": "IDENTIFIER",
+                  "value": "leadingPoint"
+              },
+              "var_type_annotated": "REAL"
+            }
+          ]
+        },
+        {
+
+          "node_type": "VAR_DECL",
+          "var_type_annotated": "REAL",
+          "left": 
+          {
+
+            "node_type": "NUMBER",
+            "token": {
+                "type": "REAL_CONST",
+                "value": "6.e1"
+            },
+            "var_type_annotated": "REAL",
+            "i_val": 0
+          }
+,
+          "right": 
+          {
+
+            "node_type": "TYPE_IDENTIFIER",
+            "token": {
+                "type": "IDENTIFIER",
+                "value": "float"
+            },
+            "var_type_annotated": "REAL"
+          }
+,
+          "children": [
+            {
+
+              "node_type": "VARIABLE",
+              "token": {
+                  "type": "IDENTIFIER",
+                  "value": "trailingExponent"
+              },
+              "var_type_annotated": "REAL"
+            }
+          ]
         }
       ]
     }

--- a/Tests/rea/scientific_number.rea
+++ b/Tests/rea/scientific_number.rea
@@ -1,2 +1,5 @@
 float big = 1e9;
 float small = 2.5e-3;
+float trailingPoint = 3.;
+float leadingPoint = .75;
+float trailingExponent = 6.e1;


### PR DESCRIPTION
## Summary
- add a lookahead helper so the REA lexer only folds a trailing dot into a numeric literal when a real exponent with digits follows
- prevent dots preceding identifiers that start with e/E from being absorbed into the number token while keeping existing decimal/exponent forms working

## Testing
- cmake --build build --target rea
- Tests/run_rea_tests.sh

------
https://chatgpt.com/codex/tasks/task_b_68d984ad6a7c832990c1902ed5dee5d0