### PR TITLE
Add source builtin and dynamic prompt to psh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,6 +419,7 @@ set(SHELL_SOURCES
     src/shell/semantics.c
     src/shell/codegen.c
     src/shell/builtins.c
+    src/shell/runner.c
     src/shell/opt.c
     src/shell/stubs.c
     src/backend_ast/builtin.c

--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -118,6 +118,7 @@ Value vmBuiltinShellCaseEnd(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellDefineFunction(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellCd(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellPwd(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinShellSource(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellExit(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellSetenv(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellExport(struct VM_s* vm, int arg_count, Value* args);
@@ -135,6 +136,7 @@ bool shellRuntimeConsumeExitRequested(void);
 int shellRuntimeLastStatus(void);
 void shellRuntimeRecordHistory(const char *line);
 void shellRuntimeSetArg0(const char *name);
+const char *shellRuntimeGetArg0(void);
 size_t shellRuntimeHistoryCount(void);
 bool shellRuntimeHistoryGetEntry(size_t reverse_index, char **out_line);
 bool shellRuntimeExpandHistoryReference(const char *input,

--- a/src/ext_builtins/shell_frontend.c
+++ b/src/ext_builtins/shell_frontend.c
@@ -30,6 +30,7 @@ void registerShellFrontendBuiltins(void) {
 
     registerShellBuiltin(category, command_group, "cd", vmBuiltinShellCd);
     registerShellBuiltin(category, command_group, "pwd", vmBuiltinShellPwd);
+    registerShellBuiltin(category, command_group, "source", vmBuiltinShellSource);
     registerShellBuiltin(category, command_group, "exit", vmBuiltinShellExit);
     registerShellBuiltin(category, command_group, "setenv", vmBuiltinShellSetenv);
     registerShellBuiltin(category, command_group, "export", vmBuiltinShellExport);

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -31,6 +31,7 @@ static const ShellBuiltinEntry kShellBuiltins[] = {
     {"fg", "fg", 18},
     {"bg", "bg", 19},
     {"wait", "wait", 20},
+    {"source", "source", 21},
     {"__shell_exec", "__shell_exec", 1001},
     {"__shell_pipeline", "__shell_pipeline", 1002},
     {"__shell_and", "__shell_and", 1003},

--- a/src/shell/runner.c
+++ b/src/shell/runner.c
@@ -1,0 +1,203 @@
+#include "shell/runner.h"
+
+#include "backend_ast/builtin.h"
+#include "compiler/bytecode.h"
+#include "core/cache.h"
+#include "core/preproc.h"
+#include "shell/builtins.h"
+#include "shell/codegen.h"
+#include "shell/opt.h"
+#include "shell/parser.h"
+#include "shell/semantics.h"
+#include "symbol/symbol.h"
+#include "vm/vm.h"
+#include "Pascal/globals.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char *const kShellCompilerId = "shell";
+
+char *shellLoadFile(const char *path) {
+    if (!path) {
+        return NULL;
+    }
+    FILE *f = fopen(path, "rb");
+    if (!f) {
+        fprintf(stderr, "Unable to open '%s': %s\n", path, strerror(errno));
+        return NULL;
+    }
+    if (fseek(f, 0, SEEK_END) != 0) {
+        fclose(f);
+        return NULL;
+    }
+    long len = ftell(f);
+    if (len < 0) {
+        fclose(f);
+        return NULL;
+    }
+    rewind(f);
+    char *buffer = (char *)malloc((size_t)len + 1);
+    if (!buffer) {
+        fclose(f);
+        return NULL;
+    }
+    size_t read = fread(buffer, 1, (size_t)len, f);
+    fclose(f);
+    if (read != (size_t)len) {
+        free(buffer);
+        return NULL;
+    }
+    buffer[len] = '\0';
+    return buffer;
+}
+
+int shellRunSource(const char *source,
+                   const char *path,
+                   const ShellRunOptions *options,
+                   bool *out_exit_requested) {
+    if (out_exit_requested) {
+        *out_exit_requested = false;
+    }
+    if (!source || !options) {
+        return EXIT_FAILURE;
+    }
+
+    vmSetVerboseErrors(options->verbose_errors);
+
+    const char *defines[1];
+    int define_count = 0;
+    char *pre_src = preprocessConditionals(source, defines, define_count);
+
+    globalSymbols = createHashTable();
+    constGlobalSymbols = createHashTable();
+    procedure_table = createHashTable();
+    if (!globalSymbols || !constGlobalSymbols || !procedure_table) {
+        fprintf(stderr, "shell: failed to allocate symbol tables.\n");
+        if (globalSymbols) { freeHashTable(globalSymbols); globalSymbols = NULL; }
+        if (constGlobalSymbols) { freeHashTable(constGlobalSymbols); constGlobalSymbols = NULL; }
+        if (procedure_table) { freeHashTable(procedure_table); procedure_table = NULL; }
+        if (pre_src) free(pre_src);
+        return EXIT_FAILURE;
+    }
+    current_procedure_table = procedure_table;
+    registerAllBuiltins();
+
+    int exit_code = EXIT_FAILURE;
+    ShellProgram *program = NULL;
+    ShellSemanticContext sem_ctx;
+    bool sem_ctx_initialized = false;
+    BytecodeChunk chunk;
+    bool chunk_initialized = false;
+    VM vm;
+    bool vm_initialized = false;
+    bool exit_flag = false;
+
+    ShellParser parser;
+    program = shellParseString(pre_src ? pre_src : source, &parser);
+    shellParserFree(&parser);
+    if (parser.had_error || !program) {
+        fprintf(stderr, "Parsing failed.\n");
+        goto cleanup;
+    }
+
+    if (options->dump_ast_json) {
+        shellDumpAstJson(stdout, program);
+        exit_code = EXIT_SUCCESS;
+        goto cleanup;
+    }
+
+    shellInitSemanticContext(&sem_ctx);
+    sem_ctx_initialized = true;
+    ShellSemanticResult sem_result = shellAnalyzeProgram(&sem_ctx, program);
+    if (sem_result.warning_count > 0) {
+        fprintf(stderr, "Semantic analysis produced %d warning(s).\n", sem_result.warning_count);
+    }
+    if (sem_result.error_count > 0) {
+        fprintf(stderr, "Semantic analysis failed with %d error(s).\n", sem_result.error_count);
+        goto cleanup;
+    }
+
+    initBytecodeChunk(&chunk);
+    chunk_initialized = true;
+    bool used_cache = false;
+    if (!options->no_cache && path && path[0]) {
+        used_cache = loadBytecodeFromCache(path, kShellCompilerId, options->frontend_path, NULL, 0, &chunk);
+    }
+
+    if (!used_cache) {
+        ShellOptConfig opt_config = { false };
+        shellRunOptimizations(program, &opt_config);
+        shellCompile(program, &chunk);
+        if (path && path[0] && !options->no_cache) {
+            saveBytecodeToCache(path, kShellCompilerId, &chunk);
+        }
+        if (!options->quiet) {
+            fprintf(stderr, "Compilation successful. Byte code size: %d bytes, Constants: %d\n",
+                    chunk.count, chunk.constants_count);
+        }
+        if (options->dump_bytecode) {
+            fprintf(stderr, "--- Compiling Shell Script to Bytecode ---\n");
+            disassembleBytecodeChunk(&chunk, path ? path : "script", procedure_table);
+            if (!options->dump_bytecode_only) {
+                fprintf(stderr, "\n--- executing Script with VM ---\n");
+            }
+        }
+    } else {
+        if (!options->quiet) {
+            fprintf(stderr, "Loaded cached bytecode. Byte code size: %d bytes, Constants: %d\n",
+                    chunk.count, chunk.constants_count);
+        }
+        if (options->dump_bytecode) {
+            disassembleBytecodeChunk(&chunk, path ? path : "script", procedure_table);
+            if (!options->dump_bytecode_only) {
+                fprintf(stderr, "\n--- executing Script with VM (cached) ---\n");
+            }
+        }
+    }
+
+    if (options->dump_bytecode_only) {
+        exit_code = EXIT_SUCCESS;
+        goto cleanup;
+    }
+
+    initVM(&vm);
+    vm_initialized = true;
+    if (options->vm_trace_head > 0) {
+        vm.trace_head_instructions = options->vm_trace_head;
+    }
+
+    InterpretResult result = interpretBytecode(&vm, &chunk, globalSymbols, constGlobalSymbols, procedure_table, 0);
+    int last_status = shellRuntimeLastStatus();
+    exit_flag = shellRuntimeConsumeExitRequested();
+    exit_code = (result == INTERPRET_OK) ? last_status : EXIT_FAILURE;
+
+cleanup:
+    if (out_exit_requested) {
+        *out_exit_requested = exit_flag;
+    } else {
+        (void)exit_flag;
+    }
+    if (vm_initialized) {
+        freeVM(&vm);
+    }
+    if (chunk_initialized) {
+        freeBytecodeChunk(&chunk);
+    }
+    if (sem_ctx_initialized) {
+        shellFreeSemanticContext(&sem_ctx);
+    }
+    if (program) {
+        shellFreeProgram(program);
+    }
+    if (globalSymbols) { freeHashTable(globalSymbols); globalSymbols = NULL; }
+    if (constGlobalSymbols) { freeHashTable(constGlobalSymbols); constGlobalSymbols = NULL; }
+    if (procedure_table) { freeHashTable(procedure_table); procedure_table = NULL; }
+    current_procedure_table = NULL;
+    if (pre_src) {
+        free(pre_src);
+    }
+    return exit_code;
+}

--- a/src/shell/runner.h
+++ b/src/shell/runner.h
@@ -1,0 +1,31 @@
+#ifndef SHELL_RUNNER_H
+#define SHELL_RUNNER_H
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ShellRunOptions {
+    int dump_ast_json;
+    int dump_bytecode;
+    int dump_bytecode_only;
+    int no_cache;
+    int vm_trace_head;
+    bool quiet;
+    bool verbose_errors;
+    const char *frontend_path;
+} ShellRunOptions;
+
+char *shellLoadFile(const char *path);
+int shellRunSource(const char *source,
+                   const char *path,
+                   const ShellRunOptions *options,
+                   bool *out_exit_requested);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SHELL_RUNNER_H */


### PR DESCRIPTION
## Summary
- extract reusable shellRunSource helper into src/shell/runner.{c,h}
- add a built-in `source` command wired through registration, runtime execution, and caching
- update the interactive loop to honor PS1 for prompts and reuse the shared runner

## Testing
- cmake -S . -B build
- cmake --build build --target psh

------
https://chatgpt.com/codex/tasks/task_b_68dfe1fa82b883299c54eae5753a4529