### PR TITLE
Enhance Rea landscape sky visuals

### DIFF
--- a/Examples/rea/sdl/landscape
+++ b/Examples/rea/sdl/landscape
@@ -27,6 +27,8 @@ const int CloudCount = 14;
 const float SunDistance = 220.0;
 const float SunCoreRadius = 18.0;
 const float SunHaloRadius = 34.0;
+const float SkyDomeRadius = 260.0;
+const int LensFlareElementCount = 6;
 const int ScanCodeW = 26; // SDL_SCANCODE_W
 const int ScanCodeS = 22; // SDL_SCANCODE_S
 const int ScanCodeA = 4;  // SDL_SCANCODE_A
@@ -390,6 +392,7 @@ class LandscapeDemo {
   float cloudPrimaryRadius[CloudCount];
   float cloudVerticalRadius[CloudCount];
   float cloudClusterSpread[CloudCount];
+  float cloudParallaxWeight[CloudCount];
 
   void LandscapeDemo(int initialSeed) {
     my.field = new TerrainField();
@@ -599,18 +602,28 @@ class LandscapeDemo {
       float brightNoise = my.skyRandom(i, 101);
       float rollNoise = my.skyRandom(i, 121);
       float puffNoise = my.skyRandom(i, 151);
+      int layerIndex = i % 2;
+      float parallaxWeight = 0.45 + layerIndex * 0.45 + my.skyRandom(i, 167) * 0.12;
       my.cloudAzimuth[i] = azNoise * TwoPi;
-      my.cloudElevation[i] = 0.16 + elevNoise * 0.20;
-      my.cloudDistance[i] = 150.0 + distNoise * 90.0;
-      my.cloudScale[i] = 15.0 + scaleNoise * 20.0;
-      my.cloudSpeed[i] = 0.002 + speedNoise * 0.006;
-      my.cloudBrightness[i] = 0.68 + brightNoise * 0.26;
+      if (layerIndex == 0) {
+        my.cloudElevation[i] = 0.18 + elevNoise * 0.22;
+        my.cloudDistance[i] = SkyDomeRadius * (0.55 + distNoise * 0.18);
+        my.cloudScale[i] = 22.0 + scaleNoise * 26.0;
+        my.cloudSpeed[i] = 0.0030 + speedNoise * 0.0065;
+      } else {
+        my.cloudElevation[i] = 0.30 + elevNoise * 0.28;
+        my.cloudDistance[i] = SkyDomeRadius * (0.80 + distNoise * 0.26);
+        my.cloudScale[i] = 16.0 + scaleNoise * 20.0;
+        my.cloudSpeed[i] = 0.0015 + speedNoise * 0.0045;
+      }
+      my.cloudBrightness[i] = 0.66 + brightNoise * 0.28 + layerIndex * 0.05;
       my.cloudRoll[i] = rollNoise * TwoPi;
-      my.cloudPuffCount[i] = 3 + floor(puffNoise * 4.0);
+      my.cloudPuffCount[i] = 3 + floor(puffNoise * 5.0);
       if (my.cloudPuffCount[i] < 3) my.cloudPuffCount[i] = 3;
-      my.cloudPrimaryRadius[i] = 0.50 + my.skyRandom(i, 167) * 0.32;
-      my.cloudVerticalRadius[i] = 0.34 + my.skyRandom(i, 181) * 0.28;
-      my.cloudClusterSpread[i] = 0.32 + my.skyRandom(i, 193) * 0.55;
+      my.cloudPrimaryRadius[i] = 0.52 + my.skyRandom(i, 193) * 0.30;
+      my.cloudVerticalRadius[i] = 0.36 + my.skyRandom(i, 181) * 0.30;
+      my.cloudClusterSpread[i] = 0.34 + my.skyRandom(i, 205) * 0.55;
+      my.cloudParallaxWeight[i] = parallaxWeight;
       i = i + 1;
     }
   }
@@ -904,28 +917,196 @@ class LandscapeDemo {
                      float upY,
                      float upZ,
                      float brightness) {
-    int segments = 24;
-    float highlight = my.saturate(0.86 + brightness * 0.20);
-    float rim = my.saturate(0.78 + brightness * 0.18);
+    int segments = 28;
+    float highlight = my.saturate(0.82 + brightness * 0.26);
+    float rim = my.saturate(0.72 + brightness * 0.22);
+    float rimAlpha = 0.12 + brightness * 0.16;
     GLBegin("triangle_fan");
-    GLColor4f(highlight, highlight, highlight + 0.05, 0.75);
+    GLColor4f(highlight, highlight, highlight + 0.06, 0.78);
     GLVertex3f(centerX, centerY, centerZ);
     int i = 0;
     while (i <= segments) {
       float angle = i * (TwoPi / segments);
       float cosA = cos(angle);
       float sinA = sin(angle);
-      float px = centerX + rightX * (cosA * radiusX) + upX * (sinA * radiusY);
-      float py = centerY + rightY * (cosA * radiusX) + upY * (sinA * radiusY);
-      float pz = centerZ + rightZ * (cosA * radiusX) + upZ * (sinA * radiusY);
-      GLColor4f(rim, rim, rim + 0.03, 0.0);
+      float distortion = 1.0 + sin(angle * 2.7 + brightness * 1.4) * 0.08;
+      float px = centerX + rightX * (cosA * radiusX * distortion) +
+                 upX * (sinA * radiusY * distortion);
+      float py = centerY + rightY * (cosA * radiusX * distortion) +
+                 upY * (sinA * radiusY * distortion);
+      float pz = centerZ + rightZ * (cosA * radiusX * distortion) +
+                 upZ * (sinA * radiusY * distortion);
+      float rimTint = my.saturate(rim + sin(angle * 5.0) * 0.04);
+      GLColor4f(rimTint, rimTint, rimTint + 0.04, rimAlpha * 0.25);
       GLVertex3f(px, py, pz);
       i = i + 1;
     }
     GLEnd();
   }
 
+  void drawLensFlare(float timeSeconds,
+                     float forwardX,
+                     float forwardY,
+                     float forwardZ,
+                     float rightX,
+                     float rightY,
+                     float rightZ,
+                     float upX,
+                     float upY,
+                     float upZ) {
+    float sunForward = my.sunDirX * forwardX +
+                       my.sunDirY * forwardY +
+                       my.sunDirZ * forwardZ;
+    if (sunForward <= 0.05) return;
+    float screenX = my.sunDirX * rightX + my.sunDirY * rightY + my.sunDirZ * rightZ;
+    float screenY = my.sunDirX * upX + my.sunDirY * upY + my.sunDirZ * upZ;
+    float lensVecX = -screenX;
+    float lensVecY = -screenY;
+    float lensLen = sqrt(lensVecX * lensVecX + lensVecY * lensVecY);
+    if (lensLen <= 0.0001) {
+      lensVecX = 1.0;
+      lensVecY = 0.0;
+      lensLen = 1.0;
+    }
+    lensVecX = lensVecX / lensLen;
+    lensVecY = lensVecY / lensLen;
+    float lensPerpX = -lensVecY;
+    float lensPerpY = lensVecX;
+    float baseIntensity = my.saturate((sunForward - 0.08) * 1.35);
+    if (baseIntensity <= 0.01) return;
+
+    float offsets[LensFlareElementCount];
+    float scales[LensFlareElementCount];
+    float colorR[LensFlareElementCount];
+    float colorG[LensFlareElementCount];
+    float colorB[LensFlareElementCount];
+    float alphaScale[LensFlareElementCount];
+
+    offsets[0] = 0.0;
+    offsets[1] = 0.32;
+    offsets[2] = 0.68;
+    offsets[3] = -0.28;
+    offsets[4] = 1.08;
+    offsets[5] = -1.36;
+
+    scales[0] = SunHaloRadius * 0.55;
+    scales[1] = SunCoreRadius * 0.45;
+    scales[2] = SunHaloRadius * 0.34;
+    scales[3] = SunCoreRadius * 0.58;
+    scales[4] = SunHaloRadius * 0.48;
+    scales[5] = SunCoreRadius * 0.40;
+
+    colorR[0] = 1.0;   colorG[0] = 0.92;  colorB[0] = 0.70;  alphaScale[0] = 0.38;
+    colorR[1] = 0.95;  colorG[1] = 0.78;  colorB[1] = 0.55;  alphaScale[1] = 0.26;
+    colorR[2] = 0.88;  colorG[2] = 0.72;  colorB[2] = 0.60;  alphaScale[2] = 0.22;
+    colorR[3] = 0.92;  colorG[3] = 0.68;  colorB[3] = 0.90;  alphaScale[3] = 0.20;
+    colorR[4] = 0.80;  colorG[4] = 0.90;  colorB[4] = 1.00;  alphaScale[4] = 0.18;
+    colorR[5] = 0.74;  colorG[5] = 0.84;  colorB[5] = 0.98;  alphaScale[5] = 0.16;
+
+    GLBlendFunc("src_alpha", "one");
+
+    int element = 0;
+    while (element < LensFlareElementCount) {
+      float offset = offsets[element];
+      float flicker = 0.65 + 0.35 * sin(timeSeconds * 1.35 + offset * 4.2);
+      float elementAlpha = baseIntensity * alphaScale[element] * flicker;
+      if (elementAlpha > 0.001) {
+        float elementScreenX = screenX + lensVecX * offset;
+        float elementScreenY = screenY + lensVecY * offset;
+        float elementForward = sunForward + offset * 0.02;
+        float dirX = forwardX * elementForward +
+                     rightX * elementScreenX +
+                     upX * elementScreenY;
+        float dirY = forwardY * elementForward +
+                     rightY * elementScreenX +
+                     upY * elementScreenY;
+        float dirZ = forwardZ * elementForward +
+                     rightZ * elementScreenX +
+                     upZ * elementScreenY;
+        float dirLen = sqrt(dirX * dirX + dirY * dirY + dirZ * dirZ);
+        if (dirLen > 0.0001) {
+          dirX = dirX / dirLen;
+          dirY = dirY / dirLen;
+          dirZ = dirZ / dirLen;
+          float distance = SunDistance * (1.0 + absf(offset) * 0.12);
+          float centerX = dirX * distance;
+          float centerY = dirY * distance;
+          float centerZ = dirZ * distance;
+          float flareRightX = rightX * lensVecX + upX * lensVecY;
+          float flareRightY = rightY * lensVecX + upY * lensVecY;
+          float flareRightZ = rightZ * lensVecX + upZ * lensVecY;
+          float rightLen = sqrt(flareRightX * flareRightX +
+                                flareRightY * flareRightY +
+                                flareRightZ * flareRightZ);
+          if (rightLen <= 0.0001) {
+            flareRightX = rightX;
+            flareRightY = rightY;
+            flareRightZ = rightZ;
+            rightLen = 1.0;
+          }
+          flareRightX = flareRightX / rightLen;
+          flareRightY = flareRightY / rightLen;
+          flareRightZ = flareRightZ / rightLen;
+
+          float flareUpX = rightX * lensPerpX + upX * lensPerpY;
+          float flareUpY = rightY * lensPerpX + upY * lensPerpY;
+          float flareUpZ = rightZ * lensPerpX + upZ * lensPerpY;
+          float upLen = sqrt(flareUpX * flareUpX +
+                             flareUpY * flareUpY +
+                             flareUpZ * flareUpZ);
+          if (upLen <= 0.0001) {
+            flareUpX = upX;
+            flareUpY = upY;
+            flareUpZ = upZ;
+            upLen = 1.0;
+          }
+          flareUpX = flareUpX / upLen;
+          flareUpY = flareUpY / upLen;
+          flareUpZ = flareUpZ / upLen;
+
+          float radius = scales[element] * (0.9 + absf(offset) * 0.25);
+          float aspect = 0.85 + absf(offset) * 0.30;
+
+          int segments = 16;
+          GLBegin("triangle_fan");
+          GLColor4f(colorR[element],
+                    colorG[element],
+                    colorB[element],
+                    elementAlpha);
+          GLVertex3f(centerX, centerY, centerZ);
+          int j = 0;
+          while (j <= segments) {
+            float angle = j * (TwoPi / segments);
+            float cosA = cos(angle);
+            float sinA = sin(angle);
+            float offsetX = flareRightX * (cosA * radius) +
+                            flareUpX * (sinA * radius * aspect);
+            float offsetY = flareRightY * (cosA * radius) +
+                            flareUpY * (sinA * radius * aspect);
+            float offsetZ = flareRightZ * (cosA * radius) +
+                            flareUpZ * (sinA * radius * aspect);
+            GLColor4f(colorR[element],
+                      colorG[element],
+                      colorB[element],
+                      0.0);
+            GLVertex3f(centerX + offsetX,
+                       centerY + offsetY,
+                       centerZ + offsetZ);
+            j = j + 1;
+          }
+          GLEnd();
+        }
+      }
+      element = element + 1;
+    }
+
+    GLBlendFunc("src_alpha", "one_minus_src_alpha");
+  }
+
   void drawCloudLayer(float timeSeconds,
+                      float forwardX,
+                      float forwardY,
+                      float forwardZ,
                       float rightX,
                       float rightY,
                       float rightZ,
@@ -948,10 +1129,23 @@ class LandscapeDemo {
       float baseScale = my.cloudScale[i];
       float baseBrightness = my.cloudBrightness[i];
       float sunInfluence = my.sunDirX * dirX + my.sunDirY * dirY + my.sunDirZ * dirZ;
-      float puffBrightness = my.saturate(baseBrightness + sunInfluence * 0.18);
+      float horizonLift = my.saturate((elevation - 0.10) * 2.6);
+      float puffBrightness = my.saturate(baseBrightness * (0.72 + horizonLift * 0.28) +
+                                         sunInfluence * 0.24);
+      float parallax = my.cloudParallaxWeight[i];
+      float camOffsetX = (my.camX - TerrainSize * 0.5) * TileScale;
+      float camOffsetZ = (my.camZ - TerrainSize * 0.5) * TileScale;
+      float offsetRight = (camOffsetX * rightX + camOffsetZ * rightZ) * 0.35 * parallax;
+      float offsetForward = (camOffsetX * forwardX + camOffsetZ * forwardZ) * 0.20 * parallax;
+      float offsetUp = (camOffsetX * upX + camOffsetZ * upZ) * 0.08 * parallax;
+      centerX = centerX + rightX * offsetRight + forwardX * offsetForward;
+      centerY = centerY + rightY * offsetRight + forwardY * offsetForward + upY * offsetUp;
+      centerZ = centerZ + rightZ * offsetRight + forwardZ * offsetForward + upZ * offsetUp;
+      float wobble = sin(timeSeconds * 0.25 + my.cloudRoll[i]) * 0.4 * parallax;
+      centerY = centerY + wobble;
       float radiusX = baseScale * my.cloudPrimaryRadius[i];
       float radiusY = baseScale * my.cloudVerticalRadius[i];
-      float clusterSpread = baseScale * my.cloudClusterSpread[i];
+      float clusterSpread = baseScale * my.cloudClusterSpread[i] * (0.85 + parallax * 0.3);
       float roll = my.cloudRoll[i];
       float cosRoll = cos(roll);
       float sinRoll = sin(roll);
@@ -1064,7 +1258,26 @@ class LandscapeDemo {
       upZ = upZ / upLen;
     }
     my.drawSunBillboard(rightX, rightY, rightZ, upX, upY, upZ);
-    my.drawCloudLayer(timeSeconds, rightX, rightY, rightZ, upX, upY, upZ);
+    my.drawLensFlare(timeSeconds,
+                     forwardX,
+                     forwardY,
+                     forwardZ,
+                     rightX,
+                     rightY,
+                     rightZ,
+                     upX,
+                     upY,
+                     upZ);
+    my.drawCloudLayer(timeSeconds,
+                      forwardX,
+                      forwardY,
+                      forwardZ,
+                      rightX,
+                      rightY,
+                      rightZ,
+                      upX,
+                      upY,
+                      upZ);
   }
 
   void setupLighting() {


### PR DESCRIPTION
## Summary
- Layer clouds into near and far groups with parallax-aware offsets, updated noise parameters, and brighter shading
- Distort individual cloud puffs for softer silhouettes and add a screen-space lens flare effect for the sun
- Integrate the new lens flare and cloud parallax rendering into the sky draw routine

## Testing
- not run (demo only)


------
https://chatgpt.com/codex/tasks/task_b_68dd8cc609a48329b65668a8c146ce91