### PR TITLE
Auto-detect LM Studio model slug for chat demo

### DIFF
--- a/Examples/rea/base/openai_chat_demo
+++ b/Examples/rea/base/openai_chat_demo
@@ -624,6 +624,25 @@ str collectModelIds(str json) {
   return result;
 }
 
+str extractFirstModelId(str modelList) {
+  str trimmedList = trim(modelList);
+  if (trimmedList == "") {
+    return "";
+  }
+  int len = length(trimmedList);
+  int index = 1;
+  str first = "";
+  while (index <= len) {
+    char ch = trimmedList[index];
+    if (ch == ',') {
+      break;
+    }
+    first = first + charToString(ch);
+    index = index + 1;
+  }
+  return trim(first);
+}
+
 str composeMessages(str systemPrompt, str userPrompt) {
   str result = "[";
   if (length(systemPrompt) > 0) {
@@ -689,6 +708,68 @@ str buildUrl(str baseUrl, str endpoint) {
   str prefix = trimTrailingSlash(base);
   str suffix = ensureLeadingSlash(trimmedEndpoint);
   return prefix + suffix;
+}
+
+str autoDetectLmStudioModel(str baseUrl, str apiKey, str userAgent) {
+  str modelsUrl = buildUrl(baseUrl, "/v1/models");
+  int session = httpsession();
+  if (session < 0) {
+    writeln("Error: Unable to allocate an HTTP session for LM Studio model discovery.");
+    return "";
+  }
+
+  httpsetoption(session, "timeout_ms", DEFAULT_TIMEOUT_MS);
+  httpsetheader(session, "Accept", "application/json");
+  if (userAgent != "") {
+    httpsetheader(session, "User-Agent", userAgent);
+  }
+  if (apiKey != "") {
+    httpsetheader(session, "Authorization", "Bearer " + apiKey);
+  }
+
+  mstream out = mstreamcreate();
+  int status = httprequest(session, "GET", modelsUrl, nil, out);
+  str responseBody = mstreambuffer(out);
+
+  if (status < 0) {
+    writeln("Error: Unable to query LM Studio model list (status ", status, ").");
+    int errCode = httperrorcode(session);
+    str errMsg = httplasterror(session);
+    if (errCode != 0) {
+      writeln("HTTP error code: ", errCode);
+    }
+    if (errMsg != "") {
+      writeln("HTTP error message: ", errMsg);
+    }
+    mstreamfree(out);
+    httpclose(session);
+    return "";
+  }
+
+  if (status < 200 || status >= 300) {
+    writeln("Error: LM Studio returned HTTP status ", status, " when listing models.");
+    if (responseBody != "") {
+      writeln("Response: ", responseBody);
+    }
+    mstreamfree(out);
+    httpclose(session);
+    return "";
+  }
+
+  str allModels = collectModelIds(responseBody);
+  str firstModel = extractFirstModelId(allModels);
+  if (firstModel == "") {
+    writeln("Error: LM Studio did not report any loaded models. Load a model in the API panel and retry.");
+    mstreamfree(out);
+    httpclose(session);
+    return "";
+  }
+
+  writeln("Info: Auto-detected LM Studio model '", firstModel, "'. Use --model to override.");
+
+  mstreamfree(out);
+  httpclose(session);
+  return firstModel;
 }
 
 bool verifyLmStudioModel(str baseUrl, str apiKey, str userAgent, str modelId) {
@@ -902,8 +983,16 @@ int main() {
     if (!endpointExplicit) {
       endpointOverride = "/v1/chat/completions";
     }
-    if (!verifyLmStudioModel(baseUrl, apiKey, userAgent, model)) {
-      return 1;
+    if (model == "") {
+      model = autoDetectLmStudioModel(baseUrl, apiKey, userAgent);
+      model = trim(model);
+      if (model == "") {
+        return 1;
+      }
+    } else {
+      if (!verifyLmStudioModel(baseUrl, apiKey, userAgent, model)) {
+        return 1;
+      }
     }
   }
 

--- a/Examples/rea/base/openai_chat_demo
+++ b/Examples/rea/base/openai_chat_demo
@@ -51,6 +51,14 @@ bool isDigit(char ch) {
   return ch >= '0' && ch <= '9';
 }
 
+bool hasEnvValue(str name) {
+  if (name == "") {
+    return false;
+  }
+  str value = getenv(name);
+  return value != "";
+}
+
 bool isValidNumber(str value) {
   int len = length(value);
   if (len == 0) {
@@ -845,6 +853,7 @@ int main() {
   str model;
   setlength(model, 0);
   model = resolveEnvOrDefault("LLM_MODEL", "OPENAI_MODEL", DEFAULT_MODEL);
+  bool modelExplicit = hasEnvValue("LLM_MODEL") || hasEnvValue("OPENAI_MODEL");
   str baseUrl;
   setlength(baseUrl, 0);
   baseUrl = resolveEnvOrDefault("LLM_API_BASE_URL", "OPENAI_BASE_URL", DEFAULT_BASE_URL);
@@ -884,6 +893,7 @@ int main() {
       }
       str modelArg = paramstr(i + 1);
       model = duplicateString(modelArg);
+      modelExplicit = true;
       i = i + 2;
       continue;
     } else if (arg == "--system") {
@@ -983,7 +993,7 @@ int main() {
     if (!endpointExplicit) {
       endpointOverride = "/v1/chat/completions";
     }
-    if (model == "") {
+    if (!modelExplicit) {
       model = autoDetectLmStudioModel(baseUrl, apiKey, userAgent);
       model = trim(model);
       if (model == "") {


### PR DESCRIPTION
## Summary
- add helpers to parse the LM Studio model list and grab the first model identifier
- auto-detect a model when the LM Studio preset is used without an explicit --model flag, while preserving verification for explicit selections

## Testing
- not run (rea interpreter unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68de947112bc8329a547721d8c0441b3