### PR TITLE
Add SDL OpenGL CullFace builtin

### DIFF
--- a/src/backend_ast/gl.c
+++ b/src/backend_ast/gl.c
@@ -1064,6 +1064,23 @@ Value vmBuiltinGldepthtest(VM* vm, int arg_count, Value* args) {
     return makeVoid();
 }
 
+Value vmBuiltinGlcullface(VM* vm, int arg_count, Value* args) {
+    if (arg_count != 1) {
+        runtimeError(vm, "GLCullFace expects 1 argument (face mode).");
+        return makeVoid();
+    }
+    if (!ensureGlContext(vm, "GLCullFace")) return makeVoid();
+
+    GLenum mode;
+    if (!parseMaterialFace(args[0], &mode)) {
+        runtimeError(vm, "GLCullFace argument must be 'front', 'back', 'front_and_back', or a GLenum value.");
+        return makeVoid();
+    }
+
+    glCullFace(mode);
+    return makeVoid();
+}
+
 Value vmBuiltinGlishardwareaccelerated(VM* vm, int arg_count, Value* args) {
     if (arg_count != 0) {
         runtimeError(vm, "GLIsHardwareAccelerated does not take any arguments.");

--- a/src/backend_ast/gl.h
+++ b/src/backend_ast/gl.h
@@ -17,6 +17,7 @@ Value vmBuiltinGlcleardepth(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinGlcolor3f(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinGlcolor4f(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinGldepthtest(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinGlcullface(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinGlend(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinGlenable(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinGldisable(struct VM_s* vm, int arg_count, Value* args);

--- a/src/ext_builtins/graphics/register.c
+++ b/src/ext_builtins/graphics/register.c
@@ -95,6 +95,7 @@ static const GraphicsBuiltin graphics_builtins[] = {
     {"opengl", "GLNormal3f", "glnormal3f", BUILTIN_TYPE_PROCEDURE, vmBuiltinGlnormal3f},
     {"opengl", "GLEnable", "glenable", BUILTIN_TYPE_PROCEDURE, vmBuiltinGlenable},
     {"opengl", "GLDisable", "gldisable", BUILTIN_TYPE_PROCEDURE, vmBuiltinGldisable},
+    {"opengl", "GLCullFace", "glcullface", BUILTIN_TYPE_PROCEDURE, vmBuiltinGlcullface},
     {"opengl", "GLShadeModel", "glshademodel", BUILTIN_TYPE_PROCEDURE, vmBuiltinGlshademodel},
     {"opengl", "GLLightfv", "gllightfv", BUILTIN_TYPE_PROCEDURE, vmBuiltinGllightfv},
     {"opengl", "GLMaterialfv", "glmaterialfv", BUILTIN_TYPE_PROCEDURE, vmBuiltinGlmaterialfv},


### PR DESCRIPTION
## Summary
- expose the SDL OpenGL `GLCullFace` routine through the extended graphics builtin registry
- implement the VM handler that validates the face argument and calls `glCullFace`
- declare the handler for inclusion with the other OpenGL helpers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dd4dbde3e48329b2bb1655e4ce51e3