### PR TITLE
Avoid rebuilding existing Spotify demo database

### DIFF
--- a/Examples/rea/sqlite_spotify_demo
+++ b/Examples/rea/sqlite_spotify_demo
@@ -647,9 +647,12 @@ int main() {
     return 1;
   }
 
-  if (!ensureDataset(CSV_PATH)) {
-    writeln("Unable to ensure dataset availability. Exiting.");
-    return 1;
+  bool dbExists = fileexists(DB_PATH);
+  if (!dbExists) {
+    if (!ensureDataset(CSV_PATH)) {
+      writeln("Unable to ensure dataset availability. Exiting.");
+      return 1;
+    }
   }
 
   int db = SqliteOpen(DB_PATH);
@@ -658,19 +661,23 @@ int main() {
     return 1;
   }
 
-  if (!setupDatabase(db)) {
-    SqliteClose(db);
-    return 1;
-  }
+  if (!dbExists) {
+    if (!setupDatabase(db)) {
+      SqliteClose(db);
+      return 1;
+    }
 
-  writeln("Importing Spotify tracks into SQLite ...");
-  int inserted = importSpotifyCsv(CSV_PATH, db);
-  if (inserted < 0) {
-    writeln("Import failed. See messages above for details.");
-    SqliteClose(db);
-    return 1;
+    writeln("Importing Spotify tracks into SQLite ...");
+    int inserted = importSpotifyCsv(CSV_PATH, db);
+    if (inserted < 0) {
+      writeln("Import failed. See messages above for details.");
+      SqliteClose(db);
+      return 1;
+    }
+    writeln("Imported ", inserted, " rows into spotify_songs.");
+  } else {
+    writeln("Found existing SQLite database at ", DB_PATH, ". Skipping rebuild.");
   }
-  writeln("Imported ", inserted, " rows into spotify_songs.");
 
   runMenu(db);
 


### PR DESCRIPTION
## Summary
- detect when the sqlite_spotify_demo database already exists before importing data
- reuse the existing database by skipping dataset download, schema rebuild, and reimport
- notify the user when an existing database is reused

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d9de4d55948329b9743019b56b0aae