### PR TITLE
Show ambiguous tab completion options in exsh

### DIFF
--- a/src/shell/main.c
+++ b/src/shell/main.c
@@ -1160,8 +1160,29 @@ static bool interactiveHandleTabCompletion(const char *prompt,
     } else {
         replacement_len = interactiveCommonPrefixLength(results.gl_pathv, results.gl_pathc);
         if (replacement_len <= word_len) {
+            putchar('\n');
+            for (size_t i = 0; i < results.gl_pathc; ++i) {
+                const char *match = results.gl_pathv[i];
+                if (!match) {
+                    continue;
+                }
+                fputs(match, stdout);
+                fputc('\n', stdout);
+            }
             globfree(&results);
-            return false;
+            fflush(stdout);
+
+            *cursor = *length;
+            redrawInteractiveLine(prompt,
+                                  *buffer,
+                                  *length,
+                                  *cursor,
+                                  displayed_length,
+                                  displayed_prompt_lines);
+            if (scratch) {
+                interactiveUpdateScratch(scratch, *buffer, *length);
+            }
+            return true;
         }
     }
 


### PR DESCRIPTION
## Summary
- list matching paths when interactive tab completion finds multiple results but cannot extend the current word
- redraw the prompt after displaying matches so the user can continue editing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e03567639c8329b711354184d2dcb0