### PR TITLE
Add VM shell execution builtins and docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,6 +235,7 @@ set(PSCAL_SOURCES
     src/Pascal/lexer.c src/Pascal/parser.c src/ast/ast.c src/Pascal/opt.c
     src/symbol/symbol.c
     src/backend_ast/builtin.c
+    src/backend_ast/shell.c
     src/backend_ast/builtin_network_api.c
     src/compiler/bytecode.c src/compiler/compiler.c
     src/core/cache.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -425,7 +425,7 @@ set(CLIKE_SOURCES
     src/core/utils.c src/core/types.c src/core/list.c src/core/preproc.c src/core/version.c src/core/cache.c
     src/compiler/bytecode.c
     src/vm/vm.c
-    src/backend_ast/builtin.c src/backend_ast/builtin_network_api.c
+    src/backend_ast/builtin.c src/backend_ast/shell.c src/backend_ast/builtin_network_api.c
     src/symbol/symbol.c
     src/clike/stubs.c
 )
@@ -543,7 +543,7 @@ set(REA_SOURCES
     src/compiler/bytecode.c
     src/compiler/compiler.c
     src/vm/vm.c
-    src/backend_ast/builtin.c src/backend_ast/builtin_network_api.c
+    src/backend_ast/builtin.c src/backend_ast/shell.c src/backend_ast/builtin_network_api.c
     src/symbol/symbol.c
 )
 
@@ -639,7 +639,7 @@ set(JSON2BC_SOURCES
     src/ast/ast.c
     src/core/utils.c src/core/types.c src/core/list.c src/core/version.c src/core/cache.c
     src/compiler/bytecode.c src/compiler/compiler.c
-    src/backend_ast/builtin.c src/backend_ast/builtin_network_api.c
+    src/backend_ast/builtin.c src/backend_ast/shell.c src/backend_ast/builtin_network_api.c
     src/backend_ast/sdl.c src/backend_ast/sdl3d.c src/backend_ast/gl.c src/backend_ast/audio.c
     src/symbol/symbol.c
     src/vm/vm.c

--- a/Docs/extended_builtins.md
+++ b/Docs/extended_builtins.md
@@ -19,7 +19,7 @@ The project currently ships several optional built‑in groups:
 | Category | Location | Groups |
 | -------- | -------- | ------ |
 | **Math** | `src/ext_builtins/math` | `series` (`Factorial`, `Fibonacci`), `fractal` (`MandelbrotRow`), `constants` (`Chudnovsky`) |
-| **System** | `src/ext_builtins/system` | `filesystem` (`FileExists`), `process` (`GetPid`), `timing` (`RealTimeClock`), `utility` (`Swap`) |
+| **System** | `src/ext_builtins/system` | `filesystem` (`FileExists`), `process` (`GetPid`), `timing` (`RealTimeClock`), `utility` (`Swap`), `shell` (`__shell_exec`, `__shell_pipeline`, `__shell_and`, `__shell_or`, `__shell_subshell`, `__shell_loop`, `__shell_if`, `cd`, `pwd`, `exit`, `export`, `unset`, `alias`) |
 | **Strings** | `src/ext_builtins/strings` | `conversion` (`Atoi`) |
 | **Yyjson** | `src/ext_builtins/yyjson` | `document` (`YyjsonRead`, `YyjsonReadFile`, `YyjsonDocFree`), `query` (`YyjsonFreeValue`, `YyjsonGetRoot`, `YyjsonGetKey`, `YyjsonGetIndex`, `YyjsonGetLength`, `YyjsonGetType`), `primitives` (`YyjsonGetString`, `YyjsonGetNumber`, `YyjsonGetInt`, `YyjsonGetBool`, `YyjsonIsNull`) |
 | **Sqlite** | `src/ext_builtins/sqlite` | `connection` (`SqliteOpen`, `SqliteClose`, `SqliteExec`, `SqliteErrMsg`, `SqliteLastInsertRowId`, `SqliteChanges`), `statement` (`SqlitePrepare`, `SqliteFinalize`, `SqliteStep`, `SqliteReset`, `SqliteClearBindings`), `metadata` (`SqliteColumnCount`, `SqliteColumnType`, `SqliteColumnName`), `results` (`SqliteColumnInt`, `SqliteColumnDouble`, `SqliteColumnText`), `binding` (`SqliteBindText`, `SqliteBindInt`, `SqliteBindDouble`, `SqliteBindNull`) |
@@ -63,6 +63,29 @@ argument is empty the runtime falls back to the `OPENAI_API_KEY` environment
 variable. All three front ends ship helper libraries that build message arrays,
 invoke the builtin, and extract the assistant's response text for quick
 integration.
+
+### Shell orchestration built-ins
+
+The system category now enumerates a `shell` group that mirrors the runtime
+helpers used by the standalone shell front end. These routines are implemented
+inside the VM, so scripts can orchestrate processes without spawning additional
+interpreters.
+
+- `__shell_exec(meta, ...)` launches a single command, honouring simple
+  redirections encoded in its argument vector and optionally running in the
+  background.
+- `__shell_pipeline(meta)` initialises pipeline state so the subsequent
+  `__shell_exec` calls connect their standard streams via POSIX pipes. Background
+  pipelines are registered with the VM's job table for later polling.
+- Logical helpers (`__shell_and`, `__shell_or`, `__shell_subshell`,
+  `__shell_loop`, `__shell_if`) allow the compiler to model complex control
+  structures without embedding host-specific branching.
+- Classic shell utilities (`cd`, `pwd`, `exit`, `export`, `unset`, `alias`) run
+  entirely inside the interpreter so callers avoid forking when they need to
+  mutate the current environment.
+
+Although primarily targeted by the shell front end, these routines are exposed
+to every VM client via the builtin registry and host function table.
 
 ## Discovering available categories at runtime
 

--- a/Docs/pscal_vm_builtins.md
+++ b/Docs/pscal_vm_builtins.md
@@ -112,6 +112,24 @@ VM. For instructions on adding your own routines, see
 | unlock | (mid: Integer) | void | Release the specified mutex. |
 | destroy | (mid: Integer) | void | Destroy the specified mutex. |
 
+## Shell orchestration
+
+| Name | Parameters | Returns | Description |
+| ---- | ---------- | ------- | ----------- |
+| __shell_exec | (meta: String, argv: String...) | void | Launch a process described by the metadata/argument vector. Supports `bg=1` metadata for background execution and simple `<`, `>`, `>>` redirections encoded as argument tokens. |
+| __shell_pipeline | (meta: String) | void | Initialise pipeline state before emitting a sequence of `__shell_exec` calls. The metadata string carries the stage count and negation flag. |
+| __shell_and | (meta: String) | void | Update the shell status for `&&` lists. Primarily used by the shell compiler. |
+| __shell_or | (meta: String) | void | Update the shell status for `||` lists. Primarily used by the shell compiler. |
+| __shell_subshell | (meta: String) | void | Reset pipeline/bookkeeping before running a subshell block. |
+| __shell_loop | (meta: String) | void | Reset pipeline/bookkeeping before running a loop body. |
+| __shell_if | (meta: String) | void | Reset pipeline/bookkeeping before running a conditional branch. |
+| cd | (path: String) | void | Change the current working directory and update the `PWD` environment variable. |
+| pwd | () | void | Print the current working directory. |
+| exit | ([code: Integer]) | void | Exit the current shell script with the provided status code. |
+| export | (assignments: String...) | void | Set one or more environment variables using `NAME=value` pairs. |
+| unset | (names: String...) | void | Remove environment variables from the current process. |
+| alias | ([assignments: String...]) | void | Define shell aliases or list existing ones when called without arguments. |
+
 ## HTTP (Synchronous)
 
 | Name | Parameters | Returns | Description |

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -4481,6 +4481,21 @@ void registerAllBuiltins(void) {
     registerBuiltinFunction("unlock", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunction("destroy", AST_PROCEDURE_DECL, NULL);
 
+    /* Shell front-end builtins */
+    registerBuiltinFunction("__shell_exec", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("__shell_pipeline", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("__shell_and", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("__shell_or", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("__shell_subshell", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("__shell_loop", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("__shell_if", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("cd", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("pwd", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("exit", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("export", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("unset", AST_PROCEDURE_DECL, NULL);
+    registerBuiltinFunction("alias", AST_PROCEDURE_DECL, NULL);
+
     // Additional registrations to ensure CLike builtins are classified correctly
     registerBuiltinFunction("Fopen", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunction("Fclose", AST_PROCEDURE_DECL, NULL);
@@ -4501,5 +4516,18 @@ void registerAllBuiltins(void) {
     registerVmBuiltin("tochar",   vmBuiltinToChar,   BUILTIN_TYPE_FUNCTION, NULL);
     registerVmBuiltin("tobool",   vmBuiltinToBool,   BUILTIN_TYPE_FUNCTION, NULL);
     registerVmBuiltin("tobyte",   vmBuiltinToByte,   BUILTIN_TYPE_FUNCTION, NULL);
+    registerVmBuiltin("__shell_exec", vmBuiltinShellExec, BUILTIN_TYPE_PROCEDURE, NULL);
+    registerVmBuiltin("__shell_pipeline", vmBuiltinShellPipeline, BUILTIN_TYPE_PROCEDURE, NULL);
+    registerVmBuiltin("__shell_and", vmBuiltinShellAnd, BUILTIN_TYPE_PROCEDURE, NULL);
+    registerVmBuiltin("__shell_or", vmBuiltinShellOr, BUILTIN_TYPE_PROCEDURE, NULL);
+    registerVmBuiltin("__shell_subshell", vmBuiltinShellSubshell, BUILTIN_TYPE_PROCEDURE, NULL);
+    registerVmBuiltin("__shell_loop", vmBuiltinShellLoop, BUILTIN_TYPE_PROCEDURE, NULL);
+    registerVmBuiltin("__shell_if", vmBuiltinShellIf, BUILTIN_TYPE_PROCEDURE, NULL);
+    registerVmBuiltin("cd", vmBuiltinShellCd, BUILTIN_TYPE_PROCEDURE, NULL);
+    registerVmBuiltin("pwd", vmBuiltinShellPwd, BUILTIN_TYPE_PROCEDURE, NULL);
+    registerVmBuiltin("exit", vmBuiltinShellExit, BUILTIN_TYPE_PROCEDURE, NULL);
+    registerVmBuiltin("export", vmBuiltinShellExport, BUILTIN_TYPE_PROCEDURE, NULL);
+    registerVmBuiltin("unset", vmBuiltinShellUnset, BUILTIN_TYPE_PROCEDURE, NULL);
+    registerVmBuiltin("alias", vmBuiltinShellAlias, BUILTIN_TYPE_PROCEDURE, NULL);
     pthread_mutex_unlock(&builtin_registry_mutex);
 }

--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -102,6 +102,23 @@ Value vmBuiltinReal(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinVMVersion(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinBytecodeVersion(struct VM_s* vm, int arg_count, Value* args);
 
+/* Shell builtins */
+Value vmBuiltinShellExec(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinShellPipeline(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinShellAnd(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinShellOr(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinShellSubshell(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinShellLoop(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinShellIf(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinShellCd(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinShellPwd(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinShellExit(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinShellExport(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinShellUnset(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinShellAlias(struct VM_s* vm, int arg_count, Value* args);
+Value vmHostShellLastStatus(struct VM_s* vm);
+Value vmHostShellPollJobs(struct VM_s* vm);
+
 /* VM-native file I/O */
 Value vmBuiltinAssign(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinReset(struct VM_s* vm, int arg_count, Value* args);

--- a/src/backend_ast/shell.c
+++ b/src/backend_ast/shell.c
@@ -1,0 +1,859 @@
+#include "backend_ast/builtin.h"
+#include "core/utils.h"
+#include "vm/vm.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <signal.h>
+#include <spawn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+extern char **environ;
+
+typedef struct {
+    int fd;
+    int flags;
+    mode_t mode;
+    char *path;
+} ShellRedirection;
+
+typedef struct {
+    char **argv;
+    size_t argc;
+    ShellRedirection *redirs;
+    size_t redir_count;
+    bool background;
+    int pipeline_index;
+    bool is_pipeline_head;
+    bool is_pipeline_tail;
+} ShellCommand;
+
+typedef struct {
+    bool active;
+    size_t stage_count;
+    bool negated;
+    pid_t *pids;
+    int (*pipes)[2];
+    size_t launched;
+    bool background;
+    int last_status;
+} ShellPipelineContext;
+
+typedef struct {
+    int last_status;
+    ShellPipelineContext pipeline;
+} ShellRuntimeState;
+
+static ShellRuntimeState gShellRuntime = {
+    .last_status = 0,
+    .pipeline = {0}
+};
+
+typedef struct {
+    pid_t pid;
+    char *command;
+} ShellJob;
+
+static ShellJob *gShellJobs = NULL;
+static size_t gShellJobCount = 0;
+
+static void shellFreeRedirections(ShellCommand *cmd) {
+    if (!cmd) {
+        return;
+    }
+    for (size_t i = 0; i < cmd->redir_count; ++i) {
+        free(cmd->redirs[i].path);
+    }
+    free(cmd->redirs);
+    cmd->redirs = NULL;
+    cmd->redir_count = 0;
+}
+
+static void shellFreeCommand(ShellCommand *cmd) {
+    if (!cmd) {
+        return;
+    }
+    for (size_t i = 0; i < cmd->argc; ++i) {
+        free(cmd->argv[i]);
+    }
+    free(cmd->argv);
+    cmd->argv = NULL;
+    cmd->argc = 0;
+    shellFreeRedirections(cmd);
+}
+
+static bool shellParseBool(const char *value, bool *out_flag) {
+    if (!value || !out_flag) {
+        return false;
+    }
+    if (strcasecmp(value, "1") == 0 || strcasecmp(value, "true") == 0 || strcasecmp(value, "yes") == 0) {
+        *out_flag = true;
+        return true;
+    }
+    if (strcasecmp(value, "0") == 0 || strcasecmp(value, "false") == 0 || strcasecmp(value, "no") == 0) {
+        *out_flag = false;
+        return true;
+    }
+    return false;
+}
+
+static void shellUpdateStatus(int status) {
+    gShellRuntime.last_status = status;
+    char buffer[16];
+    snprintf(buffer, sizeof(buffer), "%d", status);
+    setenv("PSCALSHELL_LAST_STATUS", buffer, 1);
+}
+
+static void shellFreeJob(ShellJob *job) {
+    if (!job) {
+        return;
+    }
+    free(job->command);
+    job->command = NULL;
+    job->pid = -1;
+}
+
+static void shellRegisterJob(pid_t pid, const ShellCommand *cmd) {
+    if (pid <= 0 || !cmd) {
+        return;
+    }
+    ShellJob *new_jobs = realloc(gShellJobs, sizeof(ShellJob) * (gShellJobCount + 1));
+    if (!new_jobs) {
+        return;
+    }
+    gShellJobs = new_jobs;
+    ShellJob *job = &gShellJobs[gShellJobCount++];
+    job->pid = pid;
+    size_t len = 0;
+    for (size_t i = 0; i < cmd->argc; ++i) {
+        len += strlen(cmd->argv[i]) + 1;
+    }
+    char *summary = malloc(len + 1);
+    if (!summary) {
+        job->command = NULL;
+        return;
+    }
+    summary[0] = '\0';
+    for (size_t i = 0; i < cmd->argc; ++i) {
+        strcat(summary, cmd->argv[i]);
+        if (i + 1 < cmd->argc) {
+            strcat(summary, " ");
+        }
+    }
+    job->command = summary;
+}
+
+static int shellCollectJobs(void) {
+    int reaped = 0;
+    for (size_t i = 0; i < gShellJobCount;) {
+        ShellJob *job = &gShellJobs[i];
+        int status = 0;
+        pid_t res = waitpid(job->pid, &status, WNOHANG);
+        if (res == 0) {
+            ++i;
+            continue;
+        }
+        if (res < 0) {
+            ++i;
+            continue;
+        }
+        int exit_status = 0;
+        if (WIFEXITED(status)) {
+            exit_status = WEXITSTATUS(status);
+        } else if (WIFSIGNALED(status)) {
+            exit_status = 128 + WTERMSIG(status);
+        }
+        shellUpdateStatus(exit_status);
+        shellFreeJob(job);
+        if (i + 1 < gShellJobCount) {
+            gShellJobs[i] = gShellJobs[gShellJobCount - 1];
+        }
+        gShellJobCount--;
+        reaped++;
+    }
+    if (gShellJobCount == 0 && gShellJobs) {
+        free(gShellJobs);
+        gShellJobs = NULL;
+    }
+    return reaped;
+}
+
+static void shellParseMetadata(const char *meta, ShellCommand *cmd) {
+    if (!meta || !cmd) {
+        return;
+    }
+    char *copy = strdup(meta);
+    if (!copy) {
+        return;
+    }
+    char *cursor = copy;
+    while (cursor && *cursor) {
+        char *next = strchr(cursor, ';');
+        if (next) {
+            *next = '\0';
+        }
+        char *eq = strchr(cursor, '=');
+        if (eq) {
+            *eq = '\0';
+            const char *key = cursor;
+            const char *value = eq + 1;
+            if (strcmp(key, "bg") == 0) {
+                shellParseBool(value, &cmd->background);
+            } else if (strcmp(key, "pipe") == 0) {
+                cmd->pipeline_index = atoi(value);
+            } else if (strcmp(key, "head") == 0) {
+                shellParseBool(value, &cmd->is_pipeline_head);
+            } else if (strcmp(key, "tail") == 0) {
+                shellParseBool(value, &cmd->is_pipeline_tail);
+            }
+        }
+        if (!next) {
+            break;
+        }
+        cursor = next + 1;
+    }
+    free(copy);
+}
+
+static bool shellAddArg(ShellCommand *cmd, const char *arg) {
+    if (!cmd || !arg) {
+        return false;
+    }
+    char **new_argv = realloc(cmd->argv, sizeof(char*) * (cmd->argc + 2));
+    if (!new_argv) {
+        return false;
+    }
+    cmd->argv = new_argv;
+    cmd->argv[cmd->argc] = strdup(arg);
+    if (!cmd->argv[cmd->argc]) {
+        return false;
+    }
+    cmd->argc++;
+    cmd->argv[cmd->argc] = NULL;
+    return true;
+}
+
+static bool shellAddRedirection(ShellCommand *cmd, const char *spec) {
+    if (!cmd || !spec) {
+        return false;
+    }
+    const char *payload = spec + strlen("redir:");
+    char *copy = strdup(payload);
+    if (!copy) {
+        return false;
+    }
+    char *parts[3] = {NULL, NULL, NULL};
+    size_t part_index = 0;
+    char *cursor = copy;
+    while (cursor && part_index < 3) {
+        char *next = strchr(cursor, ':');
+        if (next) {
+            *next = '\0';
+        }
+        parts[part_index++] = cursor;
+        if (!next) {
+            break;
+        }
+        cursor = next + 1;
+    }
+    if (part_index < 3) {
+        free(copy);
+        return false;
+    }
+    const char *fd_str = parts[0];
+    const char *type = parts[1];
+    const char *target = parts[2];
+    int fd = -1;
+    if (fd_str && *fd_str) {
+        fd = atoi(fd_str);
+    } else if (strcmp(type, "<") == 0) {
+        fd = STDIN_FILENO;
+    } else {
+        fd = STDOUT_FILENO;
+    }
+    int flags = 0;
+    mode_t mode = 0;
+    if (strcmp(type, "<") == 0) {
+        flags = O_RDONLY;
+    } else if (strcmp(type, ">") == 0) {
+        flags = O_WRONLY | O_CREAT | O_TRUNC;
+        mode = 0666;
+    } else if (strcmp(type, ">>") == 0) {
+        flags = O_WRONLY | O_CREAT | O_APPEND;
+        mode = 0666;
+    } else {
+        free(copy);
+        return false;
+    }
+    ShellRedirection *new_redirs = realloc(cmd->redirs, sizeof(ShellRedirection) * (cmd->redir_count + 1));
+    if (!new_redirs) {
+        free(copy);
+        return false;
+    }
+    cmd->redirs = new_redirs;
+    ShellRedirection *redir = &cmd->redirs[cmd->redir_count++];
+    redir->fd = fd;
+    redir->flags = flags;
+    redir->mode = mode;
+    redir->path = strdup(target ? target : "");
+    free(copy);
+    if (!redir->path) {
+        cmd->redir_count--;
+        return false;
+    }
+    return true;
+}
+
+static bool shellBuildCommand(VM *vm, int arg_count, Value *args, ShellCommand *out_cmd) {
+    if (!out_cmd) {
+        return false;
+    }
+    memset(out_cmd, 0, sizeof(*out_cmd));
+    if (arg_count <= 0) {
+        runtimeError(vm, "shell exec: missing metadata argument");
+        return false;
+    }
+    Value meta = args[0];
+    if (meta.type != TYPE_STRING || !meta.s_val) {
+        runtimeError(vm, "shell exec: metadata must be a string");
+        return false;
+    }
+    shellParseMetadata(meta.s_val, out_cmd);
+    for (int i = 1; i < arg_count; ++i) {
+        Value v = args[i];
+        if (v.type != TYPE_STRING || !v.s_val) {
+            runtimeError(vm, "shell exec: arguments must be strings");
+            shellFreeCommand(out_cmd);
+            return false;
+        }
+        if (strncmp(v.s_val, "redir:", 6) == 0) {
+            if (!shellAddRedirection(out_cmd, v.s_val)) {
+                runtimeError(vm, "shell exec: invalid redirection '%s'", v.s_val);
+                shellFreeCommand(out_cmd);
+                return false;
+            }
+        } else {
+            if (!shellAddArg(out_cmd, v.s_val)) {
+                runtimeError(vm, "shell exec: unable to add argument");
+                shellFreeCommand(out_cmd);
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+static int shellSpawnProcess(const ShellCommand *cmd, int stdin_fd, int stdout_fd, pid_t *child_pid) {
+    if (!cmd || cmd->argc == 0 || !cmd->argv || !cmd->argv[0]) {
+        return EINVAL;
+    }
+    posix_spawn_file_actions_t actions;
+    posix_spawn_file_actions_init(&actions);
+
+    if (stdin_fd >= 0) {
+        posix_spawn_file_actions_adddup2(&actions, stdin_fd, STDIN_FILENO);
+        posix_spawn_file_actions_addclose(&actions, stdin_fd);
+    }
+    if (stdout_fd >= 0) {
+        posix_spawn_file_actions_adddup2(&actions, stdout_fd, STDOUT_FILENO);
+        posix_spawn_file_actions_addclose(&actions, stdout_fd);
+    }
+
+    int opened_fds[16];
+    size_t opened_count = 0;
+
+    for (size_t i = 0; i < cmd->redir_count; ++i) {
+        const ShellRedirection *redir = &cmd->redirs[i];
+        int fd = open(redir->path, redir->flags, redir->mode);
+        if (fd < 0) {
+            for (size_t j = 0; j < opened_count; ++j) {
+                close(opened_fds[j]);
+            }
+            posix_spawn_file_actions_destroy(&actions);
+            return errno;
+        }
+        if (opened_count < sizeof(opened_fds) / sizeof(opened_fds[0])) {
+            opened_fds[opened_count++] = fd;
+        }
+        posix_spawn_file_actions_adddup2(&actions, fd, redir->fd);
+        posix_spawn_file_actions_addclose(&actions, fd);
+    }
+
+    posix_spawnattr_t attr;
+    posix_spawnattr_init(&attr);
+
+    int result = posix_spawnp(child_pid, cmd->argv[0], &actions, &attr, cmd->argv, environ);
+
+    posix_spawnattr_destroy(&attr);
+    posix_spawn_file_actions_destroy(&actions);
+
+    for (size_t j = 0; j < opened_count; ++j) {
+        close(opened_fds[j]);
+    }
+
+    return result;
+}
+
+static int shellWaitPid(pid_t pid, int *status_out) {
+    int status = 0;
+    pid_t waited = waitpid(pid, &status, 0);
+    if (waited < 0) {
+        return errno;
+    }
+    if (status_out) {
+        if (WIFEXITED(status)) {
+            *status_out = WEXITSTATUS(status);
+        } else if (WIFSIGNALED(status)) {
+            *status_out = 128 + WTERMSIG(status);
+        } else {
+            *status_out = status;
+        }
+    }
+    return 0;
+}
+
+static void shellResetPipeline(void) {
+    ShellPipelineContext *ctx = &gShellRuntime.pipeline;
+    if (!ctx->active) {
+        return;
+    }
+    if (ctx->pipes) {
+        size_t pipe_count = (ctx->stage_count > 0) ? (ctx->stage_count - 1) : 0;
+        for (size_t i = 0; i < pipe_count; ++i) {
+            if (ctx->pipes[i][0] >= 0) close(ctx->pipes[i][0]);
+            if (ctx->pipes[i][1] >= 0) close(ctx->pipes[i][1]);
+        }
+        free(ctx->pipes);
+        ctx->pipes = NULL;
+    }
+    free(ctx->pids);
+    ctx->pids = NULL;
+    ctx->active = false;
+    ctx->stage_count = 0;
+    ctx->launched = 0;
+    ctx->background = false;
+    ctx->last_status = 0;
+}
+
+static bool shellEnsurePipeline(size_t stages, bool negated) {
+    ShellPipelineContext *ctx = &gShellRuntime.pipeline;
+    shellResetPipeline();
+    ctx->stage_count = stages;
+    ctx->negated = negated;
+    ctx->active = true;
+    ctx->launched = 0;
+    ctx->last_status = 0;
+    ctx->background = false;
+    ctx->pids = calloc(stages, sizeof(pid_t));
+    if (!ctx->pids) {
+        shellResetPipeline();
+        return false;
+    }
+    if (stages > 1) {
+        ctx->pipes = calloc(stages - 1, sizeof(int[2]));
+        if (!ctx->pipes) {
+            shellResetPipeline();
+            return false;
+        }
+        for (size_t i = 0; i < stages - 1; ++i) {
+            ctx->pipes[i][0] = -1;
+            ctx->pipes[i][1] = -1;
+            if (pipe(ctx->pipes[i]) != 0) {
+                shellResetPipeline();
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+static int shellFinishPipeline(const ShellCommand *tail_cmd) {
+    ShellPipelineContext *ctx = &gShellRuntime.pipeline;
+    if (!ctx->active) {
+        return gShellRuntime.last_status;
+    }
+    int final_status = ctx->last_status;
+    if (!ctx->background) {
+        for (size_t i = 0; i < ctx->launched; ++i) {
+            int status = 0;
+            shellWaitPid(ctx->pids[i], &status);
+            if (i + 1 == ctx->launched) {
+                final_status = status;
+            }
+        }
+    } else if (ctx->launched > 0) {
+        shellRegisterJob(ctx->pids[ctx->launched - 1], tail_cmd);
+        final_status = 0;
+    }
+    if (ctx->negated) {
+        final_status = (final_status == 0) ? 1 : 0;
+    }
+    ctx->last_status = final_status;
+    shellResetPipeline();
+    shellUpdateStatus(final_status);
+    return final_status;
+}
+
+static Value shellExecuteCommand(VM *vm, ShellCommand *cmd) {
+    ShellPipelineContext *ctx = &gShellRuntime.pipeline;
+    int stdin_fd = -1;
+    int stdout_fd = -1;
+    if (ctx->active) {
+        size_t idx = (size_t)cmd->pipeline_index;
+        if (idx >= ctx->stage_count) {
+            runtimeError(vm, "shell exec: pipeline index out of range");
+            shellFreeCommand(cmd);
+            shellResetPipeline();
+            return makeVoid();
+        }
+        if (ctx->stage_count > 1) {
+            if (!cmd->is_pipeline_head) {
+                stdin_fd = ctx->pipes[idx - 1][0];
+            }
+            if (!cmd->is_pipeline_tail) {
+                stdout_fd = ctx->pipes[idx][1];
+            }
+        }
+    }
+
+    pid_t child = -1;
+    int spawn_err = shellSpawnProcess(cmd, stdin_fd, stdout_fd, &child);
+    if (spawn_err != 0) {
+        runtimeError(vm, "shell exec: failed to spawn '%s': %s", cmd->argv[0], strerror(spawn_err));
+        if (ctx->active) {
+            shellResetPipeline();
+        }
+        shellFreeCommand(cmd);
+        shellUpdateStatus(127);
+        return makeVoid();
+    }
+
+    if (ctx->active) {
+        if (!cmd->is_pipeline_head && stdin_fd >= 0) {
+            close(stdin_fd);
+            if (cmd->pipeline_index > 0) {
+                ctx->pipes[cmd->pipeline_index - 1][0] = -1;
+            }
+        }
+        if (!cmd->is_pipeline_tail && stdout_fd >= 0) {
+            close(stdout_fd);
+            ctx->pipes[cmd->pipeline_index][1] = -1;
+        }
+        ctx->pids[ctx->launched++] = child;
+        if (cmd->is_pipeline_tail) {
+            ctx->background = cmd->background;
+            shellFinishPipeline(cmd);
+        }
+    } else {
+        int status = 0;
+        if (!cmd->background) {
+            shellWaitPid(child, &status);
+        } else {
+            shellRegisterJob(child, cmd);
+        }
+        shellUpdateStatus(status);
+    }
+
+    shellFreeCommand(cmd);
+    return makeVoid();
+}
+
+Value vmBuiltinShellExec(VM *vm, int arg_count, Value *args) {
+    shellCollectJobs();
+    ShellCommand cmd;
+    if (!shellBuildCommand(vm, arg_count, args, &cmd)) {
+        return makeVoid();
+    }
+    return shellExecuteCommand(vm, &cmd);
+}
+
+Value vmBuiltinShellPipeline(VM *vm, int arg_count, Value *args) {
+    if (arg_count != 1 || args[0].type != TYPE_STRING || !args[0].s_val) {
+        runtimeError(vm, "shell pipeline: expected metadata string");
+        return makeVoid();
+    }
+    const char *meta = args[0].s_val;
+    size_t stages = 0;
+    bool negated = false;
+    char *copy = strdup(meta);
+    if (!copy) {
+        runtimeError(vm, "shell pipeline: out of memory");
+        return makeVoid();
+    }
+    char *cursor = copy;
+    while (cursor && *cursor) {
+        char *next = strchr(cursor, ';');
+        if (next) *next = '\0';
+        char *eq = strchr(cursor, '=');
+        if (eq) {
+            *eq = '\0';
+            const char *key = cursor;
+            const char *value = eq + 1;
+            if (strcmp(key, "stages") == 0) {
+                stages = (size_t)strtoul(value, NULL, 10);
+            } else if (strcmp(key, "negated") == 0) {
+                shellParseBool(value, &negated);
+            }
+        }
+        if (!next) break;
+        cursor = next + 1;
+    }
+    free(copy);
+    if (stages == 0) {
+        runtimeError(vm, "shell pipeline: invalid stage count");
+        return makeVoid();
+    }
+    if (!shellEnsurePipeline(stages, negated)) {
+        runtimeError(vm, "shell pipeline: unable to allocate context");
+    }
+    return makeVoid();
+}
+
+Value vmBuiltinShellAnd(VM *vm, int arg_count, Value *args) {
+    (void)vm;
+    (void)arg_count;
+    (void)args;
+    if (gShellRuntime.last_status != 0) {
+        shellUpdateStatus(gShellRuntime.last_status);
+    }
+    return makeVoid();
+}
+
+Value vmBuiltinShellOr(VM *vm, int arg_count, Value *args) {
+    (void)vm;
+    (void)arg_count;
+    (void)args;
+    if (gShellRuntime.last_status == 0) {
+        shellUpdateStatus(0);
+    }
+    return makeVoid();
+}
+
+Value vmBuiltinShellSubshell(VM *vm, int arg_count, Value *args) {
+    (void)vm;
+    (void)arg_count;
+    (void)args;
+    shellResetPipeline();
+    return makeVoid();
+}
+
+Value vmBuiltinShellLoop(VM *vm, int arg_count, Value *args) {
+    (void)vm;
+    (void)arg_count;
+    (void)args;
+    shellResetPipeline();
+    return makeVoid();
+}
+
+Value vmBuiltinShellIf(VM *vm, int arg_count, Value *args) {
+    (void)vm;
+    (void)arg_count;
+    (void)args;
+    return makeVoid();
+}
+
+Value vmBuiltinShellCd(VM *vm, int arg_count, Value *args) {
+    const char *path = NULL;
+    if (arg_count == 0) {
+        path = getenv("HOME");
+        if (!path) {
+            runtimeError(vm, "cd: HOME not set");
+            shellUpdateStatus(1);
+            return makeVoid();
+        }
+    } else if (args[0].type == TYPE_STRING && args[0].s_val) {
+        path = args[0].s_val;
+    } else {
+        runtimeError(vm, "cd: expected directory path");
+        shellUpdateStatus(1);
+        return makeVoid();
+    }
+    if (chdir(path) != 0) {
+        runtimeError(vm, "cd: %s", strerror(errno));
+        shellUpdateStatus(errno ? errno : 1);
+        return makeVoid();
+    }
+    char cwd[PATH_MAX];
+    if (getcwd(cwd, sizeof(cwd))) {
+        setenv("PWD", cwd, 1);
+    }
+    shellUpdateStatus(0);
+    return makeVoid();
+}
+
+Value vmBuiltinShellPwd(VM *vm, int arg_count, Value *args) {
+    (void)arg_count;
+    (void)args;
+    char cwd[PATH_MAX];
+    if (!getcwd(cwd, sizeof(cwd))) {
+        runtimeError(vm, "pwd: %s", strerror(errno));
+        shellUpdateStatus(errno ? errno : 1);
+        return makeVoid();
+    }
+    printf("%s\n", cwd);
+    shellUpdateStatus(0);
+    return makeVoid();
+}
+
+Value vmBuiltinShellExit(VM *vm, int arg_count, Value *args) {
+    int code = 0;
+    if (arg_count >= 1 && IS_INTLIKE(args[0])) {
+        code = (int)AS_INTEGER(args[0]);
+    }
+    shellUpdateStatus(code);
+    vm->exit_requested = true;
+    vm->current_builtin_name = "exit";
+    return makeVoid();
+}
+
+Value vmBuiltinShellExport(VM *vm, int arg_count, Value *args) {
+    for (int i = 0; i < arg_count; ++i) {
+        if (args[i].type != TYPE_STRING || !args[i].s_val) {
+            runtimeError(vm, "export: expected name=value string");
+            shellUpdateStatus(1);
+            return makeVoid();
+        }
+        const char *assignment = args[i].s_val;
+        const char *eq = strchr(assignment, '=');
+        if (!eq || eq == assignment) {
+            runtimeError(vm, "export: invalid assignment '%s'", assignment);
+            shellUpdateStatus(1);
+            return makeVoid();
+        }
+        size_t name_len = (size_t)(eq - assignment);
+        char *name = strndup(assignment, name_len);
+        const char *value = eq + 1;
+        if (!name) {
+            runtimeError(vm, "export: out of memory");
+            shellUpdateStatus(1);
+            return makeVoid();
+        }
+        setenv(name, value, 1);
+        free(name);
+    }
+    shellUpdateStatus(0);
+    return makeVoid();
+}
+
+Value vmBuiltinShellUnset(VM *vm, int arg_count, Value *args) {
+    for (int i = 0; i < arg_count; ++i) {
+        if (args[i].type != TYPE_STRING || !args[i].s_val) {
+            runtimeError(vm, "unset: expected variable name");
+            shellUpdateStatus(1);
+            return makeVoid();
+        }
+        unsetenv(args[i].s_val);
+    }
+    shellUpdateStatus(0);
+    return makeVoid();
+}
+
+typedef struct {
+    char *name;
+    char *value;
+} ShellAlias;
+
+static ShellAlias *gShellAliases = NULL;
+static size_t gShellAliasCount = 0;
+
+static ShellAlias *shellFindAlias(const char *name) {
+    if (!name) {
+        return NULL;
+    }
+    for (size_t i = 0; i < gShellAliasCount; ++i) {
+        if (strcmp(gShellAliases[i].name, name) == 0) {
+            return &gShellAliases[i];
+        }
+    }
+    return NULL;
+}
+
+static bool shellSetAlias(const char *name, const char *value) {
+    if (!name || !value) {
+        return false;
+    }
+    ShellAlias *existing = shellFindAlias(name);
+    if (existing) {
+        char *copy = strdup(value);
+        if (!copy) {
+            return false;
+        }
+        free(existing->value);
+        existing->value = copy;
+        return true;
+    }
+    ShellAlias *new_aliases = realloc(gShellAliases, sizeof(ShellAlias) * (gShellAliasCount + 1));
+    if (!new_aliases) {
+        return false;
+    }
+    gShellAliases = new_aliases;
+    ShellAlias *alias = &gShellAliases[gShellAliasCount++];
+    alias->name = strdup(name);
+    alias->value = strdup(value);
+    if (!alias->name || !alias->value) {
+        free(alias->name);
+        free(alias->value);
+        gShellAliasCount--;
+        return false;
+    }
+    return true;
+}
+
+Value vmBuiltinShellAlias(VM *vm, int arg_count, Value *args) {
+    if (arg_count == 0) {
+        for (size_t i = 0; i < gShellAliasCount; ++i) {
+            printf("alias %s='%s'\n", gShellAliases[i].name, gShellAliases[i].value);
+        }
+        shellUpdateStatus(0);
+        return makeVoid();
+    }
+    for (int i = 0; i < arg_count; ++i) {
+        if (args[i].type != TYPE_STRING || !args[i].s_val) {
+            runtimeError(vm, "alias: expected name=value");
+            shellUpdateStatus(1);
+            return makeVoid();
+        }
+        const char *assignment = args[i].s_val;
+        const char *eq = strchr(assignment, '=');
+        if (!eq || eq == assignment) {
+            runtimeError(vm, "alias: invalid assignment '%s'", assignment);
+            shellUpdateStatus(1);
+            return makeVoid();
+        }
+        size_t name_len = (size_t)(eq - assignment);
+        char *name = strndup(assignment, name_len);
+        const char *value = eq + 1;
+        if (!name) {
+            runtimeError(vm, "alias: out of memory");
+            shellUpdateStatus(1);
+            return makeVoid();
+        }
+        if (!shellSetAlias(name, value)) {
+            free(name);
+            runtimeError(vm, "alias: failed to store alias");
+            shellUpdateStatus(1);
+            return makeVoid();
+        }
+        free(name);
+    }
+    shellUpdateStatus(0);
+    return makeVoid();
+}
+
+Value vmHostShellLastStatus(VM *vm) {
+    (void)vm;
+    return makeInt(gShellRuntime.last_status);
+}
+
+Value vmHostShellPollJobs(VM *vm) {
+    (void)vm;
+    return makeInt(shellCollectJobs());
+}

--- a/src/ext_builtins/system/register.c
+++ b/src/ext_builtins/system/register.c
@@ -13,10 +13,24 @@ void registerSystemBuiltins(void) {
   extBuiltinRegisterGroup(category, "process");
   extBuiltinRegisterGroup(category, "timing");
   extBuiltinRegisterGroup(category, "utility");
+  extBuiltinRegisterGroup(category, "shell");
   extBuiltinRegisterFunction(category, "filesystem", "FileExists");
   extBuiltinRegisterFunction(category, "process", "GetPid");
   extBuiltinRegisterFunction(category, "timing", "RealTimeClock");
   extBuiltinRegisterFunction(category, "utility", "Swap");
+  extBuiltinRegisterFunction(category, "shell", "__shell_exec");
+  extBuiltinRegisterFunction(category, "shell", "__shell_pipeline");
+  extBuiltinRegisterFunction(category, "shell", "__shell_and");
+  extBuiltinRegisterFunction(category, "shell", "__shell_or");
+  extBuiltinRegisterFunction(category, "shell", "__shell_subshell");
+  extBuiltinRegisterFunction(category, "shell", "__shell_loop");
+  extBuiltinRegisterFunction(category, "shell", "__shell_if");
+  extBuiltinRegisterFunction(category, "shell", "cd");
+  extBuiltinRegisterFunction(category, "shell", "pwd");
+  extBuiltinRegisterFunction(category, "shell", "exit");
+  extBuiltinRegisterFunction(category, "shell", "export");
+  extBuiltinRegisterFunction(category, "shell", "unset");
+  extBuiltinRegisterFunction(category, "shell", "alias");
 
   registerFileExistsBuiltin();
   registerGetPidBuiltin();

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1270,6 +1270,14 @@ static Value vmHostPrintf(VM* vm) {
     return makeInt(0);
 }
 
+static Value vmHostShellLastStatusHost(VM* vm) {
+    return vmHostShellLastStatus(vm);
+}
+
+static Value vmHostShellPollJobsHost(VM* vm) {
+    return vmHostShellPollJobs(vm);
+}
+
 // --- Host Function Registration ---
 bool registerHostFunction(VM* vm, HostFunctionID id, HostFn fn) {
     if (!vm) return false;
@@ -1321,6 +1329,8 @@ void initVM(VM* vm) { // As in all.txt, with frameCount
     registerHostFunction(vm, HOST_FN_CREATE_THREAD_ADDR, vmHostCreateThreadAddr);
     registerHostFunction(vm, HOST_FN_WAIT_THREAD, vmHostWaitThread);
     registerHostFunction(vm, HOST_FN_PRINTF, vmHostPrintf);
+    registerHostFunction(vm, HOST_FN_SHELL_LAST_STATUS, vmHostShellLastStatusHost);
+    registerHostFunction(vm, HOST_FN_SHELL_POLL_JOBS, vmHostShellPollJobsHost);
 
     // Default: tracing disabled
     vm->trace_head_instructions = 0;

--- a/src/vm/vm.h
+++ b/src/vm/vm.h
@@ -40,6 +40,8 @@ typedef enum {
     HOST_FN_CREATE_THREAD_ADDR,
     HOST_FN_WAIT_THREAD,
     HOST_FN_PRINTF,
+    HOST_FN_SHELL_LAST_STATUS,
+    HOST_FN_SHELL_POLL_JOBS,
     // ... add other host function IDs here ...
     HOST_FN_COUNT
 } HostFunctionID;


### PR DESCRIPTION
## Summary
- add a dedicated shell runtime module that spawns processes, wires pipelines, tracks jobs, and implements shell builtins such as cd/pwd/export inside the VM
- register the new helpers with the builtin registry, host function table, and extended builtin dump output so front ends can reference them directly
- document the shell helpers in the manuals and include the module in the core build

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dea7a8a0408329a0ee904f96682888