### PR TITLE
Implement environment expansion and history recall in psh

### DIFF
--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -123,6 +123,8 @@ Value vmHostShellPollJobs(struct VM_s* vm);
 bool shellRuntimeConsumeExitRequested(void);
 int shellRuntimeLastStatus(void);
 void shellRuntimeRecordHistory(const char *line);
+void shellRuntimeSetArg0(const char *name);
+bool shellRuntimeExpandHistoryReference(const char *input, char **out_line);
 
 /* VM-native file I/O */
 Value vmBuiltinAssign(struct VM_s* vm, int arg_count, Value* args);

--- a/src/shell/lexer.c
+++ b/src/shell/lexer.c
@@ -27,13 +27,6 @@ static int peekChar(const ShellLexer *lexer) {
     return (unsigned char)lexer->src[lexer->pos];
 }
 
-static int peekNextChar(const ShellLexer *lexer) {
-    if (!lexer || lexer->pos + 1 >= lexer->length) {
-        return EOF;
-    }
-    return (unsigned char)lexer->src[lexer->pos + 1];
-}
-
 static int advanceChar(ShellLexer *lexer) {
     if (!lexer || lexer->pos >= lexer->length) {
         return EOF;
@@ -184,7 +177,6 @@ static bool isOperatorDelimiter(int c) {
 }
 
 static ShellToken scanWord(ShellLexer *lexer) {
-    size_t start = lexer->pos;
     bool singleQuoted = false;
     bool doubleQuoted = false;
     bool hasParam = false;
@@ -214,33 +206,59 @@ static ShellToken scanWord(ShellLexer *lexer) {
                 advanceChar(lexer);
                 c = next;
             }
-        } else if (c == '\'"' && !doubleQuoted) {
+        } else if (c == '\'' && !doubleQuoted) {
             singleQuoted = !singleQuoted;
             continue;
         } else if (c == '"') {
             doubleQuoted = !doubleQuoted;
             continue;
-        } else if (c == '$') {
+        } else if (c == '$' && !singleQuoted) {
             hasParam = true;
+            if (bufLen + 2 >= bufCap) {
+                bufCap = bufCap ? bufCap * 2 : 32;
+                char *tmp = (char *)realloc(buffer, bufCap);
+                if (!tmp) {
+                    free(buffer);
+                    return makeErrorToken(lexer, "Out of memory while scanning word");
+                }
+                buffer = tmp;
+            }
+            buffer[bufLen++] = (char)c;
             int next = peekChar(lexer);
             if (next == '{' || next == '(') {
-                // consume balanced structure but keep placeholder
-                advanceChar(lexer);
+                buffer[bufLen++] = (char)advanceChar(lexer);
                 int depth = 1;
                 while (depth > 0) {
                     int inner = peekChar(lexer);
                     if (inner == EOF) {
                         break;
                     }
-                    advanceChar(lexer);
+                    buffer[bufLen++] = (char)advanceChar(lexer);
                     if (inner == '{' || inner == '(') depth++;
                     else if (inner == '}' || inner == ')') depth--;
+                    if (bufLen + 1 >= bufCap) {
+                        bufCap = bufCap ? bufCap * 2 : 32;
+                        char *tmp2 = (char *)realloc(buffer, bufCap);
+                        if (!tmp2) {
+                            free(buffer);
+                            return makeErrorToken(lexer, "Out of memory while scanning word");
+                        }
+                        buffer = tmp2;
+                    }
                 }
-                // append placeholder
                 continue;
             } else {
                 while (isalnum(next) || next == '_' || next == '#') {
-                    advanceChar(lexer);
+                    buffer[bufLen++] = (char)advanceChar(lexer);
+                    if (bufLen + 1 >= bufCap) {
+                        bufCap = bufCap ? bufCap * 2 : 32;
+                        char *tmp3 = (char *)realloc(buffer, bufCap);
+                        if (!tmp3) {
+                            free(buffer);
+                            return makeErrorToken(lexer, "Out of memory while scanning word");
+                        }
+                        buffer = tmp3;
+                    }
                     next = peekChar(lexer);
                 }
                 continue;

--- a/src/shell/word_encoding.h
+++ b/src/shell/word_encoding.h
@@ -1,0 +1,14 @@
+#ifndef SHELL_WORD_ENCODING_H
+#define SHELL_WORD_ENCODING_H
+
+#include <stdint.h>
+
+#define SHELL_WORD_ENCODE_PREFIX ((char)0x1F)
+
+enum {
+    SHELL_WORD_FLAG_SINGLE_QUOTED = 1 << 0,
+    SHELL_WORD_FLAG_DOUBLE_QUOTED = 1 << 1,
+    SHELL_WORD_FLAG_HAS_PARAM = 1 << 2
+};
+
+#endif /* SHELL_WORD_ENCODING_H */


### PR DESCRIPTION
## Summary
- encode shell words with metadata so the runtime can recover quoting information and perform parameter expansion when building argv and redirection targets
- add runtime helpers to expand environment and positional parameters, track $0, and expose history lookup for interactive !N recall
- teach the interactive loop to resolve history references before execution and relax semantic checks so environment variables no longer produce false errors
- update the lexer to preserve parameter tokens inside words so expansions execute correctly

## Testing
- cmake -S . -B build
- cmake --build build --target psh
- ./build/bin/psh --no-cache /tmp/test.sh
- ./build/bin/psh --no-cache /tmp/test3.sh arg1 arg2

------
https://chatgpt.com/codex/tasks/task_b_68deec43483c83298beaf9f95cf93050