### PR TITLE
Stop linking shell builtins into non-shell front ends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,7 +235,6 @@ set(PSCAL_SOURCES
     src/Pascal/lexer.c src/Pascal/parser.c src/ast/ast.c src/Pascal/opt.c
     src/symbol/symbol.c
     src/backend_ast/builtin.c
-    src/backend_ast/shell.c
     src/backend_ast/builtin_network_api.c
     src/compiler/bytecode.c src/compiler/compiler.c
     src/core/cache.c
@@ -510,7 +509,7 @@ set(CLIKE_SOURCES
     src/core/utils.c src/core/types.c src/core/list.c src/core/preproc.c src/core/version.c src/core/cache.c
     src/compiler/bytecode.c
     src/vm/vm.c
-    src/backend_ast/builtin.c src/backend_ast/shell.c src/backend_ast/builtin_network_api.c
+    src/backend_ast/builtin.c src/backend_ast/builtin_network_api.c
     src/symbol/symbol.c
     src/clike/stubs.c
 )
@@ -628,7 +627,7 @@ set(REA_SOURCES
     src/compiler/bytecode.c
     src/compiler/compiler.c
     src/vm/vm.c
-    src/backend_ast/builtin.c src/backend_ast/shell.c src/backend_ast/builtin_network_api.c
+    src/backend_ast/builtin.c src/backend_ast/builtin_network_api.c
     src/symbol/symbol.c
 )
 
@@ -724,7 +723,7 @@ set(JSON2BC_SOURCES
     src/ast/ast.c
     src/core/utils.c src/core/types.c src/core/list.c src/core/version.c src/core/cache.c
     src/compiler/bytecode.c src/compiler/compiler.c
-    src/backend_ast/builtin.c src/backend_ast/shell.c src/backend_ast/builtin_network_api.c
+    src/backend_ast/builtin.c src/backend_ast/builtin_network_api.c
     src/backend_ast/sdl.c src/backend_ast/sdl3d.c src/backend_ast/gl.c src/backend_ast/audio.c
     src/symbol/symbol.c
     src/vm/vm.c

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1331,6 +1331,7 @@ static Value vmHostPrintf(VM* vm) {
     return makeInt(0);
 }
 
+#ifdef FRONTEND_SHELL
 static Value vmHostShellLastStatusHost(VM* vm) {
     return vmHostShellLastStatus(vm);
 }
@@ -1338,6 +1339,17 @@ static Value vmHostShellLastStatusHost(VM* vm) {
 static Value vmHostShellPollJobsHost(VM* vm) {
     return vmHostShellPollJobs(vm);
 }
+#else
+static Value vmHostShellLastStatusHost(VM* vm) {
+    (void)vm;
+    return makeNil();
+}
+
+static Value vmHostShellPollJobsHost(VM* vm) {
+    (void)vm;
+    return makeNil();
+}
+#endif
 
 // --- Host Function Registration ---
 bool registerHostFunction(VM* vm, HostFunctionID id, HostFn fn) {


### PR DESCRIPTION
## Summary
- stop compiling the shell backend into the Pascal, C-like, Rea, and json2bc builds so they no longer depend on the shell runner
- guard the VM shell host helpers behind FRONTEND_SHELL and return nil in other front ends

## Testing
- cmake -S . -B build
- cmake --build build --target pascal clike rea

------
https://chatgpt.com/codex/tasks/task_b_68dfe64c442c8329aed7b1f3207142fc