### PR TITLE
Fix SQLite Spotify demo nil handling

### DIFF
--- a/Examples/rea/sqlite_spotify_demo
+++ b/Examples/rea/sqlite_spotify_demo
@@ -256,6 +256,12 @@ int parseCsvLine(str line, str fields[], int maxFields) {
   bool inQuotes = false;
   str current = "";
 
+  int resetIndex = 0;
+  while (resetIndex < maxFields) {
+    fields[resetIndex] = "";
+    resetIndex = resetIndex + 1;
+  }
+
   while (idx <= len) {
     char ch = line[idx];
     if (inQuotes) {
@@ -295,7 +301,7 @@ int parseCsvLine(str line, str fields[], int maxFields) {
 
 bool bindField(int stmt, int index, str value) {
   int rc;
-  if (value == nil || value == "") {
+  if (value == "") {
     rc = SqliteBindNull(stmt, index);
   } else {
     rc = SqliteBindText(stmt, index, value);


### PR DESCRIPTION
## Summary
- clear CSV field buffers before parsing each line so empty columns do not leave nil entries behind
- treat empty strings as NULL bindings without comparing strings to nil to avoid runtime errors

## Testing
- Examples/rea/sqlite_spotify_demo *(fails: /usr/bin/env: ‘rea’: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68d9b67e63ec83298584f3a965995d5a