### PR TITLE
Fix SQL insert termination in Spotify SQLite demo

### DIFF
--- a/Examples/rea/sqlite_spotify_demo
+++ b/Examples/rea/sqlite_spotify_demo
@@ -179,7 +179,7 @@ int importSpotifyCsv(str path, int db) {
     " tempo, duration_ms"
     ") VALUES ("
     " ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15,"
-    " ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23");");
+    " ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23);");
   if (stmt < 0) {
     writeln("Failed to prepare insert statement: ", SqliteErrMsg(db));
     close(f);


### PR DESCRIPTION
## Summary
- correct the VALUES placeholder string in the Spotify SQLite demo so the INSERT statement ends with the closing placeholder list and semicolon
- ensures the prepared statement now covers all 23 parameters instead of stopping early at ?15

## Testing
- not run (rea interpreter unavailable in container)

------
https://chatgpt.com/codex/tasks/task_b_68d9a9f69f70832988e8bf9f2f0f4599