### PR TITLE
Allow match identifiers in Rea parser

### DIFF
--- a/src/rea/parser.c
+++ b/src/rea/parser.c
@@ -507,6 +507,7 @@ static bool looksLikeCallTypeArguments(ReaParser *p);
 static AST *parseMatch(ReaParser *p);
 static AST *parseTry(ReaParser *p);
 static AST *parseThrow(ReaParser *p);
+static bool tokenIsIdentifierLike(ReaTokenType t);
 
 // Access to global type table provided by Pascal front end
 AST *lookupType(const char* name);


### PR DESCRIPTION
## Summary
- treat the Rea `match` keyword as an identifier when it appears in declaration or expression contexts
- add a lookahead helper so real match statements are still detected while allowing names like `match`

## Testing
- python3 Tests/libs/rea/run_tests.py *(fails: Rea executable not found)*

------
https://chatgpt.com/codex/tasks/task_b_68dd9c09a83c8329b5ae78ffa2ddc0c7