### PR TITLE
Improve WebSocket echo example connection handling

### DIFF
--- a/Examples/clike/WebSocketEcho
+++ b/Examples/clike/WebSocketEcho
@@ -1,84 +1,84 @@
 #!/usr/bin/env clike
 
+int openSocket(const char *host, int port, int family) {
+    int sock;
+    if (family == 6) {
+        sock = socketcreate(0, 6);
+    } else {
+        sock = socketcreate(0);
+    }
+    if (sock < 0) {
+        printf("socketcreate (%s) failed: %d\n", family == 6 ? "IPv6" : "IPv4", socketlasterror());
+        return -1;
+    }
+    if (socketconnect(sock, host, port) != 0) {
+        printf("socketconnect (%s) failed: %d\n", family == 6 ? "IPv6" : "IPv4", socketlasterror());
+        socketclose(sock);
+        return -1;
+    }
+    return sock;
+}
+
 int main() {
-  const char *host = "ws.postman-echo.com";
-  int port = 80;
+    const char *host = "ws.postman-echo.com";
+    int port = 80;
 
-  int s = socketcreate(0);
-  if (s < 0) {
-    printf("socketcreate failed: %d\n", socketlasterror());
-    return 1;
-  }
+    int s = openSocket(host, port, 6);
+    if (s < 0) {
+        printf("Retrying with IPv4...\n");
+        s = openSocket(host, port, 4);
+        if (s < 0) {
+            return 1;
+        }
+    }
 
-  if (socketconnect(s, host, port) != 0) {
-    int err = socketlasterror();
-    if (err == 5) {
-      printf("socketconnect failed (IPv4): %d, retrying with IPv6...\n", err);
-      socketclose(s);
-      s = socketcreate(0, 6);
-      if (s < 0) {
-        printf("socketcreate IPv6 failed: %d\n", socketlasterror());
-        return 1;
-      }
-      if (socketconnect(s, host, port) != 0) {
-        printf("socketconnect (IPv6) failed: %d\n", socketlasterror());
+    if (socketsend(s,
+            "GET /raw HTTP/1.1\r\n"
+            "Host: ws.postman-echo.com\r\n"
+            "Origin: http://ws.postman-echo.com\r\n"
+            "Upgrade: websocket\r\n"
+            "Connection: Upgrade\r\n"
+            "Sec-WebSocket-Version: 13\r\n"
+            "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+            "\r\n") < 0) {
+        printf("failed to send handshake: %d\n", socketlasterror());
         socketclose(s);
         return 1;
-      }
-    } else {
-      printf("socketconnect failed: %d\n", err);
-      socketclose(s);
-      return 1;
     }
-  }
 
-  if (socketsend(s,
-        "GET /raw HTTP/1.1\r\n"
-        "Host: ws.postman-echo.com\r\n"
-        "Origin: http://ws.postman-echo.com\r\n"
-        "Upgrade: websocket\r\n"
-        "Connection: Upgrade\r\n"
-        "Sec-WebSocket-Version: 13\r\n"
-        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
-        "\r\n") < 0) {
-    printf("failed to send handshake: %d\n", socketlasterror());
+    mstream resp = socketreceive(s, 1024);
+    if (resp == NULL) {
+        printf("handshake receive failed: %d\n", socketlasterror());
+        socketclose(s);
+        return 1;
+    }
+
+    str handshake = mstreambuffer(resp);
+    printf("handshake:\n%s\n", handshake);
+    mstreamfree(&resp);
+
+    // send masked text frame "hi"
+    if (socketsend(s, "\x81\x82\x12\x34\x56\x78\x7a\x5d") < 0) {
+        printf("failed to send WebSocket frame: %d\n", socketlasterror());
+        socketclose(s);
+        return 1;
+    }
+
+    mstream msg = socketreceive(s, 1024);
+    if (msg == NULL) {
+        printf("echo receive failed: %d\n", socketlasterror());
+        socketclose(s);
+        return 1;
+    }
+
+    str buf = mstreambuffer(msg);
+    int msglen = strlen(buf);
+    if (msglen >= 4) {
+        printf("echo: %c%c\n", buf[3], buf[4]);
+    } else {
+        printf("unexpected echo payload (length=%d)\n", msglen);
+    }
+    mstreamfree(&msg);
     socketclose(s);
-    return 1;
-  }
-
-  mstream resp = socketreceive(s, 1024);
-  if (resp == NULL) {
-    printf("handshake receive failed: %d\n", socketlasterror());
-    socketclose(s);
-    return 1;
-  }
-
-  str handshake = mstreambuffer(resp);
-  printf("handshake:\n%s\n", handshake);
-  mstreamfree(&resp);
-
-  // send masked text frame "hi"
-  if (socketsend(s, "\x81\x82\x12\x34\x56\x78\x7a\x5d") < 0) {
-    printf("failed to send WebSocket frame: %d\n", socketlasterror());
-    socketclose(s);
-    return 1;
-  }
-
-  mstream msg = socketreceive(s, 1024);
-  if (msg == NULL) {
-    printf("echo receive failed: %d\n", socketlasterror());
-    socketclose(s);
-    return 1;
-  }
-
-  str buf = mstreambuffer(msg);
-  int msglen = strlen(buf);
-  if (msglen >= 4) {
-    printf("echo: %c%c\n", buf[3], buf[4]);
-  } else {
-    printf("unexpected echo payload (length=%d)\n", msglen);
-  }
-  mstreamfree(&msg);
-  socketclose(s);
-  return 0;
+    return 0;
 }


### PR DESCRIPTION
## Summary
- add a helper that attempts IPv6 connections first and falls back to IPv4 for the WebSocket echo example
- update the example to provide clearer diagnostics when socket creation or connection fails

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68db0a9054788329ba96c47d9ae864da