### PR TITLE
Fix landscape builtin min/max height var parameters

### DIFF
--- a/Examples/rea/sdl/landscape
+++ b/Examples/rea/sdl/landscape
@@ -151,15 +151,21 @@ class TerrainField {
     if (!hasextbuiltin("user", "LandscapeBuildHeightField")) {
       return false;
     }
+    float minHeight = 0.0;
+    float maxHeight = 0.0;
+    float normalizationScale = 0.0;
     landscapebuildheightfield(my.heights,
                               s,
                               TerrainSize,
                               VertexStride,
                               HeightScale,
                               NoiseOctaves,
-                              my.minHeight,
-                              my.maxHeight,
-                              my.normalizationScale);
+                              minHeight,
+                              maxHeight,
+                              normalizationScale);
+    my.minHeight = minHeight;
+    my.maxHeight = maxHeight;
+    my.normalizationScale = normalizationScale;
     float sanity = my.heights[0];
     if (!(sanity == sanity)) return false;
     return true;


### PR DESCRIPTION
## Summary
- update the Rea SDL landscape demo to call `landscapebuildheightfield` with local variables for the VAR outputs
- store the generated min/max height data back onto the terrain instance after the builtin returns

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dc969eb2c083299331598b75ec367b