### PR TITLE
Support width specifiers in Str builtin

### DIFF
--- a/src/Pascal/parser.c
+++ b/src/Pascal/parser.c
@@ -2617,11 +2617,38 @@ AST *parseWriteArgument(Parser *parser) {
         int w=atoi(widthTok->value); int p=(precTok)?atoi(precTok->value):-1;
         char fs[32]; snprintf(fs,sizeof(fs),"%d,%d",w,p);
         fmt->token=newToken(TOKEN_STRING_CONST,fs, expr_line, expr_column); // Stores "width,precision"
+        setTypeAST(fmt, TYPE_STRING);
         freeToken(widthTok); if(precTok)freeToken(precTok);
         return fmt;
     } else {
         return exprNode; // No formatting
     }
+}
+
+// Parses the STR built-in argument list, allowing optional width/precision on the first argument.
+static AST *parseStrArgumentList(Parser *parser) {
+    AST *args = newASTNode(AST_COMPOUND, NULL);
+    if (!args) { return NULL; }
+
+    AST *first = parseWriteArgument(parser);
+    if (!first || first->type == AST_NOOP) {
+        errorParser(parser, "Expected expression for Str argument");
+        freeAST(args);
+        return NULL;
+    }
+    addChild(args, first);
+
+    while (parser->current_token && parser->current_token->type == TOKEN_COMMA) {
+        eat(parser, TOKEN_COMMA);
+        AST *next = expression(parser);
+        if (!next || next->type == AST_NOOP) {
+            errorParser(parser, "Expected expression after comma in Str arguments");
+            return args;
+        }
+        addChild(args, next);
+    }
+
+    return args;
 }
 
 AST *parseArrayInitializer(Parser *parser) {
@@ -2948,8 +2975,9 @@ AST *factor(Parser *parser) {
              node = funcCallNode; // The new procedure call node is now our main node.
 
              eat(parser, TOKEN_LPAREN);      // Eat '('
+             bool isStrCall = (node->token && node->token->value && strcasecmp(node->token->value, "str") == 0);
              if (parser->current_token && parser->current_token->type != TOKEN_RPAREN) {
-                 AST* args = exprList(parser); // Parse argument list
+                 AST* args = isStrCall ? parseStrArgumentList(parser) : exprList(parser); // Parse argument list
                  if (!args || args->type == AST_NOOP) { errorParser(parser,"Bad arg list"); return node; }
                  // Transfer arguments safely
                  if (args && args->type == AST_COMPOUND && args->child_count > 0) {


### PR DESCRIPTION
## Summary
- allow the Pascal parser to treat the first Str argument like a formatted expression so width and precision tokens are accepted
- update the Str builtin to accept pre-formatted strings (including boolean values) and restore the DOS example's width specifier

## Testing
- cmake -S . -B build
- cmake --build build --target pscalvm

------
https://chatgpt.com/codex/tasks/task_b_68dbd6c642fc8329a9bb3a83c01907b9