### PR TITLE
Handle duplicate-row resets in Spotify demo

### DIFF
--- a/Examples/rea/sqlite_spotify_demo
+++ b/Examples/rea/sqlite_spotify_demo
@@ -270,6 +270,7 @@ int importSpotifyCsv(str path, int db) {
 
     int rc = SqliteStep(stmt);
     bool handled = false;
+    bool constraintViolation = rc == 19;
     if (rc == 101) {
       inserted = inserted + 1;
       handled = true;
@@ -289,6 +290,9 @@ int importSpotifyCsv(str path, int db) {
     }
 
     rc = SqliteReset(stmt);
+    if (constraintViolation && rc == 19) {
+      rc = 0;
+    }
     if (rc != 0) {
       writeln("SqliteReset failed with rc=", rc, ".");
       ok = false;


### PR DESCRIPTION
## Summary
- treat SQLITE_CONSTRAINT returns from sqlite3_reset as a handled duplicate row in the Spotify import demo
- allow import to continue after encountering duplicate track/playlist combinations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d9c09dc6cc83298d260390d690f611