### PR TITLE
Fix job control handling for exsh

### DIFF
--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -144,6 +144,7 @@ int shellRuntimeLastStatus(void);
 void shellRuntimeRecordHistory(const char *line);
 void shellRuntimeSetArg0(const char *name);
 const char *shellRuntimeGetArg0(void);
+void shellRuntimeInitJobControl(void);
 size_t shellRuntimeHistoryCount(void);
 bool shellRuntimeHistoryGetEntry(size_t reverse_index, char **out_line);
 bool shellRuntimeExpandHistoryReference(const char *input,

--- a/src/backend_ast/shell.c
+++ b/src/backend_ast/shell.c
@@ -3432,6 +3432,21 @@ static int shellSpawnProcess(const ShellCommand *cmd, int stdin_fd, int stdout_f
     posix_spawnattr_t attr;
     posix_spawnattr_init(&attr);
 
+#if defined(POSIX_SPAWN_SETSIGDEF)
+    sigset_t default_signals;
+    sigemptyset(&default_signals);
+    sigaddset(&default_signals, SIGTTIN);
+    sigaddset(&default_signals, SIGTTOU);
+    if (posix_spawnattr_setsigdefault(&attr, &default_signals) == 0) {
+        short attr_flags = 0;
+        if (posix_spawnattr_getflags(&attr, &attr_flags) != 0) {
+            attr_flags = 0;
+        }
+        attr_flags |= POSIX_SPAWN_SETSIGDEF;
+        posix_spawnattr_setflags(&attr, attr_flags);
+    }
+#endif
+
     int result = posix_spawnp(child_pid, cmd->argv[0], &actions, &attr, cmd->argv, environ);
 
     posix_spawnattr_destroy(&attr);

--- a/src/shell/main.c
+++ b/src/shell/main.c
@@ -2345,6 +2345,7 @@ int main(int argc, char **argv) {
     gParamValues = NULL;
 
     if (isatty(STDIN_FILENO)) {
+        shellRuntimeInitJobControl();
         int status = runInteractiveSession(&options);
         return vmExitWithCleanup(status);
     }


### PR DESCRIPTION
## Summary
- ensure the shell front end establishes its own process group and foreground control before running commands
- expose a runtime job-control initializer and invoke it from the interactive entry point

## Testing
- cmake -S . -B build
- cmake --build build --target exsh

------
https://chatgpt.com/codex/tasks/task_b_68e04aa127608329aa8581123d04c7f6