### PR TITLE
Avoid false shell warnings and gate VM crash dumps

### DIFF
--- a/src/shell/main.c
+++ b/src/shell/main.c
@@ -60,7 +60,8 @@ static const char *SHELL_USAGE =
     "     --dump-bytecode-only        Disassemble bytecode and exit.\n"
     "     --dump-ext-builtins         List builtin commands.\n"
     "     --no-cache                  Compile fresh (ignore cached bytecode).\n"
-    "     --vm-trace-head=N           Trace first N VM instructions.\n";
+    "     --vm-trace-head=N           Trace first N VM instructions.\n"
+    "     -d                          Enable verbose VM error diagnostics.\n";
 
 static const char *const kShellCompilerId = "shell";
 
@@ -102,6 +103,7 @@ typedef struct {
     int no_cache;
     int vm_trace_head;
     bool quiet;
+    bool verbose_errors;
     const char *frontend_path;
 } ShellRunOptions;
 
@@ -151,6 +153,8 @@ static int runShellSource(const char *source,
     if (!source || !options) {
         return EXIT_FAILURE;
     }
+
+    vmSetVerboseErrors(options->verbose_errors);
 
     const char *defines[1];
     int define_count = 0;
@@ -897,6 +901,8 @@ int main(int argc, char **argv) {
             options.no_cache = 1;
         } else if (strncmp(argv[i], "--vm-trace-head=", 16) == 0) {
             options.vm_trace_head = atoi(argv[i] + 16);
+        } else if (strcmp(argv[i], "-d") == 0) {
+            options.verbose_errors = true;
         } else if (argv[i][0] == '-') {
             fprintf(stderr, "Unknown option: %s\n%s\n", argv[i], SHELL_USAGE);
             return EXIT_FAILURE;

--- a/src/shell/semantics.c
+++ b/src/shell/semantics.c
@@ -143,7 +143,10 @@ static bool shellCommandExistsOnPath(const char *name) {
         return false;
     }
     if (strchr(name, '/')) {
-        return access(name, X_OK) == 0;
+        if (access(name, X_OK) == 0) {
+            return true;
+        }
+        return access(name, F_OK) == 0;
     }
 
     const char *path_env = getenv("PATH");
@@ -187,6 +190,9 @@ static bool shellCommandExistsOnPath(const char *name) {
         candidate[pos] = '\0';
 
         bool found = access(candidate, X_OK) == 0;
+        if (!found) {
+            found = access(candidate, F_OK) == 0;
+        }
         free(candidate);
         if (found) {
             return true;

--- a/src/vm/vm.h
+++ b/src/vm/vm.h
@@ -135,5 +135,6 @@ void runtimeError(VM* vm, const char* format, ...);
 void runtimeWarning(VM* vm, const char* format, ...);
 void vmDumpStackInfo(VM* vm);
 void vmDumpStackInfoDetailed(VM* vm, const char* context_message);
+void vmSetVerboseErrors(bool enabled);
 
 #endif // PSCAL_VM_H


### PR DESCRIPTION
## Summary
- treat script paths that exist but lack execute permission as valid during semantic analysis to prevent misleading "unknown command" warnings
- gate VM runtime location and crash context output behind a new verbosity flag and expose it via the shell runtime options
- add a `-d` switch to `psh` to enable verbose VM diagnostics on demand

## Testing
- cmake --build build --target psh

------
https://chatgpt.com/codex/tasks/task_b_68df2681ac288329801b83c01867fe3f