### PR TITLE
Handle missing required fields in Spotify SQLite demo

### DIFF
--- a/Examples/rea/sqlite_spotify_demo
+++ b/Examples/rea/sqlite_spotify_demo
@@ -171,6 +171,7 @@ int importSpotifyCsv(str path, int db) {
   str line;
   int lineNumber = 1;
   int inserted = 0;
+  int skipped = 0;
 
   int stmt = SqlitePrepare(db,
     "INSERT INTO spotify_songs ("
@@ -200,6 +201,17 @@ int importSpotifyCsv(str path, int db) {
     if (fieldCount != EXPECTED_FIELD_COUNT) {
       writeln("Skipping line ", lineNumber, ": expected ", EXPECTED_FIELD_COUNT,
               " fields but saw ", fieldCount, ".");
+      skipped = skipped + 1;
+      continue;
+    }
+
+    bool missingRequired =
+      fields[0] == "" || fields[1] == "" || fields[2] == "" || fields[8] == "";
+    if (missingRequired) {
+      writeln("Skipping line ", lineNumber,
+              ": required fields (track_id, track_name, track_artist, playlist_id) "
+              "must be present.");
+      skipped = skipped + 1;
       continue;
     }
 
@@ -242,6 +254,8 @@ int importSpotifyCsv(str path, int db) {
     writeln("SqliteFinalize returned rc=", finalizeRc, ".");
     ok = false;
   }
+
+  writeln("Import summary: ", inserted, " valid rows, ", skipped, " skipped.");
 
   if (!ok) {
     return -1;


### PR DESCRIPTION
## Summary
- skip Spotify CSV rows that are missing required identifiers so inserts no longer violate NOT NULL constraints
- track valid versus skipped rows during import and print a summary after parsing

## Testing
- not run (explain why)

------
https://chatgpt.com/codex/tasks/task_b_68d9bb13ed188329840b4a5fce3a093d