### PR TITLE
Fix SDL keypad keycode translation to avoid range warning

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -131,15 +131,26 @@ static int sdlTranslateKeycode(SDL_Keycode code, int* extraBytes, int* extraCoun
                 *extraCount = 2;
             }
             return 27;
-        default:
-            break;
-    }
-
-    if (code >= SDLK_KP_0 && code <= SDLK_KP_9) {
-        return '0' + (int)(code - SDLK_KP_0);
-    }
-
-    switch (code) {
+        case SDLK_KP_0:
+            return '0';
+        case SDLK_KP_1:
+            return '1';
+        case SDLK_KP_2:
+            return '2';
+        case SDLK_KP_3:
+            return '3';
+        case SDLK_KP_4:
+            return '4';
+        case SDLK_KP_5:
+            return '5';
+        case SDLK_KP_6:
+            return '6';
+        case SDLK_KP_7:
+            return '7';
+        case SDLK_KP_8:
+            return '8';
+        case SDLK_KP_9:
+            return '9';
         case SDLK_KP_PERIOD:
             return '.';
         case SDLK_KP_DIVIDE:


### PR DESCRIPTION
## Summary
- replace the SDL keypad digit range check with explicit keycode cases to avoid tautological comparison warnings
- keep keypad numeric translation alongside other keypad symbol handling

## Testing
- cmake --build build --target pscalvm

------
https://chatgpt.com/codex/tasks/task_b_68dbe21674ec8329a07a257f4c915dd6