### PR TITLE
Fix Rea landscape input regression and restore terrain rendering

### DIFF
--- a/Examples/rea/sdl/landscape
+++ b/Examples/rea/sdl/landscape
@@ -23,8 +23,8 @@ const int CloudCount = 14;
 const float SunDistance = 220.0;
 const float SunCoreRadius = 18.0;
 const float SunHaloRadius = 34.0;
-const int ScanCodeW = 26; // SDL_SCANCODE_W
-const int ScanCodeS = 22; // SDL_SCANCODE_S
+const str KeyForward = "w";
+const str KeyBackward = "s";
 
 bool hasDigit(str s) {
   int i = 1;
@@ -799,6 +799,7 @@ class LandscapeDemo {
     GLEnable("normalize");
     GLShadeModel("smooth");
     GLColorMaterial("front", "ambient_and_diffuse");
+    GLDisable("cull_face");
 
     GLLightfv("light0", "ambient", 0.20, 0.24, 0.30, 1.0);
     GLLightfv("light0", "diffuse", 0.90, 0.90, 0.88, 1.0);
@@ -851,8 +852,8 @@ class LandscapeDemo {
   void handleDiscreteInput() {
     // Prime the SDL key watcher before draining the queue so it sees any new
     // keydown events we are about to consume with pollkey().
-    IsKeyDown(ScanCodeW);
-    IsKeyDown(ScanCodeS);
+    IsKeyDown(KeyForward);
+    IsKeyDown(KeyBackward);
 
     int key = pollkey();
     while (key != 0) {
@@ -874,8 +875,8 @@ class LandscapeDemo {
     // Sample the movement keys after pumping events so their latched state
     // reflects the latest SDL keyboard state even while the mouse is inside
     // the window.
-    my.forwardKeyDown = IsKeyDown(ScanCodeW);
-    my.backwardKeyDown = IsKeyDown(ScanCodeS);
+    my.forwardKeyDown = IsKeyDown(KeyForward);
+    my.backwardKeyDown = IsKeyDown(KeyBackward);
   }
 
   void drawTerrain() {

--- a/Examples/rea/sdl/landscape_simple
+++ b/Examples/rea/sdl/landscape_simple
@@ -17,8 +17,8 @@ const float MaxPitch = 75.0;
 const float MouseYawSensitivity = 0.30;
 const float MousePitchSensitivity = 0.15;
 const float DegreesToRadians = 0.017453292519943295;
-const int ScanCodeW = 26; // SDL_SCANCODE_W
-const int ScanCodeS = 22; // SDL_SCANCODE_S
+const str KeyForward = "w";
+const str KeyBackward = "s";
 
 bool hasDigit(str s) {
   int i = 1;
@@ -310,6 +310,7 @@ class LandscapeDemo {
     GLViewport(0, 0, WindowWidth, WindowHeight);
     GLClearDepth(1.0);
     GLDepthTest(true);
+    GLDisable("cull_face");
     GLSetSwapInterval(1);
     writeln("Controls: W/S to move, use the mouse to look around. N/P change seed, R randomizes, Q or Esc exits.");
     int mouseX = 0;
@@ -408,8 +409,8 @@ class LandscapeDemo {
       }
     }
 
-    bool forward = IsKeyDown(ScanCodeS);
-    bool backward = IsKeyDown(ScanCodeW);
+    bool forward = IsKeyDown(KeyForward);
+    bool backward = IsKeyDown(KeyBackward);
 
     float moveForward = 0.0;
     if (forward) moveForward = moveForward + 1.0;
@@ -464,6 +465,7 @@ class LandscapeDemo {
     my.initGraphics();
     my.lastTicks = getticks();
     while (my.running) {
+      GraphLoop(0);
       my.handleDiscreteInput();
       if (QuitRequested()) break;
       int now = getticks();


### PR DESCRIPTION
## Summary
- switch the SDL landscape demos to use named key lookups so the W/S movement controls keep working with the updated runtime keyboard handling
- disable face culling in both demos to restore the intended terrain rendering after the recent OpenGL state changes
- pump SDL events at the start of the simple landscape loop to keep keyboard state fresh before sampling movement keys

## Testing
- not run (SDL examples require an interactive environment)


------
https://chatgpt.com/codex/tasks/task_b_68dc9efc8fb08329b67eb934a34bc631