### PR TITLE
Allow GraphLoop to accept real arguments

### DIFF
--- a/src/backend_ast/sdl.c
+++ b/src/backend_ast/sdl.c
@@ -20,6 +20,8 @@
 #include "Pascal/globals.h" // Includes SDL.h and SDL_ttf.h via its includes, and audio.h
 
 #include <ctype.h>
+#include <limits.h>
+#include <math.h>
 #include <string.h>
 #include <strings.h>
 
@@ -1469,7 +1471,16 @@ Value vmBuiltinGraphloop(VM* vm, int arg_count, Value* args) {
     if (IS_INTLIKE(args[0]) || args[0].type == TYPE_WORD || args[0].type == TYPE_BYTE) {
         ms = AS_INTEGER(args[0]);
     } else if (isRealType(args[0].type)) {
-        ms = (long long)AS_REAL(args[0]);
+        double delay = AS_REAL(args[0]);
+        if (!isfinite(delay)) {
+            runtimeError(vm, "GraphLoop delay must be finite.");
+            return makeVoid();
+        }
+        if (delay > (double)LLONG_MAX || delay < (double)LLONG_MIN) {
+            runtimeError(vm, "GraphLoop delay is out of range.");
+            return makeVoid();
+        }
+        ms = (long long)delay;
     } else {
         runtimeError(vm, "GraphLoop argument must be an integer-like type.");
         return makeVoid();


### PR DESCRIPTION
## Summary
- allow the SDL GraphLoop builtin to accept real-valued delays by truncating them to integers
- retain type validation for unsupported argument kinds

## Testing
- cmake -S . -B build
- cmake --build build --target pscalvm

------
https://chatgpt.com/codex/tasks/task_b_68dc1aa98f0083299b6ea02b8524095c