### PR TITLE
Add psh builtin command and documentation

### DIFF
--- a/Docs/shell_overview.md
+++ b/Docs/shell_overview.md
@@ -79,6 +79,14 @@ extends it with orchestration helpers implemented in
 - The complete PSCAL builtin catalog (HTTP, sockets, JSON, extended math/string
   groups, optional SQLite/SDL bindings) via `registerAllBuiltins()`.
 
+The `builtin` shell command bridges these catalogs into scripts. Invoke it with
+the VM builtin name followed by any arguments. Values are treated as strings by
+default; prefix a token with `int:`, `float:`/`double:`/`real:`, `bool:` or
+`str:` to coerce the argument to the corresponding VM type. Supplying `nil` (or
+`nil:`) passes the VM's `nil` value directly. When the target builtin returns a
+value, `builtin` prints it to `stdout`; procedures that return `void` simply set
+`PSCALSHELL_LAST_STATUS` to `0` on success.
+
 High-level control-flow syntax (`if`, loops) is parsed and lowered to the
 placeholder helpers above. Those helpers currently execute sequentially, so
 scripts that rely on branching should gate behaviour using the exported status

--- a/Examples/psh/README.md
+++ b/Examples/psh/README.md
@@ -59,6 +59,34 @@ result of the most recently executed command or pipeline. You can call any other
 PSCAL builtins (HTTP, JSON, SQLite, etc.) from the same script to orchestrate
 complex workflows.
 
+## `builtins.psh`
+
+```sh
+#!/usr/bin/env psh
+builtin IntToStr int:42
+builtin Length str:psh-demo
+builtin getEnv str:HOME
+builtin ParamCount
+builtin atoi str:1337
+builtin getpid
+```
+
+The `builtin` command exposes the VM's core and extended builtin catalog from
+the shell. Arguments are parsed as strings by default; add an explicit prefix to
+force other types:
+
+- `str:<value>` – keep the payload as a string.
+- `int:<value>` – parse the payload with `strtoll` (base `0`, so `0x`, `0` and
+  decimal forms are accepted).
+- `float:<value>` / `double:<value>` / `real:<value>` – parse the payload with
+  `strtod`.
+- `bool:<value>` / `boolean:<value>` – coerce common truthy/falsy literals.
+- `nil` or `nil:` – pass the VM's `nil` value.
+
+When a builtin returns a result the command prints it to `stdout`. Procedures
+that return `void` simply update `PSCALSHELL_LAST_STATUS` to `0` on success so
+you can chain them in conditionals.
+
 ## `logical.psh`
 
 ```sh

--- a/Examples/psh/builtins.psh
+++ b/Examples/psh/builtins.psh
@@ -1,0 +1,27 @@
+#!/usr/bin/env psh
+# Demonstrate invoking VM builtins from the shell frontend.
+
+setenv ORIGINAL_STATUS $PSCALSHELL_LAST_STATUS
+
+echo "builtins:start"
+
+# Core builtin: convert an integer to a string and report its length.
+builtin IntToStr int:42
+builtin Length str:psh-demo
+
+# Core builtin returning process metadata.
+builtin getEnv str:HOME
+builtin ParamCount
+
+# Extended builtin from the strings group.
+builtin atoi str:1337
+
+# Extended builtin from the system group.
+builtin getpid
+
+echo "builtins:end"
+
+# Restore the environment variable we touched at the top.
+if [ -n "$ORIGINAL_STATUS" ]; then
+    setenv PSCALSHELL_LAST_STATUS "$ORIGINAL_STATUS"
+fi

--- a/README.md
+++ b/README.md
@@ -236,13 +236,16 @@ Configure per-session knobs via `HttpSetOption/httpsetoption`:
 Pipelines, background jobs, and conditionals map to dedicated VM
 builtins implemented in `backend_ast/shell.c`, while the full PSCAL builtin
 catalog (HTTP, sockets, extended math/string helpers, optional SDL/SQLite
-bindings) is available via direct function calls.
+bindings) is available via the `builtin` command. Prefix arguments with
+`int:`, `float:`/`double:`/`real:`, `bool:`, `str:` or `nil` to coerce shell
+tokens to the appropriate VM types before dispatch.
 
 Example usage:
 
 ```sh
 build/bin/psh Examples/psh/pipeline.psh
 build/bin/psh --dump-bytecode Examples/psh/functions.psh
+build/bin/psh Examples/psh/builtins.psh
 ```
 
 Bytecode for each script is cached in `~/.pscal/bc_cache` under a

--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -129,6 +129,7 @@ Value vmBuiltinShellJobs(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellFg(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellBg(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellWait(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinShellBuiltin(struct VM_s* vm, int arg_count, Value* args);
 Value vmHostShellLastStatus(struct VM_s* vm);
 Value vmHostShellPollJobs(struct VM_s* vm);
 bool shellRuntimeConsumeExitRequested(void);

--- a/src/backend_ast/shell.c
+++ b/src/backend_ast/shell.c
@@ -1775,6 +1775,169 @@ static bool shellParseBool(const char *value, bool *out_flag) {
     return false;
 }
 
+static bool shellStringEqualsIgnoreCase(const char *lhs, const char *rhs) {
+    if (!lhs || !rhs) {
+        return false;
+    }
+    return strcasecmp(lhs, rhs) == 0;
+}
+
+static bool shellTryParseIntegerLiteral(const char *text, long long *out_value) {
+    if (!text || !*text) {
+        return false;
+    }
+    errno = 0;
+    char *end = NULL;
+    long long value = strtoll(text, &end, 0);
+    if (errno != 0 || !end || *end != '\0') {
+        return false;
+    }
+    if (out_value) {
+        *out_value = value;
+    }
+    return true;
+}
+
+static bool shellLooksLikeFloatLiteral(const char *text) {
+    if (!text) {
+        return false;
+    }
+    for (const char *cursor = text; *cursor; ++cursor) {
+        if (*cursor == '.' || *cursor == 'e' || *cursor == 'E') {
+            return true;
+        }
+    }
+    if (shellStringEqualsIgnoreCase(text, "inf") ||
+        shellStringEqualsIgnoreCase(text, "+inf") ||
+        shellStringEqualsIgnoreCase(text, "-inf") ||
+        shellStringEqualsIgnoreCase(text, "infinity") ||
+        shellStringEqualsIgnoreCase(text, "+infinity") ||
+        shellStringEqualsIgnoreCase(text, "-infinity") ||
+        shellStringEqualsIgnoreCase(text, "nan") ||
+        shellStringEqualsIgnoreCase(text, "+nan") ||
+        shellStringEqualsIgnoreCase(text, "-nan")) {
+        return true;
+    }
+    return false;
+}
+
+static bool shellTryParseFloatLiteral(const char *text, double *out_value) {
+    if (!text || !*text) {
+        return false;
+    }
+    errno = 0;
+    char *end = NULL;
+    double value = strtod(text, &end);
+    if (errno != 0 || !end || *end != '\0') {
+        return false;
+    }
+    if (out_value) {
+        *out_value = value;
+    }
+    return true;
+}
+
+static Value shellConvertBuiltinArgument(const char *text) {
+    if (!text) {
+        return makeString("");
+    }
+
+    enum {
+        SHELL_ARG_MODE_AUTO,
+        SHELL_ARG_MODE_STRING,
+        SHELL_ARG_MODE_BOOL,
+        SHELL_ARG_MODE_INT,
+        SHELL_ARG_MODE_FLOAT,
+        SHELL_ARG_MODE_NIL
+    } mode = SHELL_ARG_MODE_AUTO;
+
+    const char *payload = text;
+
+    if (strncasecmp(payload, "str:", 4) == 0) {
+        mode = SHELL_ARG_MODE_STRING;
+        payload += 4;
+    } else if (strncasecmp(payload, "string:", 7) == 0) {
+        mode = SHELL_ARG_MODE_STRING;
+        payload += 7;
+    } else if (strncasecmp(payload, "raw:", 4) == 0) {
+        mode = SHELL_ARG_MODE_STRING;
+        payload += 4;
+    } else if (strncasecmp(payload, "bool:", 5) == 0) {
+        mode = SHELL_ARG_MODE_BOOL;
+        payload += 5;
+    } else if (strncasecmp(payload, "boolean:", 8) == 0) {
+        mode = SHELL_ARG_MODE_BOOL;
+        payload += 8;
+    } else if (strncasecmp(payload, "int:", 4) == 0) {
+        mode = SHELL_ARG_MODE_INT;
+        payload += 4;
+    } else if (strncasecmp(payload, "integer:", 8) == 0) {
+        mode = SHELL_ARG_MODE_INT;
+        payload += 8;
+    } else if (strncasecmp(payload, "float:", 6) == 0) {
+        mode = SHELL_ARG_MODE_FLOAT;
+        payload += 6;
+    } else if (strncasecmp(payload, "double:", 7) == 0) {
+        mode = SHELL_ARG_MODE_FLOAT;
+        payload += 7;
+    } else if (strncasecmp(payload, "real:", 5) == 0) {
+        mode = SHELL_ARG_MODE_FLOAT;
+        payload += 5;
+    } else if (strncasecmp(payload, "nil:", 4) == 0) {
+        mode = SHELL_ARG_MODE_NIL;
+        payload += 4;
+    }
+
+    if (mode == SHELL_ARG_MODE_STRING) {
+        return makeString(payload ? payload : "");
+    }
+
+    if (mode == SHELL_ARG_MODE_NIL) {
+        return makeNil();
+    }
+
+    if (mode == SHELL_ARG_MODE_BOOL || mode == SHELL_ARG_MODE_AUTO) {
+        bool flag = false;
+        if (shellParseBool(payload, &flag)) {
+            return makeBoolean(flag ? 1 : 0);
+        }
+        if (mode == SHELL_ARG_MODE_BOOL) {
+            return makeString(payload ? payload : "");
+        }
+    }
+
+    if (mode == SHELL_ARG_MODE_INT || mode == SHELL_ARG_MODE_AUTO) {
+        long long int_value = 0;
+        if (shellTryParseIntegerLiteral(payload, &int_value)) {
+            return makeInt(int_value);
+        }
+        if (mode == SHELL_ARG_MODE_INT) {
+            return makeString(payload ? payload : "");
+        }
+    }
+
+    if (mode == SHELL_ARG_MODE_FLOAT || mode == SHELL_ARG_MODE_AUTO) {
+        if (mode == SHELL_ARG_MODE_FLOAT || shellLooksLikeFloatLiteral(payload)) {
+            double dbl_value = 0.0;
+            if (shellTryParseFloatLiteral(payload, &dbl_value)) {
+                return makeDouble(dbl_value);
+            }
+            if (mode == SHELL_ARG_MODE_FLOAT) {
+                return makeString(payload ? payload : "");
+            }
+        }
+    }
+
+    if (mode == SHELL_ARG_MODE_AUTO && payload && *payload) {
+        if (shellStringEqualsIgnoreCase(payload, "nil") ||
+            shellStringEqualsIgnoreCase(payload, "null")) {
+            return makeNil();
+        }
+    }
+
+    return makeString(payload ? payload : "");
+}
+
 static void shellUpdateStatus(int status) {
     if (gShellArithmeticErrorPending) {
         status = 1;
@@ -2180,7 +2343,7 @@ static bool shellIsRuntimeBuiltin(const char *name) {
         return false;
     }
     static const char *kBuiltins[] = {"cd", "pwd", "exit", "export", "unset", "setenv", "unsetenv", "alias", "history",
-                                      "jobs", "fg", "bg", "wait"};
+                                      "jobs", "fg", "bg", "wait", "builtin"};
     size_t count = sizeof(kBuiltins) / sizeof(kBuiltins[0]);
     for (size_t i = 0; i < count; ++i) {
         if (strcasecmp(name, kBuiltins[i]) == 0) {
@@ -3587,6 +3750,66 @@ Value vmBuiltinShellWait(VM *vm, int arg_count, Value *args) {
     }
     shellRemoveJobAt(index);
     shellUpdateStatus(final_status);
+    return makeVoid();
+}
+
+Value vmBuiltinShellBuiltin(VM *vm, int arg_count, Value *args) {
+    if (arg_count < 1 || args[0].type != TYPE_STRING || !args[0].s_val || args[0].s_val[0] == '\0') {
+        runtimeError(vm, "builtin: expected VM builtin name");
+        shellUpdateStatus(1);
+        return makeVoid();
+    }
+
+    const char *name = args[0].s_val;
+    VmBuiltinFn handler = getVmBuiltinHandler(name);
+    if (!handler) {
+        runtimeError(vm, "builtin: unknown VM builtin '%s'", name);
+        shellUpdateStatus(1);
+        return makeVoid();
+    }
+
+    int call_argc = arg_count - 1;
+    Value *call_args = NULL;
+    if (call_argc > 0) {
+        call_args = (Value *)calloc((size_t)call_argc, sizeof(Value));
+        if (!call_args) {
+            runtimeError(vm, "builtin: out of memory");
+            shellUpdateStatus(1);
+            return makeVoid();
+        }
+        for (int i = 0; i < call_argc; ++i) {
+            Value src = args[i + 1];
+            if (src.type == TYPE_STRING && src.s_val) {
+                call_args[i] = shellConvertBuiltinArgument(src.s_val);
+            } else if (src.type == TYPE_NIL) {
+                call_args[i] = makeNil();
+            } else {
+                call_args[i] = makeString("");
+            }
+        }
+    }
+
+    Value result = handler(vm, call_argc, call_args);
+
+    if (call_args) {
+        for (int i = 0; i < call_argc; ++i) {
+            freeValue(&call_args[i]);
+        }
+        free(call_args);
+    }
+
+    int status = 0;
+    if (vm && (vm->abort_requested || vm->exit_requested)) {
+        status = 1;
+    }
+    shellUpdateStatus(status);
+
+    if (status == 0 && result.type != TYPE_VOID) {
+        printValueToStream(result, stdout);
+        fputc('\n', stdout);
+    }
+
+    freeValue(&result);
     return makeVoid();
 }
 

--- a/src/backend_ast/shell.c
+++ b/src/backend_ast/shell.c
@@ -3789,6 +3789,7 @@ Value vmBuiltinShellBuiltin(VM *vm, int arg_count, Value *args) {
         }
     }
 
+    int previous_status = shellRuntimeLastStatus();
     Value result = handler(vm, call_argc, call_args);
 
     if (call_args) {
@@ -3798,11 +3799,11 @@ Value vmBuiltinShellBuiltin(VM *vm, int arg_count, Value *args) {
         free(call_args);
     }
 
-    int status = 0;
-    if (vm && (vm->abort_requested || vm->exit_requested)) {
-        status = 1;
+    if (vm && vm->abort_requested && shellRuntimeLastStatus() == previous_status) {
+        shellUpdateStatus(1);
     }
-    shellUpdateStatus(status);
+
+    int status = shellRuntimeLastStatus();
 
     if (status == 0 && result.type != TYPE_VOID) {
         printValueToStream(result, stdout);

--- a/src/ext_builtins/shell_frontend.c
+++ b/src/ext_builtins/shell_frontend.c
@@ -41,4 +41,5 @@ void registerShellFrontendBuiltins(void) {
     registerShellBuiltin(category, command_group, "fg", vmBuiltinShellFg);
     registerShellBuiltin(category, command_group, "bg", vmBuiltinShellBg);
     registerShellBuiltin(category, command_group, "wait", vmBuiltinShellWait);
+    registerShellBuiltin(category, command_group, "builtin", vmBuiltinShellBuiltin);
 }

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -31,6 +31,7 @@ static const ShellBuiltinEntry kShellBuiltins[] = {
     {"fg", "fg", 18},
     {"bg", "bg", 19},
     {"wait", "wait", 20},
+    {"builtin", "builtin", 21},
     {"__shell_exec", "__shell_exec", 1001},
     {"__shell_pipeline", "__shell_pipeline", 1002},
     {"__shell_and", "__shell_and", 1003},


### PR DESCRIPTION
## Summary
- add a `builtin` shell command that dispatches to VM builtins with simple type coercions
- document the feature in the shell overview and main README and add an example script

## Testing
- cmake --build build --target psh
- build/bin/psh Examples/psh/builtins.psh

------
https://chatgpt.com/codex/tasks/task_b_68dfe45361c08329960e2cc5f65b7323