### PR TITLE
Fix integer arguments for game over text position

### DIFF
--- a/Examples/rea/sdl/block_game
+++ b/Examples/rea/sdl/block_game
@@ -453,7 +453,9 @@ class Game {
         
         if (myself.gameOver) {
             str gameOverStr = "GAME OVER - Press Q to quit";
-            outtextxy(BoardX + 10, BoardY + BoardHeight * CellSize / 2 - 20, gameOverStr);
+            outtextxy(BoardX + 10,
+                      BoardY + (BoardHeight * CellSize) div 2 - 20,
+                      gameOverStr);
         }
         
         updatescreen();


### PR DESCRIPTION
## Summary
- ensure the block game passes integer coordinates to `outtextxy` when rendering the game-over message

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dc4b1fdf9c832982815058bc9c8496