### PR TITLE
Enable inline history expansion in psh interactive shell

### DIFF
--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -126,7 +126,10 @@ bool shellRuntimeConsumeExitRequested(void);
 int shellRuntimeLastStatus(void);
 void shellRuntimeRecordHistory(const char *line);
 void shellRuntimeSetArg0(const char *name);
-bool shellRuntimeExpandHistoryReference(const char *input, char **out_line);
+bool shellRuntimeExpandHistoryReference(const char *input,
+                                        char **out_line,
+                                        bool *out_did_expand,
+                                        char **out_error_token);
 
 /* VM-native file I/O */
 Value vmBuiltinAssign(struct VM_s* vm, int arg_count, Value* args);


### PR DESCRIPTION
## Summary
- allow inline history designators (e.g. !$, !-2:$) to be parsed and expanded by the shell runtime, including quote and escape handling
- have the interactive loop expand every command line, echo expanded output when history is used, and report failures with the offending designator

## Testing
- cmake --build build --target psh

------
https://chatgpt.com/codex/tasks/task_b_68defd2a263c832993c02486c22206c1