### PR TITLE
Fix SDL multibouncing balls frame delay division

### DIFF
--- a/Examples/rea/sdl_multibouncingballs
+++ b/Examples/rea/sdl_multibouncingballs
@@ -99,7 +99,7 @@ class BallsApp {
     randomize();
     myself.maxX = getmaxx();
     myself.maxY = getmaxy();
-    myself.FrameDelay = trunc(1000 / TargetFPS);
+    myself.FrameDelay = trunc(1000.0 / float(TargetFPS));
     int i = 1;
     while (i <= NumBalls) {
       Ball b = new Ball();


### PR DESCRIPTION
## Summary
- ensure the SDL multibouncing balls demo computes frame delay using floating point division to avoid runtime type errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68da8c29f5c883298c5776b7c14b5129