### PR TITLE
Read SDL movement keys directly in landscape demos

### DIFF
--- a/Examples/rea/sdl/landscape
+++ b/Examples/rea/sdl/landscape
@@ -1,7 +1,8 @@
 #!/usr/bin/env rea
 // Procedural landscape demo for the Rea front end. Generates a deterministic
 // height field from a seed, renders it with the SDL/OpenGL helpers, and lets
-// the user walk with W/S while steering the camera with the mouse.
+// the user walk with either WASD or the arrow keys while steering the camera
+// with the mouse.
 
 const int WindowWidth = 1280;
 const int WindowHeight = 1024;
@@ -16,6 +17,7 @@ const float MoveSpeed = 18.0;
 const float MaxPitch = 75.0;
 const float MouseYawSensitivity = 0.30;
 const float MousePitchSensitivity = 0.15;
+const float KeyTurnSpeed = 90.0;
 const float DegreesToRadians = 0.017453292519943295;
 const float Pi = 3.141592653589793;
 const float TwoPi = 6.283185307179586;
@@ -25,6 +27,12 @@ const float SunCoreRadius = 18.0;
 const float SunHaloRadius = 34.0;
 const int ScanCodeW = 26; // SDL_SCANCODE_W
 const int ScanCodeS = 22; // SDL_SCANCODE_S
+const int ScanCodeA = 4;  // SDL_SCANCODE_A
+const int ScanCodeD = 7;  // SDL_SCANCODE_D
+const int ScanCodeUp = 82;    // SDL_SCANCODE_UP
+const int ScanCodeDown = 81;  // SDL_SCANCODE_DOWN
+const int ScanCodeLeft = 80;  // SDL_SCANCODE_LEFT
+const int ScanCodeRight = 79; // SDL_SCANCODE_RIGHT
 
 bool hasDigit(str s) {
   int i = 1;
@@ -235,8 +243,6 @@ class LandscapeDemo {
   int lastMouseX;
   int lastMouseY;
   bool hasMouseSample;
-  bool forwardKeyDown;
-  bool backwardKeyDown;
   float vertexHeights[VertexCount];
   float vertexColorR[VertexCount];
   float vertexColorG[VertexCount];
@@ -301,8 +307,6 @@ class LandscapeDemo {
     my.lastMouseX = 0;
     my.lastMouseY = 0;
     my.hasMouseSample = false;
-    my.forwardKeyDown = false;
-    my.backwardKeyDown = false;
   }
 
   bool tryPrecomputeWorldCoordinates() {
@@ -759,7 +763,7 @@ class LandscapeDemo {
     GLViewport(0, 0, WindowWidth, WindowHeight);
     GLSetSwapInterval(1);
     my.setupLighting();
-    writeln("Controls: W/S to move, use the mouse to look around. N/P change seed, R randomizes, Q or Esc exits.");
+    writeln("Controls: W/S or Up/Down to move, A/D or Left/Right to turn, use the mouse to look around. N/P change seed, R randomizes, Q or Esc exits.");
     if (my.useFastTerrain ||
         my.useFastWater ||
         my.useFastWorldCoords ||
@@ -793,11 +797,6 @@ class LandscapeDemo {
   }
 
   void handleDiscreteInput() {
-    // Prime the SDL key watcher before draining the queue so it sees any new
-    // keydown events we are about to consume with pollkey().
-    IsKeyDown(ScanCodeW);
-    IsKeyDown(ScanCodeS);
-
     int key = pollkey();
     while (key != 0) {
       if (key == 'q' || key == 'Q' || key == 27) {
@@ -814,12 +813,6 @@ class LandscapeDemo {
       }
       key = pollkey();
     }
-
-    // Sample the movement keys after pumping events so their latched state
-    // reflects the latest SDL keyboard state even while the mouse is inside
-    // the window.
-    my.forwardKeyDown = IsKeyDown(ScanCodeW);
-    my.backwardKeyDown = IsKeyDown(ScanCodeS);
   }
 
   void drawTerrain() {
@@ -987,8 +980,8 @@ class LandscapeDemo {
       }
     }
 
-    bool forward = my.forwardKeyDown;
-    bool backward = my.backwardKeyDown;
+    bool forward = IsKeyDown(ScanCodeW) || IsKeyDown(ScanCodeUp);
+    bool backward = IsKeyDown(ScanCodeS) || IsKeyDown(ScanCodeDown);
 
     float moveForward = 0.0;
     if (forward) moveForward = moveForward + 1.0;
@@ -1013,6 +1006,15 @@ class LandscapeDemo {
       float deltaZ = forwardZ * (speed / TileScale);
       my.camX = my.camX + deltaX;
       my.camZ = my.camZ + deltaZ;
+    }
+
+    float turnInput = 0.0;
+    bool turnLeft = IsKeyDown(ScanCodeLeft) || IsKeyDown(ScanCodeA);
+    bool turnRight = IsKeyDown(ScanCodeRight) || IsKeyDown(ScanCodeD);
+    if (turnLeft) turnInput = turnInput + 1.0;
+    if (turnRight) turnInput = turnInput - 1.0;
+    if (turnInput != 0.0) {
+      my.yaw = my.yaw + turnInput * KeyTurnSpeed * dt;
     }
 
     if (my.yaw >= 360.0) my.yaw = my.yaw - 360.0;

--- a/Examples/rea/sdl/landscape_simple
+++ b/Examples/rea/sdl/landscape_simple
@@ -1,7 +1,8 @@
 #!/usr/bin/env rea
 // Procedural landscape demo for the Rea front end. Generates a deterministic
 // height field from a seed, renders it with the SDL/OpenGL helpers, and lets
-// the user walk with W/S while steering the camera with the mouse.
+// the user walk with either WASD or the arrow keys while steering the camera
+// with the mouse.
 
 const int WindowWidth = 1600;
 const int WindowHeight = 1200;
@@ -16,9 +17,16 @@ const float MoveSpeed = 18.0;
 const float MaxPitch = 75.0;
 const float MouseYawSensitivity = 0.30;
 const float MousePitchSensitivity = 0.15;
+const float KeyTurnSpeed = 90.0;
 const float DegreesToRadians = 0.017453292519943295;
 const int ScanCodeW = 26; // SDL_SCANCODE_W
 const int ScanCodeS = 22; // SDL_SCANCODE_S
+const int ScanCodeA = 4;  // SDL_SCANCODE_A
+const int ScanCodeD = 7;  // SDL_SCANCODE_D
+const int ScanCodeUp = 82;    // SDL_SCANCODE_UP
+const int ScanCodeDown = 81;  // SDL_SCANCODE_DOWN
+const int ScanCodeLeft = 80;  // SDL_SCANCODE_LEFT
+const int ScanCodeRight = 79; // SDL_SCANCODE_RIGHT
 
 bool hasDigit(str s) {
   int i = 1;
@@ -311,7 +319,7 @@ class LandscapeDemo {
     GLClearDepth(1.0);
     GLDepthTest(true);
     GLSetSwapInterval(1);
-    writeln("Controls: W/S to move, use the mouse to look around. N/P change seed, R randomizes, Q or Esc exits.");
+    writeln("Controls: W/S or Up/Down to move, A/D or Left/Right to turn, use the mouse to look around. N/P change seed, R randomizes, Q or Esc exits.");
     int mouseX = 0;
     int mouseY = 0;
     int mouseButtons = 0;
@@ -408,8 +416,10 @@ class LandscapeDemo {
       }
     }
 
-    bool forward = IsKeyDown(ScanCodeS);
-    bool backward = IsKeyDown(ScanCodeW);
+    bool forward = IsKeyDown(ScanCodeW) || IsKeyDown(ScanCodeUp);
+    bool backward = IsKeyDown(ScanCodeS) || IsKeyDown(ScanCodeDown);
+    bool turnLeft = IsKeyDown(ScanCodeLeft) || IsKeyDown(ScanCodeA);
+    bool turnRight = IsKeyDown(ScanCodeRight) || IsKeyDown(ScanCodeD);
 
     float moveForward = 0.0;
     if (forward) moveForward = moveForward + 1.0;
@@ -423,6 +433,13 @@ class LandscapeDemo {
       float deltaZ = forwardZ * (speed / TileScale);
       my.camX = my.camX + deltaX;
       my.camZ = my.camZ + deltaZ;
+    }
+
+    float turnInput = 0.0;
+    if (turnLeft) turnInput = turnInput + 1.0;
+    if (turnRight) turnInput = turnInput - 1.0;
+    if (turnInput != 0.0) {
+      my.yaw = my.yaw + turnInput * KeyTurnSpeed * dt;
     }
 
     if (my.yaw >= 360.0) my.yaw = my.yaw - 360.0;
@@ -464,6 +481,9 @@ class LandscapeDemo {
     my.initGraphics();
     my.lastTicks = getticks();
     while (my.running) {
+      // Pump SDL events before sampling IsKeyDown so the keyboard state
+      // reflects the latest window input even while the mouse is captured.
+      GraphLoop(0);
       my.handleDiscreteInput();
       if (QuitRequested()) break;
       int now = getticks();


### PR DESCRIPTION
## Summary
- query the WASD and arrow movement/turn keys directly during the full landscape update so SDL focus no longer blocks forward/back input
- simplify the landscape_simple input loop to rely on the same direct IsKeyDown sampling without pre-priming the keyboard state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dc6e7604c48329bcad20dd3a2a67b2