### PR TITLE
Call vertex baking builtin from LandscapeDemo

### DIFF
--- a/Examples/rea/sdl/landscape
+++ b/Examples/rea/sdl/landscape
@@ -220,40 +220,6 @@ class TerrainField {
     return t;
   }
 
-  bool tryBakeVertexData(var float vertexHeights[],
-                         var float vertexNormalX[],
-                         var float vertexNormalY[],
-                         var float vertexNormalZ[],
-                         var float vertexColorR[],
-                         var float vertexColorG[],
-                         var float vertexColorB[],
-                         float waterLevel,
-                         var float waterHeightOut) {
-    if (!hasextbuiltin("user", "LandscapeBakeVertexData")) {
-      return false;
-    }
-    landscapebakevertexdata(my.heights,
-                            vertexHeights,
-                            vertexNormalX,
-                            vertexNormalY,
-                            vertexNormalZ,
-                            vertexColorR,
-                            vertexColorG,
-                            vertexColorB,
-                            waterHeightOut,
-                            my.minHeight,
-                            my.maxHeight,
-                            my.normalizationScale,
-                            waterLevel,
-                            TileScale,
-                            TerrainSize,
-                            VertexStride);
-    if (!(waterHeightOut == waterHeightOut)) {
-      return false;
-    }
-    return true;
-  }
-
   float heightAt(float gx, float gz) {
     if (gx < 0.0) gx = 0.0;
     if (gx > TerrainSize) gx = TerrainSize;
@@ -509,16 +475,34 @@ class LandscapeDemo {
     }
   }
 
+  bool tryBakeVertexData(float waterLevel) {
+    if (!hasextbuiltin("user", "LandscapeBakeVertexData")) {
+      return false;
+    }
+    landscapebakevertexdata(my.field.heights,
+                            my.vertexHeights,
+                            my.vertexNormalX,
+                            my.vertexNormalY,
+                            my.vertexNormalZ,
+                            my.vertexColorR,
+                            my.vertexColorG,
+                            my.vertexColorB,
+                            my.waterHeight,
+                            my.field.minHeight,
+                            my.field.maxHeight,
+                            my.field.normalizationScale,
+                            waterLevel,
+                            TileScale,
+                            TerrainSize,
+                            VertexStride);
+    if (!(my.waterHeight == my.waterHeight)) {
+      return false;
+    }
+    return true;
+  }
+
   void updateVertexData() {
-    if (my.field.tryBakeVertexData(my.vertexHeights,
-                                   my.vertexNormalX,
-                                   my.vertexNormalY,
-                                   my.vertexNormalZ,
-                                   my.vertexColorR,
-                                   my.vertexColorG,
-                                   my.vertexColorB,
-                                   my.waterNormalizedLevel,
-                                   my.waterHeight)) {
+    if (my.tryBakeVertexData(my.waterNormalizedLevel)) {
       return;
     }
     my.computeVertexNormals();


### PR DESCRIPTION
## Summary
- invoke the LandscapeBakeVertexData builtin directly from LandscapeDemo using its vertex buffers
- remove the TerrainField helper that required sized var parameters and keep the NaN guard when the builtin runs

## Testing
- not run (Rea compiler not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68dc8b01da848329a3f393f67468197f