### PR TITLE
Add help flag to front ends

### DIFF
--- a/src/Pascal/main.c
+++ b/src/Pascal/main.c
@@ -381,7 +381,10 @@ int main(int argc, char *argv[]) {
     // Parse options first
     int i = 1;
     for (; i < argc; ++i) {
-        if (strcmp(argv[i], "-v") == 0) {
+        if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
+            printf("%s\n", PASCAL_USAGE);
+            return vmExitWithCleanup(EXIT_SUCCESS);
+        } else if (strcmp(argv[i], "-v") == 0) {
             printf("Pascal Version: %s (latest tag: %s)\n",
                    pscal_program_version_string(), pscal_git_tag_string());
             return vmExitWithCleanup(EXIT_SUCCESS);

--- a/src/clike/main.c
+++ b/src/clike/main.c
@@ -113,7 +113,10 @@ int main(int argc, char **argv) {
     }
 
     for (int i = 1; i < argc; ++i) {
-        if (strcmp(argv[i], "-v") == 0) {
+        if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
+            printf("%s", CLIKE_USAGE);
+            return vmExitWithCleanup(EXIT_SUCCESS);
+        } else if (strcmp(argv[i], "-v") == 0) {
             printf("Clike Compiler Version: %s (latest tag: %s)\n",
                    pscal_program_version_string(), pscal_git_tag_string());
             return vmExitWithCleanup(EXIT_SUCCESS);

--- a/src/disassembler/main.c
+++ b/src/disassembler/main.c
@@ -34,6 +34,7 @@
 #include "compiler/bytecode.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 int gParamCount = 0;
 char **gParamValues = NULL;
@@ -66,9 +67,16 @@ static void initSymbolSystem(void) {
 #endif
 }
 
+static const char *PSCALD_USAGE = "Usage: pscald <bytecode_file>\n";
+
 int main(int argc, char* argv[]) {
+    if (argc == 2 && (strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0)) {
+        printf("%s", PSCALD_USAGE);
+        return EXIT_SUCCESS;
+    }
+
     if (argc != 2) {
-        fprintf(stderr, "Usage: pscald <bytecode_file>\n");
+        fprintf(stderr, "%s", PSCALD_USAGE);
         return EXIT_FAILURE;
     }
 

--- a/src/rea/main.c
+++ b/src/rea/main.c
@@ -259,7 +259,10 @@ int main(int argc, char **argv) {
     int strict_mode = 0;
     int argi = 1;
     while (argc > argi && argv[argi][0] == '-') {
-        if (strcmp(argv[argi], "-v") == 0) {
+        if (strcmp(argv[argi], "-h") == 0 || strcmp(argv[argi], "--help") == 0) {
+            printf("%s", REA_USAGE);
+            return vmExitWithCleanup(EXIT_SUCCESS);
+        } else if (strcmp(argv[argi], "-v") == 0) {
             printf("Rea Compiler Version: %s (latest tag: %s)\n",
                    pscal_program_version_string(), pscal_git_tag_string());
             return vmExitWithCleanup(EXIT_SUCCESS);

--- a/src/shell/main.c
+++ b/src/shell/main.c
@@ -2263,7 +2263,10 @@ int main(int argc, char **argv) {
     int arg_start_index = 0;
 
     for (int i = 1; i < argc; ++i) {
-        if (strcmp(argv[i], "-v") == 0) {
+        if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
+            printf("%s", SHELL_USAGE);
+            return vmExitWithCleanup(EXIT_SUCCESS);
+        } else if (strcmp(argv[i], "-v") == 0) {
             printf("Shell Frontend Version: %s (latest tag: %s)\n",
                    pscal_program_version_string(), pscal_git_tag_string());
             return vmExitWithCleanup(EXIT_SUCCESS);

--- a/src/vm/vm_main.c
+++ b/src/vm/vm_main.c
@@ -40,10 +40,16 @@ static void initSymbolSystem(void) {
 #endif
 }
 
+static const char *PSCALVM_USAGE = "Usage: pscalvm <bytecode_file> [program_parameters...]\n";
+
 int main(int argc, char* argv[]) {
     vmInitTerminalState();
+    if (argc >= 2 && (strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0)) {
+        printf("%s", PSCALVM_USAGE);
+        return vmExitWithCleanup(EXIT_SUCCESS);
+    }
     if (argc < 2) {
-        fprintf(stderr, "Usage: pscalvm <bytecode_file> [program_parameters...]\n");
+        fprintf(stderr, "%s", PSCALVM_USAGE);
         return vmExitWithCleanup(EXIT_FAILURE);
     }
 


### PR DESCRIPTION
## Summary
- add -h/--help handling to the Pascal, C-like, Rea, and shell front ends so they print usage information and exit successfully
- extend the disassembler and VM entry points to recognise -h/--help and display their usage strings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e037f3c1a4832984070f76027402fa