### PR TITLE
Update WebSocketEcho example to use ws.postman-echo.com

### DIFF
--- a/Examples/clike/WebSocketEcho
+++ b/Examples/clike/WebSocketEcho
@@ -1,7 +1,7 @@
 #!/usr/bin/env clike
 
 int main() {
-  const char *host = "echo.websocket.events";
+  const char *host = "ws.postman-echo.com";
   int port = 80;
 
   int s = socketcreate(0);
@@ -33,8 +33,9 @@ int main() {
   }
 
   if (socketsend(s,
-        "GET / HTTP/1.1\r\n"
-        "Host: echo.websocket.events\r\n"
+        "GET /raw HTTP/1.1\r\n"
+        "Host: ws.postman-echo.com\r\n"
+        "Origin: http://ws.postman-echo.com\r\n"
         "Upgrade: websocket\r\n"
         "Connection: Upgrade\r\n"
         "Sec-WebSocket-Version: 13\r\n"


### PR DESCRIPTION
## Summary
- retarget the WebSocketEcho example to the ws.postman-echo.com /raw echo endpoint
- include an Origin header expected by the Postman echo service

## Testing
- not run (requires network access)


------
https://chatgpt.com/codex/tasks/task_b_68db04a5b81483298534cddc0424d544