### PR TITLE
Fix class const scope resolution

### DIFF
--- a/scope_verify/rea/tests/build_manifest.py
+++ b/scope_verify/rea/tests/build_manifest.py
@@ -1024,6 +1024,42 @@ add({
 })
 
 add({
+    "id": "const_class_member_initializer_uses_prior_const",
+    "name": "Class const initialisers see earlier consts",
+    "category": "const_scope",
+    "description": "Constants declared inside a class may reference earlier constants from the same class.",
+    "expect": "runtime_ok",
+    "code": """
+        const int GLOBAL_SHIFT = 3;
+
+        class Layout {
+            const int BaseY = 10;
+            const int Height = BaseY + GLOBAL_SHIFT + 2;
+            int captured;
+
+            void Layout() {
+                myself.captured = Height;
+            }
+
+            int combined() {
+                return Height + BaseY;
+            }
+        }
+
+        int main() {
+            Layout layout = new Layout();
+            writeln("captured=", layout.captured);
+            writeln("combined=", layout.combined());
+            return 0;
+        }
+    """,
+    "expected_stdout": """
+        captured=15
+        combined=25
+    """,
+})
+
+add({
     "id": "const_random_shadow_pass",
     "name": "Randomised const shadow allowed",
     "category": "const_scope",

--- a/scope_verify/rea/tests/manifest.json
+++ b/scope_verify/rea/tests/manifest.json
@@ -588,6 +588,15 @@
       "failure_reason": "Constant shadow should not permit reassignment."
     },
     {
+      "id": "const_class_member_initializer_uses_prior_const",
+      "name": "Class const initialisers see earlier consts",
+      "category": "const_scope",
+      "description": "Constants declared inside a class may reference earlier constants from the same class.",
+      "expect": "runtime_ok",
+      "code": "const int GLOBAL_SHIFT = 3;\n\nclass Layout {\n    const int BaseY = 10;\n    const int Height = BaseY + GLOBAL_SHIFT + 2;\n    int captured;\n\n    void Layout() {\n        myself.captured = Height;\n    }\n\n    int combined() {\n        return Height + BaseY;\n    }\n}\n\nint main() {\n    Layout layout = new Layout();\n    writeln(\"captured=\", layout.captured);\n    writeln(\"combined=\", layout.combined());\n    return 0;\n}",
+      "expected_stdout": "captured=15\ncombined=25"
+    },
+    {
       "id": "const_random_shadow_pass",
       "name": "Randomised const shadow allowed",
       "category": "const_scope",

--- a/src/rea/semantic.c
+++ b/src/rea/semantic.c
@@ -3611,10 +3611,19 @@ static void validateNodeInternal(AST *node, ClassInfo *currentClass) {
         return;
     }
 
-    if (node->left) validateNodeInternal(node->left, clsContext);
-    if (node->right) validateNodeInternal(node->right, clsContext);
-    if (node->extra) validateNodeInternal(node->extra, clsContext);
-    for (int i = 0; i < node->child_count; i++) validateNodeInternal(node->children[i], clsContext);
+    ClassInfo *recurseContext = clsContext;
+    if (node->type == AST_TYPE_DECL && node->left && node->left->type == AST_RECORD_TYPE &&
+        node->token && node->token->value) {
+        ClassInfo *declClass = lookupClass(node->token->value);
+        if (declClass) {
+            recurseContext = declClass;
+        }
+    }
+
+    if (node->left) validateNodeInternal(node->left, recurseContext);
+    if (node->right) validateNodeInternal(node->right, recurseContext);
+    if (node->extra) validateNodeInternal(node->extra, recurseContext);
+    for (int i = 0; i < node->child_count; i++) validateNodeInternal(node->children[i], recurseContext);
 
     if (pushedGenericFrame) popGenericFrame();
 }


### PR DESCRIPTION
## Summary
- ensure the semantic validator keeps the enclosing class context while descending into record type declarations so earlier class constants stay visible
- add a const_scope regression that exercises a class constant initializer referencing a previously-declared class constant

## Testing
- python3 scope_verify/rea/rea_scope_test_harness.py --only const_class_member_initializer_uses_prior_const

------
https://chatgpt.com/codex/tasks/task_b_68d9fcf17df88329a148b5c20237fca5