### PR TITLE
Fix substringRange helper placement in REA chat demo

### DIFF
--- a/Examples/rea/base/openai_chat_demo
+++ b/Examples/rea/base/openai_chat_demo
@@ -128,6 +128,29 @@ str repeatChar(char ch, int count) {
   return result;
 }
 
+str substringRange(str text, int startIndex, int endIndex) {
+  if (startIndex > endIndex) {
+    return "";
+  }
+  int len = length(text);
+  if (startIndex < 1) {
+    startIndex = 1;
+  }
+  if (endIndex > len) {
+    endIndex = len;
+  }
+  if (startIndex > endIndex) {
+    return "";
+  }
+  str result = "";
+  int i = startIndex;
+  while (i <= endIndex) {
+    result = result + charToString(text[i]);
+    i = i + 1;
+  }
+  return result;
+}
+
 str maskSecret(str value) {
   if (value == "") {
     return "(not set)";
@@ -304,29 +327,6 @@ int skipWhitespace(str text, int index) {
     index = index + 1;
   }
   return index;
-}
-
-str substringRange(str text, int startIndex, int endIndex) {
-  if (startIndex > endIndex) {
-    return "";
-  }
-  int len = length(text);
-  if (startIndex < 1) {
-    startIndex = 1;
-  }
-  if (endIndex > len) {
-    endIndex = len;
-  }
-  if (startIndex > endIndex) {
-    return "";
-  }
-  str result = "";
-  int i = startIndex;
-  while (i <= endIndex) {
-    result = result + charToString(text[i]);
-    i = i + 1;
-  }
-  return result;
 }
 
 str trim(str text) {


### PR DESCRIPTION
## Summary
- move the substringRange helper earlier in the script so it is declared before first use in maskSecret
- eliminate the erroneous implicit zero-argument declaration that caused compilation to fail

## Testing
- not run (REA interpreter not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68debb0207c0832984ad8e42c5bd6001