### PR TITLE
Fix Pascal overflow warning regression

### DIFF
--- a/Tests/Pascal/RealIntOverflowTest.err
+++ b/Tests/Pascal/RealIntOverflowTest.err
@@ -1,2 +1,8 @@
 Warning: Range check error assigning REAL 100000000000000000000.000000 to INTEGER.
 [Warning Location] Offset: 60, Line: 15
+Warning: Range check error assigning REAL 100000000000000000000.000000 to INTEGER.
+[Warning Location] Offset: 109, Line: 0
+Warning: Range check error assigning REAL 100000000000000000000.000000 to BYTE.
+[Warning Location] Offset: 139, Line: 24
+Warning: Range check error assigning REAL 300.000000 to BYTE.
+[Warning Location] Offset: 155, Line: 26

--- a/src/Pascal/main.c
+++ b/src/Pascal/main.c
@@ -258,6 +258,7 @@ int runProgram(const char *source, const char *programName, const char *frontend
                 } else {
                 VM vm;
                 initVM(&vm);
+                vmSetVerboseErrors(true);
                 // Inline trace toggle via source comment: {trace on} / {trace off}
                 if (s_vm_trace_head > 0) vm.trace_head_instructions = s_vm_trace_head;
                 else if (source && strstr(source, "trace on")) vm.trace_head_instructions = 16;


### PR DESCRIPTION
## Summary
- enable verbose runtime warning locations when executing Pascal programs
- refresh the RealIntOverflowTest stderr fixture to include all emitted range-check warnings

## Testing
- cd Tests && ../build/bin/pascal --no-cache Pascal/RealIntOverflowTest


------
https://chatgpt.com/codex/tasks/task_b_68e0265e0c688329acce881e2a032303