### PR TITLE
Handle separators before loop body in exsh parser

### DIFF
--- a/src/shell/parser.c
+++ b/src/shell/parser.c
@@ -630,6 +630,15 @@ static ShellCommand *parseLoopCommand(ShellParser *parser, bool is_until) {
     int column = parser->current.column;
     shellParserAdvance(parser); // consume keyword
     ShellPipeline *condition = parsePipeline(parser);
+    while (parser->current.type == SHELL_TOKEN_NEWLINE) {
+        shellParserAdvance(parser);
+    }
+    if (parser->current.type == SHELL_TOKEN_SEMICOLON) {
+        shellParserAdvance(parser);
+        while (parser->current.type == SHELL_TOKEN_NEWLINE) {
+            shellParserAdvance(parser);
+        }
+    }
     shellParserConsume(parser, SHELL_TOKEN_DO, "Expected 'do' after loop condition");
     ShellProgram *body = parseBlockUntil(parser, SHELL_TOKEN_DONE, SHELL_TOKEN_EOF, SHELL_TOKEN_EOF);
     shellParserConsume(parser, SHELL_TOKEN_DONE, "Expected 'done' to close loop");


### PR DESCRIPTION
## Summary
- allow the loop parser to consume optional newlines and semicolons between the condition and `do`
- restore support for `while …; do` constructs in exsh scripts

## Testing
- not run (explanation: parsing fix only)


------
https://chatgpt.com/codex/tasks/task_b_68e027e30188832985bd0ce754c76432