### PR TITLE
Align WebSocketEcho host with handshake header

### DIFF
--- a/Examples/clike/WebSocketEcho
+++ b/Examples/clike/WebSocketEcho
@@ -1,7 +1,7 @@
 #!/usr/bin/env clike
 
 int main() {
-  const char *host = "yahoo.com";
+  const char *host = "echo.websocket.events";
   int port = 80;
 
   int s = socketcreate(0);


### PR DESCRIPTION
## Summary
- update the WebSocketEcho example to target echo.websocket.events so the socket host matches the handshake header

## Testing
- `./Examples/clike/WebSocketEcho` *(fails: /usr/bin/env: 'clike': No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68db0351be5c8329a4a4b491002f9e42