### PR TITLE
Add colon builtin to exsh shell runtime

### DIFF
--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -137,6 +137,7 @@ Value vmBuiltinShellFg(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellBg(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellWait(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellBuiltin(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinShellColon(struct VM_s* vm, int arg_count, Value* args);
 Value vmHostShellLastStatus(struct VM_s* vm);
 Value vmHostShellPollJobs(struct VM_s* vm);
 bool shellRuntimeConsumeExitRequested(void);

--- a/src/backend_ast/shell.c
+++ b/src/backend_ast/shell.c
@@ -2875,7 +2875,7 @@ static bool shellIsRuntimeBuiltin(const char *name) {
     }
     static const char *kBuiltins[] = {"cd",    "pwd",    "exit",    "export",  "unset",    "setenv",   "unsetenv",
                                       "set",   "trap",   "local",  "break",   "continue", "alias",    "history",
-                                      "jobs",  "fg",     "bg",     "wait",    "builtin",  "source"};
+                                      "jobs",  "fg",     "bg",     "wait",    "builtin",  "source",   ":"};
 
     size_t count = sizeof(kBuiltins) / sizeof(kBuiltins[0]);
     for (size_t i = 0; i < count; ++i) {
@@ -4315,6 +4315,14 @@ Value vmBuiltinShellPwd(VM *vm, int arg_count, Value *args) {
         return makeVoid();
     }
     printf("%s\n", cwd);
+    shellUpdateStatus(0);
+    return makeVoid();
+}
+
+Value vmBuiltinShellColon(VM *vm, int arg_count, Value *args) {
+    (void)vm;
+    (void)arg_count;
+    (void)args;
     shellUpdateStatus(0);
     return makeVoid();
 }

--- a/src/ext_builtins/shell_frontend.c
+++ b/src/ext_builtins/shell_frontend.c
@@ -49,4 +49,5 @@ void registerShellFrontendBuiltins(void) {
     registerShellBuiltin(category, command_group, "bg", vmBuiltinShellBg);
     registerShellBuiltin(category, command_group, "wait", vmBuiltinShellWait);
     registerShellBuiltin(category, command_group, "builtin", vmBuiltinShellBuiltin);
+    registerShellBuiltin(category, command_group, ":", vmBuiltinShellColon);
 }

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -37,6 +37,7 @@ static const ShellBuiltinEntry kShellBuiltins[] = {
     {"local", "local", 23},
     {"break", "break", 24},
     {"continue", "continue", 25},
+    {":", ":", 26},
     {"__shell_exec", "__shell_exec", 1001},
     {"__shell_pipeline", "__shell_pipeline", 1002},
     {"__shell_and", "__shell_and", 1003},


### PR DESCRIPTION
## Summary
- add a dedicated `:` builtin handler that simply returns success so scripts can use it like bash
- register the colon builtin across the shell frontend tables so it is detected as a runtime builtin

## Testing
- cmake -S . -B build
- cmake --build build --target exsh
- timeout 3 build/bin/exsh /tmp/one

------
https://chatgpt.com/codex/tasks/task_b_68e080f93f1c8329b31795abdf1a9ccf