### PR TITLE
Handle HTTP 5xx statuses without runtime crash

### DIFF
--- a/Tests/clike/HttpServerCases.cl
+++ b/Tests/clike/HttpServerCases.cl
@@ -26,6 +26,12 @@ int main() {
   printf("E %d\n", code);
   mstreamfree(&e);
 
+  // Test server error without runtime crash
+  mstream se = mstreamcreate();
+  code = httprequest(s, "GET", base + "/error503", NULL, se);
+  printf("S %d %s\n", code, httplasterror(s));
+  mstreamfree(&se);
+
   httpclose(s);
   return 0;
 }

--- a/Tests/clike/HttpServerCases.net
+++ b/Tests/clike/HttpServerCases.net
@@ -13,6 +13,11 @@ class Handler(BaseHTTPRequestHandler):
             self.send_response(302)
             self.send_header('Location', '/headers')
             self.end_headers()
+        elif self.path == '/error503':
+            self.send_response(503)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            self.wfile.write(b'service unavailable')
         else:
             self.send_response(404)
             self.end_headers()

--- a/Tests/clike/HttpServerCases.out
+++ b/Tests/clike/HttpServerCases.out
@@ -1,3 +1,4 @@
 H 200 ok
 R 302
 E 404
+S 503 HTTP status 503

--- a/src/backend_ast/builtin_network_api.c
+++ b/src/backend_ast/builtin_network_api.c
@@ -1334,10 +1334,11 @@ Value vmBuiltinHttpRequest(VM* vm, int arg_count, Value* args) {
     s->last_status = http_code;
     s->last_error_code = 1;
     if (s->last_error_msg) free(s->last_error_msg);
-    s->last_error_msg = strdup("HTTP error");
+    char errbuf[64];
+    snprintf(errbuf, sizeof(errbuf), "HTTP status %ld", http_code);
+    s->last_error_msg = strdup(errbuf);
     if (tmp_out_file) fclose(tmp_out_file);
-    runtimeError(vm, "httpRequest: HTTP status %ld", http_code);
-    return makeInt(-1);
+    return makeInt((int)http_code);
 }
 
 // httpRequestToFile(session, method, url, bodyStrOrMStreamOrNil, outFilename): Integer (status)

--- a/src/backend_ast/builtin_network_api.c
+++ b/src/backend_ast/builtin_network_api.c
@@ -1666,10 +1666,11 @@ Value vmBuiltinHttpRequestToFile(VM* vm, int arg_count, Value* args) {
     s->last_status = http_code;
     s->last_error_code = 1;
     if (s->last_error_msg) free(s->last_error_msg);
-    s->last_error_msg = strdup("HTTP error");
+    char errbuf[64];
+    snprintf(errbuf, sizeof(errbuf), "HTTP status %ld", http_code);
+    s->last_error_msg = strdup(errbuf);
     if (out) fclose(out);
-    runtimeError(vm, "httpRequestToFile: HTTP status %ld", http_code);
-    return makeInt(-1);
+    return makeInt((int)http_code);
 }
 
 // -------------------- Existing simple helpers --------------------


### PR DESCRIPTION
## Summary
- treat HTTP 5xx responses as non-fatal by returning the HTTP status and recording the error details
- extend the HttpServerCases harness with a /error503 endpoint and expected output

## Testing
- Manual: HttpServerCases network test (clike/HttpServerCases)


------
https://chatgpt.com/codex/tasks/task_b_68dae6e9a05c832998abe4a0b4a6d6ac