### PR TITLE
Add CRT text attribute helpers for CLike modules

### DIFF
--- a/Tests/libs/clike/library_tests.cl
+++ b/Tests/libs/clike/library_tests.cl
@@ -67,7 +67,16 @@ void testCRT() {
     printf("\n-- CRT --\n");
     assertEqualInt("CRT.BLACK", 0, CRT_BLACK());
     assertEqualInt("CRT.LIGHT_RED", 12, CRT_LIGHT_RED());
-    markSkip("CRT.TextAttr", "mutable TextAttr not available in module-safe runtime");
+    int originalAttr = CRT_getTextAttr();
+    assertEqualInt("CRT.TextAttr default", CRT_LIGHT_GRAY(), originalAttr);
+
+    CRT_setTextAttr(CRT_GREEN());
+    assertEqualInt("CRT.TextAttr assignment", CRT_GREEN(), CRT_getTextAttr());
+
+    CRT_setTextAttr(0);
+    assertEqualInt("CRT.TextAttr zero assignment", 0, CRT_getTextAttr());
+
+    CRT_setTextAttr(originalAttr);
 }
 
 void testMathUtils() {

--- a/lib/clike/crt.cl
+++ b/lib/clike/crt.cl
@@ -17,3 +17,36 @@ int CRT_LIGHT_MAGENTA() { return 13; }
 int CRT_YELLOW() { return 14; }
 int CRT_WHITE() { return 15; }
 int CRT_BLINK() { return 128; }
+
+int CRT_currentTextAttr = 7;
+
+int CRT_normalizeTextAttr(int attr) {
+    int normalized = attr % 256;
+    if (normalized < 0) {
+        normalized = normalized + 256;
+    }
+    return normalized;
+}
+
+void CRT_applyTextAttrToTerminal(int attr) {
+    int foreground = attr % 16;
+    int background = (attr / 16) % 8;
+    int blink = attr / 128;
+
+    normvideo();
+    textcolor(foreground);
+    textbackground(background);
+    if (blink != 0) {
+        blinktext();
+    }
+}
+
+int CRT_getTextAttr() {
+    return CRT_currentTextAttr;
+}
+
+void CRT_setTextAttr(int attr) {
+    int normalized = CRT_normalizeTextAttr(attr);
+    CRT_currentTextAttr = normalized;
+    CRT_applyTextAttrToTerminal(normalized);
+}

--- a/src/clike/codegen.c
+++ b/src/clike/codegen.c
@@ -1662,6 +1662,22 @@ void clikeCompile(ASTNodeClike *program, BytecodeChunk *chunk) {
 
     globalVarCount = 0;
 
+    typedef struct {
+        ASTNodeClike *prog;
+        char *source;
+        char *allocated_path;
+    } LoadedModule;
+
+    LoadedModule *modules = NULL;
+    if (clike_import_count > 0) {
+        modules = (LoadedModule*)calloc(clike_import_count, sizeof(LoadedModule));
+        if (!modules) {
+            fprintf(stderr, "CLike codegen error: failed to allocate module cache.\n");
+            EXIT_FAILURE_HANDLER();
+            return;
+        }
+    }
+
     // Compile global variable declarations first so they are initialized
     // before main is invoked.
     for (int i = 0; i < program->child_count; ++i) {
@@ -1671,22 +1687,9 @@ void clikeCompile(ASTNodeClike *program, BytecodeChunk *chunk) {
         }
     }
 
-    // Predeclare all functions so forward references are recognized.
-    predeclareFunctions(program);
-
-    // Emit a call to main after globals have been defined.
-    writeBytecodeChunk(chunk, CALL_USER_PROC, 0);
-    int mainNameIdx = addStringConstant(chunk, "main");
-    emitShort(chunk, (uint16_t)mainNameIdx, 0);
-    int mainArityPatch = chunk->count;
-    writeBytecodeChunk(chunk, 0, 0);
-    writeBytecodeChunk(chunk, HALT, 0);
-
-    bool mainDefined = false;
-    uint8_t mainArity = 0;
-
-    // Compile imported modules before the main program
+    // Load imported modules so their globals can be defined before main runs.
     for (int i = 0; i < clike_import_count; ++i) {
+        LoadedModule *mod = &modules[i];
         const char *orig_path = clike_imports[i];
         const char *path = orig_path;
         char *allocated_path = NULL;
@@ -1696,33 +1699,39 @@ void clikeCompile(ASTNodeClike *program, BytecodeChunk *chunk) {
             if (lib_dir && *lib_dir) {
                 size_t len = strlen(lib_dir) + 1 + strlen(orig_path) + 1;
                 allocated_path = (char*)malloc(len);
-                snprintf(allocated_path, len, "%s/%s", lib_dir, orig_path);
-                f = fopen(allocated_path, "rb");
-                if (f) path = allocated_path; else { free(allocated_path); allocated_path = NULL; }
+                if (allocated_path) {
+                    snprintf(allocated_path, len, "%s/%s", lib_dir, orig_path);
+                    f = fopen(allocated_path, "rb");
+                    if (f) path = allocated_path; else { free(allocated_path); allocated_path = NULL; }
+                }
             }
         }
         if (!f) {
             const char *default_dir = "/usr/local/pscal/clike/lib";
             size_t len = strlen(default_dir) + 1 + strlen(orig_path) + 1;
             allocated_path = (char*)malloc(len);
-            snprintf(allocated_path, len, "%s/%s", default_dir, orig_path);
-            f = fopen(allocated_path, "rb");
-            if (f) path = allocated_path; else { free(allocated_path); allocated_path = NULL; }
+            if (allocated_path) {
+                snprintf(allocated_path, len, "%s/%s", default_dir, orig_path);
+                f = fopen(allocated_path, "rb");
+                if (f) path = allocated_path; else { free(allocated_path); allocated_path = NULL; }
+            }
         }
         if (!f) {
             fprintf(stderr, "Could not open import '%s'\n", orig_path);
+            if (allocated_path) free(allocated_path);
             continue;
         }
         fseek(f, 0, SEEK_END);
         long len = ftell(f);
         rewind(f);
         char *src = (char*)malloc(len + 1);
-        if (!src) { fclose(f); continue; }
+        if (!src) { fclose(f); if (allocated_path) free(allocated_path); continue; }
         size_t bytes_read = fread(src, 1, len, f);
         if (bytes_read != (size_t)len) {
             fprintf(stderr, "Error reading import '%s'\n", orig_path);
             free(src);
             fclose(f);
+            if (allocated_path) free(allocated_path);
             continue;
         }
         src[len] = '\0';
@@ -1736,6 +1745,7 @@ void clikeCompile(ASTNodeClike *program, BytecodeChunk *chunk) {
             fprintf(stderr, "AST verification failed for module '%s' after parsing.\n", path);
             freeASTClike(modProg);
             free(src);
+            if (allocated_path) free(allocated_path);
             EXIT_FAILURE_HANDLER();
             return;
         }
@@ -1746,19 +1756,50 @@ void clikeCompile(ASTNodeClike *program, BytecodeChunk *chunk) {
             fprintf(stderr, "AST verification failed for module '%s' after semantic analysis.\n", path);
             freeASTClike(modProg);
             free(src);
+            if (allocated_path) free(allocated_path);
             EXIT_FAILURE_HANDLER();
             return;
         }
-        predeclareFunctions(modProg);
+
         for (int j = 0; j < modProg->child_count; ++j) {
             ASTNodeClike *decl = modProg->children[j];
+            if (decl->type == TCAST_VAR_DECL) {
+                compileGlobalVar(decl, chunk);
+            }
+        }
+
+        mod->prog = modProg;
+        mod->source = src;
+        mod->allocated_path = allocated_path;
+    }
+
+    // Predeclare all functions so forward references are recognized.
+    predeclareFunctions(program);
+    for (int i = 0; i < clike_import_count; ++i) {
+        if (modules[i].prog) {
+            predeclareFunctions(modules[i].prog);
+        }
+    }
+
+    // Emit a call to main after globals have been defined.
+    writeBytecodeChunk(chunk, CALL_USER_PROC, 0);
+    int mainNameIdx = addStringConstant(chunk, "main");
+    emitShort(chunk, (uint16_t)mainNameIdx, 0);
+    int mainArityPatch = chunk->count;
+    writeBytecodeChunk(chunk, 0, 0);
+    writeBytecodeChunk(chunk, HALT, 0);
+
+    bool mainDefined = false;
+    uint8_t mainArity = 0;
+
+    for (int i = 0; i < clike_import_count; ++i) {
+        if (!modules[i].prog) continue;
+        for (int j = 0; j < modules[i].prog->child_count; ++j) {
+            ASTNodeClike *decl = modules[i].prog->children[j];
             if (decl->type == TCAST_FUN_DECL) {
                 compileFunction(decl, chunk);
             }
         }
-        freeASTClike(modProg);
-        free(src);
-        if (allocated_path) free(allocated_path);
     }
 
     for (int i = 0; i < program->child_count; ++i) {
@@ -1784,8 +1825,12 @@ void clikeCompile(ASTNodeClike *program, BytecodeChunk *chunk) {
     patchForwardCalls(chunk);
 
     for (int i = 0; i < clike_import_count; ++i) {
+        if (modules && modules[i].prog) freeASTClike(modules[i].prog);
+        if (modules && modules[i].source) free(modules[i].source);
+        if (modules && modules[i].allocated_path) free(modules[i].allocated_path);
         free(clike_imports[i]);
     }
+    if (modules) free(modules);
     free(clike_imports);
     clike_imports = NULL;
     clike_import_count = 0;

--- a/src/clike/semantics.c
+++ b/src/clike/semantics.c
@@ -1227,6 +1227,20 @@ void analyzeSemanticsClike(ASTNodeClike *program, const char *current_path) {
     globalVars.count = 0;
     ScopeStack globalsScope = {0};
     ssPush(&globalsScope);
+    for (int i = 0; i < clike_import_count; ++i) {
+        if (!modules[i].prog) continue;
+        for (int j = 0; j < modules[i].prog->child_count; ++j) {
+            ASTNodeClike *decl = modules[i].prog->children[j];
+            if (decl->type == TCAST_VAR_DECL) {
+                char *name = tokenToCString(decl->token);
+                if (ssAdd(&globalsScope, name, decl->var_type, decl, decl->is_const)) {
+                    vtAdd(&globalVars, name, decl->var_type, decl, decl->is_const);
+                }
+                if (decl->left) analyzeExpr(decl->left, &globalsScope);
+                free(name);
+            }
+        }
+    }
     for (int i = 0; i < program->child_count; ++i) {
         ASTNodeClike *decl = program->children[i];
         if (decl->type == TCAST_VAR_DECL) {


### PR DESCRIPTION
## Summary
- add mutable CRT text attribute storage to the clike CRT module and expose getter/setter helpers that apply the underlying VM builtins
- register module-level globals during semantic analysis and emit their definitions before `main` so the CRT cache persists at runtime
- update the clike library tests to exercise the new CRT helpers instead of skipping the case

## Testing
- CLIKE_LIB_DIR=$(pwd)/lib/clike build/bin/clike --no-cache Tests/libs/clike/library_tests.cl

------
https://chatgpt.com/codex/tasks/task_b_68dbe241feac83299feed39764b39c59