### PR TITLE
Refine chat payload builder

### DIFF
--- a/Examples/rea/base/openai_chat_demo
+++ b/Examples/rea/base/openai_chat_demo
@@ -281,35 +281,78 @@ int parseHexAt(str text, int index) {
 
 str jsonEscape(str text) {
   int len = length(text);
-  int i = 1;
-  str result = "";
-  while (i <= len) {
-    char ch = text[i];
+  if (len == 0) {
+    return "";
+  }
+  int outLen = 0;
+  int index = 1;
+  while (index <= len) {
+    char ch = text[index];
+    int code = ord(ch);
+    if (ch == '"' || ch == '\\') {
+      outLen = outLen + 2;
+    } else if (code == 8 || code == 9 || code == 10 || code == 12 ||
+               code == 13) {
+      outLen = outLen + 2;
+    } else if (code < 32) {
+      outLen = outLen + 6;
+    } else {
+      outLen = outLen + 1;
+    }
+    index = index + 1;
+  }
+
+  str result;
+  setlength(result, outLen);
+  int outIndex = 1;
+  index = 1;
+  while (index <= len) {
+    char ch = text[index];
     int code = ord(ch);
     if (ch == '"') {
-      result = result + "\\\"";
+      result[outIndex] = '\\';
+      result[outIndex + 1] = '"';
+      outIndex = outIndex + 2;
     } else if (ch == '\\') {
-      result = result + "\\\\";
+      result[outIndex] = '\\';
+      result[outIndex + 1] = '\\';
+      outIndex = outIndex + 2;
     } else if (code == 8) {
-      result = result + "\\b";
+      result[outIndex] = '\\';
+      result[outIndex + 1] = 'b';
+      outIndex = outIndex + 2;
     } else if (code == 9) {
-      result = result + "\\t";
+      result[outIndex] = '\\';
+      result[outIndex + 1] = 't';
+      outIndex = outIndex + 2;
     } else if (code == 10) {
-      result = result + "\\n";
+      result[outIndex] = '\\';
+      result[outIndex + 1] = 'n';
+      outIndex = outIndex + 2;
     } else if (code == 12) {
-      result = result + "\\f";
+      result[outIndex] = '\\';
+      result[outIndex + 1] = 'f';
+      outIndex = outIndex + 2;
     } else if (code == 13) {
-      result = result + "\\r";
+      result[outIndex] = '\\';
+      result[outIndex + 1] = 'r';
+      outIndex = outIndex + 2;
     } else if (code < 32) {
+      result[outIndex] = '\\';
+      result[outIndex + 1] = 'u';
+      result[outIndex + 2] = '0';
+      result[outIndex + 3] = '0';
+      str digits = hexDigits();
       int high = ((code >> 4) & 15) + 1;
       int low = (code & 15) + 1;
-      str digits = hexDigits();
-      result = result + "\\u00" + charToString(digits[high]) +
-          charToString(digits[low]);
+      result[outIndex + 4] = digits[high];
+      result[outIndex + 5] = digits[low];
+      outIndex = outIndex + 6;
     } else {
-      result = result + charToString(ch);
+      result[outIndex] = ch;
+      outIndex = outIndex + 1;
     }
-    i = i + 1;
+    index = index + 1;
   }
   return result;
 }
@@ -769,20 +812,6 @@ str extractFirstModelId(str modelList) {
   return trim(first);
 }
 
-str composeMessages(str systemPrompt, str userPrompt) {
-  str result = "[";
-  if (length(systemPrompt) > 0) {
-    result = result + "{\"role\":\"system\",\"content\":\"" +
-        jsonEscape(systemPrompt) + "\"}";
-    if (length(userPrompt) > 0) {
-      result = result + ",";
-    }
-  }
-  result = result + "{\"role\":\"user\",\"content\":\"" +
-      jsonEscape(userPrompt) + "\"}]";
-  return result;
-}
-
 str normaliseOptions(str optionsJson) {
   str trimmed = trim(optionsJson);
   if (trimmed == "") {
@@ -809,13 +838,241 @@ str normaliseOptions(str optionsJson) {
 }
 
 str buildRequestBody(str model, str systemPrompt, str userPrompt, str optionsJson) {
-  str messages = composeMessages(systemPrompt, userPrompt);
-  str body = "{\"model\":\"" + jsonEscape(model) + "\",\"messages\":" + messages;
+  str escapedModel = jsonEscape(model);
+  str escapedSystem = jsonEscape(systemPrompt);
+  str escapedUser = jsonEscape(userPrompt);
   str optionsPayload = normaliseOptions(optionsJson);
-  if (optionsPayload != "") {
-    body = body + "," + optionsPayload;
+  bool includeSystem = length(systemPrompt) > 0;
+
+
+  int totalLen = 0;
+  totalLen = totalLen + length("{\"model\":\"");
+  totalLen = totalLen + length(escapedModel);
+  totalLen = totalLen + length("\",\"messages\":[");
+  if (includeSystem) {
+    totalLen = totalLen + length("{\"role\":\"system\",\"content\":\"");
+    totalLen = totalLen + length(escapedSystem);
+    totalLen = totalLen + length("\"}");
+    totalLen = totalLen + 1;  // Comma before user message.
   }
-  body = body + "}";
+  totalLen = totalLen + length("{\"role\":\"user\",\"content\":\"");
+  totalLen = totalLen + length(escapedUser);
+  totalLen = totalLen + length("\"}]");
+  if (optionsPayload != "") {
+    totalLen = totalLen + 1;
+    totalLen = totalLen + length(optionsPayload);
+  }
+  totalLen = totalLen + 1;
+
+  str body;
+  setlength(body, totalLen);
+  int outIndex = 1;
+
+  str literal = "{\"model\":\"";
+  int litLen = length(literal);
+  int i = 1;
+  while (i <= litLen) {
+    body[outIndex] = literal[i];
+    outIndex = outIndex + 1;
+    i = i + 1;
+  }
+
+  int modelLen = length(escapedModel);
+  i = 1;
+  while (i <= modelLen) {
+    body[outIndex] = escapedModel[i];
+    outIndex = outIndex + 1;
+    i = i + 1;
+  }
+
+  body[outIndex] = '"';
+  outIndex = outIndex + 1;
+  body[outIndex] = ',';
+  outIndex = outIndex + 1;
+  body[outIndex] = '"';
+  outIndex = outIndex + 1;
+  body[outIndex] = 'm';
+  outIndex = outIndex + 1;
+  body[outIndex] = 'e';
+  outIndex = outIndex + 1;
+  body[outIndex] = 's';
+  outIndex = outIndex + 1;
+  body[outIndex] = 's';
+  outIndex = outIndex + 1;
+  body[outIndex] = 'a';
+  outIndex = outIndex + 1;
+  body[outIndex] = 'g';
+  outIndex = outIndex + 1;
+  body[outIndex] = 'e';
+  outIndex = outIndex + 1;
+  body[outIndex] = 's';
+  outIndex = outIndex + 1;
+  body[outIndex] = '"';
+  outIndex = outIndex + 1;
+  body[outIndex] = ':';
+  outIndex = outIndex + 1;
+  body[outIndex] = '[';
+  outIndex = outIndex + 1;
+
+  if (includeSystem) {
+    body[outIndex] = '{';
+    outIndex = outIndex + 1;
+    body[outIndex] = '"';
+    outIndex = outIndex + 1;
+    body[outIndex] = 'r';
+    outIndex = outIndex + 1;
+    body[outIndex] = 'o';
+    outIndex = outIndex + 1;
+    body[outIndex] = 'l';
+    outIndex = outIndex + 1;
+    body[outIndex] = 'e';
+    outIndex = outIndex + 1;
+    body[outIndex] = '"';
+    outIndex = outIndex + 1;
+    body[outIndex] = ':';
+    outIndex = outIndex + 1;
+    body[outIndex] = '"';
+    outIndex = outIndex + 1;
+    body[outIndex] = 's';
+    outIndex = outIndex + 1;
+    body[outIndex] = 'y';
+    outIndex = outIndex + 1;
+    body[outIndex] = 's';
+    outIndex = outIndex + 1;
+    body[outIndex] = 't';
+    outIndex = outIndex + 1;
+    body[outIndex] = 'e';
+    outIndex = outIndex + 1;
+    body[outIndex] = 'm';
+    outIndex = outIndex + 1;
+    body[outIndex] = '"';
+    outIndex = outIndex + 1;
+    body[outIndex] = ',';
+    outIndex = outIndex + 1;
+    body[outIndex] = '"';
+    outIndex = outIndex + 1;
+    body[outIndex] = 'c';
+    outIndex = outIndex + 1;
+    body[outIndex] = 'o';
+    outIndex = outIndex + 1;
+    body[outIndex] = 'n';
+    outIndex = outIndex + 1;
+    body[outIndex] = 't';
+    outIndex = outIndex + 1;
+    body[outIndex] = 'e';
+    outIndex = outIndex + 1;
+    body[outIndex] = 'n';
+    outIndex = outIndex + 1;
+    body[outIndex] = 't';
+    outIndex = outIndex + 1;
+    body[outIndex] = '"';
+    outIndex = outIndex + 1;
+    body[outIndex] = ':';
+    outIndex = outIndex + 1;
+    body[outIndex] = '"';
+    outIndex = outIndex + 1;
+
+    int systemLen = length(escapedSystem);
+    i = 1;
+    while (i <= systemLen) {
+      body[outIndex] = escapedSystem[i];
+      outIndex = outIndex + 1;
+      i = i + 1;
+    }
+
+    body[outIndex] = '"';
+    outIndex = outIndex + 1;
+    body[outIndex] = '}';
+    outIndex = outIndex + 1;
+    body[outIndex] = ',';
+    outIndex = outIndex + 1;
+  }
+
+  body[outIndex] = '{';
+  outIndex = outIndex + 1;
+  body[outIndex] = '"';
+  outIndex = outIndex + 1;
+  body[outIndex] = 'r';
+  outIndex = outIndex + 1;
+  body[outIndex] = 'o';
+  outIndex = outIndex + 1;
+  body[outIndex] = 'l';
+  outIndex = outIndex + 1;
+  body[outIndex] = 'e';
+  outIndex = outIndex + 1;
+  body[outIndex] = '"';
+  outIndex = outIndex + 1;
+  body[outIndex] = ':';
+  outIndex = outIndex + 1;
+  body[outIndex] = '"';
+  outIndex = outIndex + 1;
+  body[outIndex] = 'u';
+  outIndex = outIndex + 1;
+  body[outIndex] = 's';
+  outIndex = outIndex + 1;
+  body[outIndex] = 'e';
+  outIndex = outIndex + 1;
+  body[outIndex] = 'r';
+  outIndex = outIndex + 1;
+  body[outIndex] = '"';
+  outIndex = outIndex + 1;
+  body[outIndex] = ',';
+  outIndex = outIndex + 1;
+  body[outIndex] = '"';
+  outIndex = outIndex + 1;
+  body[outIndex] = 'c';
+  outIndex = outIndex + 1;
+  body[outIndex] = 'o';
+  outIndex = outIndex + 1;
+  body[outIndex] = 'n';
+  outIndex = outIndex + 1;
+  body[outIndex] = 't';
+  outIndex = outIndex + 1;
+  body[outIndex] = 'e';
+  outIndex = outIndex + 1;
+  body[outIndex] = 'n';
+  outIndex = outIndex + 1;
+  body[outIndex] = 't';
+  outIndex = outIndex + 1;
+  body[outIndex] = '"';
+  outIndex = outIndex + 1;
+  body[outIndex] = ':';
+  outIndex = outIndex + 1;
+  body[outIndex] = '"';
+  outIndex = outIndex + 1;
+
+  int userLen = length(escapedUser);
+  i = 1;
+  while (i <= userLen) {
+    body[outIndex] = escapedUser[i];
+    outIndex = outIndex + 1;
+    i = i + 1;
+  }
+
+  body[outIndex] = '"';
+  outIndex = outIndex + 1;
+  body[outIndex] = '}';
+  outIndex = outIndex + 1;
+  body[outIndex] = ']';
+  outIndex = outIndex + 1;
+
+  if (optionsPayload != "") {
+    body[outIndex] = ',';
+    outIndex = outIndex + 1;
+    int optionsLen = length(optionsPayload);
+    i = 1;
+    while (i <= optionsLen) {
+      body[outIndex] = optionsPayload[i];
+      outIndex = outIndex + 1;
+      i = i + 1;
+    }
+  }
+
+  body[outIndex] = '}';
+  outIndex = outIndex + 1;
+  if (outIndex - 1 != totalLen) {
+    setlength(body, outIndex - 1);
+  }
   return body;
 }
 


### PR DESCRIPTION
## Summary
- implement a two-pass `jsonEscape` that precomputes the escaped length and writes characters directly instead of repeated concatenation
- rebuild `buildRequestBody` to assemble the JSON payload manually, eliminating `composeMessages` and ensuring system/user entries and options are emitted character by character

## Testing
- build/bin/rea Examples/rea/base/openai_chat_demo --lmstudio --model qwen/qwen3-4b-thinking-2507 "hello"

------
https://chatgpt.com/codex/tasks/task_b_68debe8bb3208329852d1e51a7d7f299