### PR TITLE
Add regex history expansion to psh interactive shell

### DIFF
--- a/Docs/shell_overview.md
+++ b/Docs/shell_overview.md
@@ -61,7 +61,10 @@ passed after the script path (`gParamValues` inside the VM), so invoking
 Interactive sessions also support history expansion beyond `!!`. Numeric
 designators like `!-2` and `!42`, prefix/substring searches (`!foo`, `!?bar?`),
 and word designators (`!$`, `!*`, `!^`, `!:2`) work against the recorded
-history before execution, providing the usual convenience shorthands.
+history before execution, providing the usual convenience shorthands. Regular
+expression lookups (`!?/expr/?`) and substitution designators (`!:s/old/new/` or
+`!:gs/old/new/`) are honoured as well, with replacement strings supporting tab
+escapes via `\t`.
 
 ## Builtins and interaction with the VM
 


### PR DESCRIPTION
## Summary
- add regex-powered history matching and substitution support to the interactive shell runtime
- allow tab escape sequences in replacement text and document the new capabilities

## Testing
- `cmake -S . -B build`
- `cmake --build build --target psh`


------
https://chatgpt.com/codex/tasks/task_b_68df02b587288329afd720dab1654d7b