### PR TITLE
Implement shell control builtins and errexit handling

### DIFF
--- a/Docs/pscal_vm_builtins.md
+++ b/Docs/pscal_vm_builtins.md
@@ -122,6 +122,7 @@ VM. For instructions on adding your own routines, see
 | __shell_or | (meta: String) | void | Update the shell status for `||` lists. Primarily used by the shell compiler. |
 | __shell_subshell | (meta: String) | void | Reset pipeline/bookkeeping before running a subshell block. |
 | __shell_loop | (meta: String) | void | Reset pipeline/bookkeeping before running a loop body. |
+| __shell_loop_end | () | void | Signal the end of the current loop body, allowing loop-control requests to unwind. |
 | __shell_if | (meta: String) | void | Reset pipeline/bookkeeping before running a conditional branch. |
 | cd | (path: String) | void | Change the current working directory and update the `PWD` environment variable. |
 | pwd | () | void | Print the current working directory. |

--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -111,6 +111,7 @@ Value vmBuiltinShellAnd(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellOr(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellSubshell(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellLoop(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinShellLoopEnd(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellIf(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellCase(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellCaseClause(struct VM_s* vm, int arg_count, Value* args);

--- a/src/ext_builtins/shell_frontend.c
+++ b/src/ext_builtins/shell_frontend.c
@@ -22,6 +22,7 @@ void registerShellFrontendBuiltins(void) {
     registerShellBuiltin(category, runtime_group, "__shell_or", vmBuiltinShellOr);
     registerShellBuiltin(category, runtime_group, "__shell_subshell", vmBuiltinShellSubshell);
     registerShellBuiltin(category, runtime_group, "__shell_loop", vmBuiltinShellLoop);
+    registerShellBuiltin(category, runtime_group, "__shell_loop_end", vmBuiltinShellLoopEnd);
     registerShellBuiltin(category, runtime_group, "__shell_if", vmBuiltinShellIf);
     registerShellBuiltin(category, runtime_group, "__shell_case", vmBuiltinShellCase);
     registerShellBuiltin(category, runtime_group, "__shell_case_clause", vmBuiltinShellCaseClause);

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -47,7 +47,8 @@ static const ShellBuiltinEntry kShellBuiltins[] = {
     {"__shell_case", "__shell_case", 1008},
     {"__shell_case_clause", "__shell_case_clause", 1009},
     {"__shell_case_end", "__shell_case_end", 1010},
-    {"__shell_define_function", "__shell_define_function", 1011}
+    {"__shell_define_function", "__shell_define_function", 1011},
+    {"__shell_loop_end", "__shell_loop_end", 1012}
 };
 
 static char *shellLowercase(const char *name) {

--- a/src/shell/codegen.c
+++ b/src/shell/codegen.c
@@ -299,6 +299,7 @@ static void compileLoop(BytecodeChunk *chunk, const ShellLoop *loop, int line) {
     emitBuiltinProc(chunk, "__shell_loop", 1, line);
     compilePipeline(chunk, loop->condition, false);
     compileProgram(chunk, loop->body);
+    emitBuiltinProc(chunk, "__shell_loop_end", 0, line);
 }
 
 static void compileConditional(BytecodeChunk *chunk, const ShellConditional *conditional, int line) {


### PR DESCRIPTION
## Summary
- extend the shell runtime to track errexit, trap, local, and loop-control flags
- implement minimal set/trap/local/break/continue builtins and register them with the frontend
- ensure errexit triggers an interpreter abort by wiring VM context tracking into shell helpers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e0419a975c8329b1cbba67d300c924