### PR TITLE
Handle socketconnect DNS lookups per socket family

### DIFF
--- a/src/backend_ast/builtin_network_api.c
+++ b/src/backend_ast/builtin_network_api.c
@@ -1891,21 +1891,23 @@ Value vmBuiltinSocketConnect(VM* vm, int arg_count, Value* args) {
     lookupSocketInfo(s, &family, &socktype);
     struct addrinfo hints, *res = NULL;
     memset(&hints, 0, sizeof(hints));
-    if (family == AF_INET || family == AF_INET6) {
-        hints.ai_family = family;
-#ifdef AF_INET6
-        if (family == AF_INET6) {
-#ifdef AI_V4MAPPED
-            hints.ai_flags |= AI_V4MAPPED;
-#endif
-#ifdef AI_ALL
-            hints.ai_flags |= AI_ALL;
-#endif
-        }
-#endif
-    } else {
-        hints.ai_family = AF_UNSPEC;
+    hints.ai_family = AF_UNSPEC;
+    if (family == AF_INET) {
+        hints.ai_family = AF_INET;
     }
+#ifdef AF_INET6
+    else if (family == AF_INET6) {
+#ifdef AI_V4MAPPED
+        hints.ai_family = AF_INET6;
+        hints.ai_flags |= AI_V4MAPPED;
+#ifdef AI_ALL
+        hints.ai_flags |= AI_ALL;
+#endif
+#else
+        hints.ai_family = AF_UNSPEC;
+#endif
+    }
+#endif
     hints.ai_socktype = socktype;
 #ifdef AI_ADDRCONFIG
     if (hints.ai_family == AF_UNSPEC) {

--- a/src/backend_ast/builtin_network_api.c
+++ b/src/backend_ast/builtin_network_api.c
@@ -1891,10 +1891,26 @@ Value vmBuiltinSocketConnect(VM* vm, int arg_count, Value* args) {
     lookupSocketInfo(s, &family, &socktype);
     struct addrinfo hints, *res = NULL;
     memset(&hints, 0, sizeof(hints));
-    hints.ai_family = AF_UNSPEC;
+    if (family == AF_INET || family == AF_INET6) {
+        hints.ai_family = family;
+#ifdef AF_INET6
+        if (family == AF_INET6) {
+#ifdef AI_V4MAPPED
+            hints.ai_flags |= AI_V4MAPPED;
+#endif
+#ifdef AI_ALL
+            hints.ai_flags |= AI_ALL;
+#endif
+        }
+#endif
+    } else {
+        hints.ai_family = AF_UNSPEC;
+    }
     hints.ai_socktype = socktype;
 #ifdef AI_ADDRCONFIG
-    hints.ai_flags |= AI_ADDRCONFIG;
+    if (hints.ai_family == AF_UNSPEC) {
+        hints.ai_flags |= AI_ADDRCONFIG;
+    }
 #endif
     int gai_err = getaddrinfo(host, portstr, &hints, &res);
     if (gai_err != 0) {


### PR DESCRIPTION
## Summary
- request address info using the socket's family so IPv6 sockets are resolved correctly
- only apply AI_ADDRCONFIG when querying all families and enable IPv4 mapping for IPv6 sockets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68db04a5b81483298534cddc0424d544