### PR TITLE
Ensure Pascal and CLike library tests use gray output

### DIFF
--- a/Tests/libs/clike/library_tests.cl
+++ b/Tests/libs/clike/library_tests.cl
@@ -266,6 +266,14 @@ void printSummary() {
 }
 
 int main() {
+    int startingAttr = CRT_getTextAttr();
+    int changedStartingAttr = startingAttr != CRT_LIGHT_GRAY();
+    if (changedStartingAttr) {
+        CRT_setTextAttr(CRT_LIGHT_GRAY());
+    } else {
+        CRT_setTextAttr(startingAttr);
+    }
+
     printf("CLike Library Test Suite\n");
     testCRT();
     testMathUtils();
@@ -282,8 +290,14 @@ int main() {
 
     testDatetime();
     printSummary();
+    int exitCode = 0;
     if (failedTests > 0) {
-        return 1;
+        exitCode = 1;
     }
-    return 0;
+
+    if (changedStartingAttr) {
+        CRT_setTextAttr(startingAttr);
+    }
+
+    return exitCode;
 }


### PR DESCRIPTION
## Summary
- add ANSI helper routines to the Pascal library harness so it forces light gray output and restores the original attribute after running
- update the CLike library harness to match the gray output behaviour of the Rea suite

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dc13cdff008329bc929ba10cbc33bc