### PR TITLE
Initialize font system in Rea block_game example

### DIFF
--- a/Examples/rea/block_game
+++ b/Examples/rea/block_game
@@ -348,8 +348,18 @@ class Game {
     
     void run() {
         initgraph(WindowWidth, WindowHeight, "Rea Block Game");
+        str systemFontPath = "/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf";
+        str repoFontPath1 = "fonts/Roboto/static/Roboto-Regular.ttf";
+        str repoFontPath2 = "../../fonts/Roboto/static/Roboto-Regular.ttf";
+        if (fileexists(systemFontPath)) {
+            inittextsystem(systemFontPath, 18);
+        } else if (fileexists(repoFontPath1)) {
+            inittextsystem(repoFontPath1, 18);
+        } else {
+            inittextsystem(repoFontPath2, 18);
+        }
         randomize();
-        
+
         writeln("Block Game - Use A/D to move, S to drop, W to rotate, Space for hard drop. Press Q to quit.");
         
         float lastTime = 0.0;


### PR DESCRIPTION
## Summary
- initialize the text rendering system in the Rea block_game example before drawing score text
- load the bundled Roboto font with fallbacks to system and repository locations

## Testing
- not run (example change)


------
https://chatgpt.com/codex/tasks/task_b_68d9ee252a5c83299147c7bd5bc4f8b2