### PR TITLE
Refactor library tests to be module-friendly

### DIFF
--- a/Docs/pascal_overview.md
+++ b/Docs/pascal_overview.md
@@ -149,8 +149,8 @@ Provided wrappers:
 - Exponentials: `Power`, `Log10`, `Sinh`, `Cosh`, `Tanh`
 - Helpers: `Max`, `Min`, `Floor`, `Ceil`
 
-Constants exported by MathLib:
-- `Pi`, `E`, `Ln2`, `Ln10`, `TwoPi`, `PiOver2`
+Helpers exported by MathLib for common constants:
+- `PiValue`, `EValue`, `Ln2Value`, `Ln10Value`, `TwoPiValue`, `PiOver2Value`
 
 ### mylib
 Example user unit exporting a record type and routines【F:lib/pascal/mylib.pl†L1-L40】.

--- a/Tests/libs/pascal/library_tests.pas
+++ b/Tests/libs/pascal/library_tests.pas
@@ -118,9 +118,9 @@ procedure TestMathLib;
 begin
   writeln;
   writeln('-- MathLib --');
-  AssertFloatNear('MathLib.Pi', 3.141593, MathLib.Pi, 0.000001);
-  AssertFloatNear('MathLib.E', 2.718282, MathLib.E, 0.000001);
-  AssertFloatNear('MathLib.PiOver2', 1.570796, MathLib.PiOver2, 0.000001);
+  AssertFloatNear('MathLib.Pi', 3.141593, MathLib.PiValue, 0.000001);
+  AssertFloatNear('MathLib.E', 2.718282, MathLib.EValue, 0.000001);
+  AssertFloatNear('MathLib.PiOver2', 1.570796, MathLib.PiOver2Value, 0.000001);
 end;
 
 procedure TestCalculateArea;

--- a/lib/clike/README.md
+++ b/lib/clike/README.md
@@ -7,19 +7,20 @@ projects can share similar utility helpers regardless of the front end in use.
 The helpers are plain `.cl` modules that can be imported with `import`. The
 following modules are available:
 
-* `crt.cl` – legacy Turbo Pascal style color constants and the mutable
-  `CRT_TextAttr` value for applications that emulate text consoles.
+* `crt.cl` – legacy Turbo Pascal style color helpers that return color codes for
+  applications that emulate text consoles.
 * `strings.cl` – substring checks, trimming, padding, casing, repetition, and a
   simple character sorter implemented with only core string primitives.
 * `filesystem.cl` – helpers for reading and writing whole files, joining paths,
-  expanding `~`, and retrieving the first line from a file while tracking the
-  last read/write status codes.
+  expanding `~`, and retrieving the first line from a file. The read/write
+  helpers use out-parameters to report success and error codes so they work in
+  module contexts without mutable globals.
 * `json.cl` – thin wrappers around the optional `yyjson` extended built-ins that
   gate usage on availability, default lookups, and automatically free temporary
   handles.
 * `http.cl` – small wrappers around the synchronous HTTP built-ins for common
-  GET/POST/PUT requests, tracking the last response status, and downloading
-  responses to disk.
+  GET/POST/PUT requests that return bodies and status codes via out-parameters
+  along with helpers for downloading responses to disk.
 * `datetime.cl` – utilities for formatting Unix timestamps, computing day
   boundaries, performing simple arithmetic, and rendering human-friendly
   duration descriptions.

--- a/lib/clike/crt.cl
+++ b/lib/clike/crt.cl
@@ -1,21 +1,19 @@
 // CLike equivalent of the Rea CRT module.
 
-const int CRT_BLACK = 0;
-const int CRT_BLUE = 1;
-const int CRT_GREEN = 2;
-const int CRT_CYAN = 3;
-const int CRT_RED = 4;
-const int CRT_MAGENTA = 5;
-const int CRT_BROWN = 6;
-const int CRT_LIGHT_GRAY = 7;
-const int CRT_DARK_GRAY = 8;
-const int CRT_LIGHT_BLUE = 9;
-const int CRT_LIGHT_GREEN = 10;
-const int CRT_LIGHT_CYAN = 11;
-const int CRT_LIGHT_RED = 12;
-const int CRT_LIGHT_MAGENTA = 13;
-const int CRT_YELLOW = 14;
-const int CRT_WHITE = 15;
-const int CRT_BLINK = 128;
-
-int CRT_TextAttr = CRT_LIGHT_GRAY;
+int CRT_BLACK() { return 0; }
+int CRT_BLUE() { return 1; }
+int CRT_GREEN() { return 2; }
+int CRT_CYAN() { return 3; }
+int CRT_RED() { return 4; }
+int CRT_MAGENTA() { return 5; }
+int CRT_BROWN() { return 6; }
+int CRT_LIGHT_GRAY() { return 7; }
+int CRT_DARK_GRAY() { return 8; }
+int CRT_LIGHT_BLUE() { return 9; }
+int CRT_LIGHT_GREEN() { return 10; }
+int CRT_LIGHT_CYAN() { return 11; }
+int CRT_LIGHT_RED() { return 12; }
+int CRT_LIGHT_MAGENTA() { return 13; }
+int CRT_YELLOW() { return 14; }
+int CRT_WHITE() { return 15; }
+int CRT_BLINK() { return 128; }

--- a/lib/pascal/mathlib.pl
+++ b/lib/pascal/mathlib.pl
@@ -2,17 +2,51 @@ unit MathLib;
 
 interface
 
-// Functions are now part of the core builtins
-
-const
-  { Common mathematical constants }
-  Pi      = 3.1415926535897932384626433832795;
-  E       = 2.7182818284590452353602874713527;
-  Ln2     = 0.69314718055994530941723212145818;
-  Ln10    = 2.3025850929940456840179914546844;
-  TwoPi   = 2.0 * Pi;
-  PiOver2 = Pi / 2.0;
+function PiValue: real;
+function EValue: real;
+function Ln2Value: real;
+function Ln10Value: real;
+function TwoPiValue: real;
+function PiOver2Value: real;
 
 implementation
+
+const
+  MathLibPiConst      = 3.1415926535897932384626433832795;
+  MathLibEConst       = 2.7182818284590452353602874713527;
+  MathLibLn2Const     = 0.69314718055994530941723212145818;
+  MathLibLn10Const    = 2.3025850929940456840179914546844;
+  MathLibTwoPiConst   = 2.0 * MathLibPiConst;
+  MathLibPiOver2Const = MathLibPiConst / 2.0;
+
+function PiValue: real;
 begin
+  PiValue := MathLibPiConst;
+end;
+
+function EValue: real;
+begin
+  EValue := MathLibEConst;
+end;
+
+function Ln2Value: real;
+begin
+  Ln2Value := MathLibLn2Const;
+end;
+
+function Ln10Value: real;
+begin
+  Ln10Value := MathLibLn10Const;
+end;
+
+function TwoPiValue: real;
+begin
+  TwoPiValue := MathLibTwoPiConst;
+end;
+
+function PiOver2Value: real;
+begin
+  PiOver2Value := MathLibPiOver2Const;
+end;
+
 end.


### PR DESCRIPTION
## Summary
- replace filesystem stateful globals with out-parameter APIs and update tests
- expose CRT color codes as helper functions and document the simplified module
- refactor HTTP helpers to return status/response via out-parameters and adjust docs/tests
- convert Pascal MathLib constants into accessor functions and refresh docs/tests

## Testing
- CLIKE_BIN=$(pwd)/build/bin/clike python3 Tests/libs/clike/run_tests.py *(fails: UnicodeDecodeError while reading subprocess output)*
- PASCAL_BIN=$(pwd)/build/bin/pascal python3 Tests/libs/pascal/run_tests.py *(fails: Pascal executable not built in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68db285474b883299c925acc5421fb61