### PR TITLE
Add Pascal demo for OpenAI responses API

### DIFF
--- a/Examples/pascal/base/OpenAINewApiDemo
+++ b/Examples/pascal/base/OpenAINewApiDemo
@@ -1,0 +1,69 @@
+#!/usr/bin/env pascal
+program OpenAINewApiDemo;
+
+uses OpenAI, SysUtils;
+
+function LoadApiKey(): string;
+begin
+  LoadApiKey := GetEnv('OPENAI_API_KEY');
+  if LoadApiKey = '' then
+  begin
+    writeln('Error: OPENAI_API_KEY environment variable is not set.');
+  end;
+end;
+
+function BuildUserPrompt(): string;
+var
+  I: integer;
+  Parts: string;
+begin
+  if ParamCount = 0 then
+  begin
+    BuildUserPrompt :=
+      'Give me a short bullet list of ways to explore the PSCAL project.';
+    exit;
+  end;
+
+  Parts := '';
+  for I := 1 to ParamCount do
+  begin
+    if Parts <> '' then
+      Parts := Parts + ' ';
+    Parts := Parts + ParamStr(I);
+  end;
+  BuildUserPrompt := Parts;
+end;
+
+procedure PrintIntro(const Model, BaseUrl: string);
+begin
+  writeln('--- PSCAL OpenAI Responses Demo ---');
+  writeln('Model    : ', Model);
+  writeln('Endpoint : ', BaseUrl, '/chat/completions');
+  writeln;
+end;
+
+var
+  Model, BaseUrl, OptionsJson, ApiKey: string;
+  SystemPrompt, UserPrompt, Reply: string;
+begin
+  Model := 'gpt-4.1-mini';
+  BaseUrl := 'http://192.168.110.209:1234/v1';
+  OptionsJson := '{"temperature":0.7,"max_tokens":200}';
+  SystemPrompt := 'You are a concise assistant helping developers learn PSCAL.''s runtime.';
+  UserPrompt := BuildUserPrompt();
+
+  ApiKey := LoadApiKey();
+  if ApiKey = '' then
+    halt(1);
+
+  PrintIntro(Model, BaseUrl);
+  writeln('System prompt: ', SystemPrompt);
+  writeln('User prompt  : ', UserPrompt);
+  writeln;
+
+  Reply := OpenAIChatWithOptions(Model, SystemPrompt, UserPrompt,
+    OptionsJson, ApiKey, BaseUrl);
+
+  writeln('Assistant reply:');
+  writeln(Reply);
+end.


### PR DESCRIPTION
## Summary
- add a Pascal example that demonstrates calling the OpenAI chat completions builtin
- show how to target the new server endpoint and pass options for temperature and token limits
- include helper routines for loading prompts and API keys

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68ddfc92dcc8832994f2fecda35ed126