### PR TITLE
Initialize local records and enable mylib record test

### DIFF
--- a/Tests/libs/pascal/library_tests.pas
+++ b/Tests/libs/pascal/library_tests.pas
@@ -181,7 +181,11 @@ begin
   AssertEqualInt('mylib.GlobalCounter init', 0, GlobalCounter);
   GlobalCounter := GlobalCounter + 1;
   AssertEqualInt('mylib.GlobalCounter increment', 1, GlobalCounter);
-  MarkSkip('mylib.TPerson', 'record field assignments unavailable');
+
+  person.name := 'Ada Lovelace';
+  person.age := 36;
+  AssertEqualStr('mylib.TPerson.name', 'Ada Lovelace', person.name);
+  AssertEqualInt('mylib.TPerson.age', 36, person.age);
 end;
 
 procedure TestFileRoundTrip(tmpDir: string);


### PR DESCRIPTION
## Summary
- ensure Pascal locals of record type are initialized with an empty record value so field assignments work
- extend the Pascal library tests to assert mylib.TPerson record field assignments instead of skipping them

## Testing
- python Tests/libs/pascal/run_tests.py

------
https://chatgpt.com/codex/tasks/task_b_68dbe75d48348329a2be42530b9f8aaf