### PR TITLE
Add interactive history navigation to psh

### DIFF
--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -5,6 +5,7 @@
 #include "ast/ast.h"
 #include "Pascal/globals.h"
 #include <stdbool.h>
+#include <stddef.h>
 
 struct VM_s;
 
@@ -126,6 +127,8 @@ bool shellRuntimeConsumeExitRequested(void);
 int shellRuntimeLastStatus(void);
 void shellRuntimeRecordHistory(const char *line);
 void shellRuntimeSetArg0(const char *name);
+size_t shellRuntimeHistoryCount(void);
+bool shellRuntimeHistoryGetEntry(size_t reverse_index, char **out_line);
 bool shellRuntimeExpandHistoryReference(const char *input,
                                         char **out_line,
                                         bool *out_did_expand,

--- a/src/backend_ast/shell.c
+++ b/src/backend_ast/shell.c
@@ -1117,6 +1117,30 @@ void shellRuntimeRecordHistory(const char *line) {
     gShellHistory.entries[gShellHistory.count++] = copy;
 }
 
+size_t shellRuntimeHistoryCount(void) {
+    return gShellHistory.count;
+}
+
+bool shellRuntimeHistoryGetEntry(size_t reverse_index, char **out_line) {
+    if (!out_line) {
+        return false;
+    }
+    *out_line = NULL;
+    if (reverse_index >= gShellHistory.count) {
+        return false;
+    }
+    const char *entry = gShellHistory.entries[gShellHistory.count - reverse_index - 1];
+    if (!entry) {
+        return false;
+    }
+    char *copy = strdup(entry);
+    if (!copy) {
+        return false;
+    }
+    *out_line = copy;
+    return true;
+}
+
 void shellRuntimeSetArg0(const char *name) {
     char *copy = NULL;
     if (name && *name) {


### PR DESCRIPTION
## Summary
- expose helpers to query shell history entries for interactive use
- add a raw-mode line editor that supports history navigation with arrow keys
- fall back to the existing getline loop when the editor cannot be initialized

## Testing
- cmake -S . -B build
- cmake --build build --target psh

------
https://chatgpt.com/codex/tasks/task_b_68df0a9c67788329b7277302b0ece571