### PR TITLE
Add brace group metadata and pipeline helpers

### DIFF
--- a/src/shell/codegen.c
+++ b/src/shell/codegen.c
@@ -482,6 +482,9 @@ static void compileCommand(BytecodeChunk *chunk, const ShellCommand *command, bo
         case SHELL_COMMAND_SUBSHELL:
             compileSubshell(chunk, command->data.subshell.body, command->line, command->exec.pipeline_index);
             break;
+        case SHELL_COMMAND_BRACE_GROUP:
+            compileProgram(chunk, command->data.brace_group.body);
+            break;
         case SHELL_COMMAND_LOOP:
             compileLoop(chunk, command->data.loop, command->line);
             break;

--- a/src/shell/parser.c
+++ b/src/shell/parser.c
@@ -234,7 +234,7 @@ static ShellPipeline *parsePipeline(ShellParser *parser) {
         return NULL;
     }
 
-    pipeline->negated = negate;
+    shellPipelineSetNegated(pipeline, negate);
 
     ShellCommand *command = parsePrimary(parser);
     if (!command) {

--- a/src/shell/semantics.c
+++ b/src/shell/semantics.c
@@ -370,6 +370,9 @@ static void shellAnalyzeCommand(ShellSemanticContext *ctx, ShellCommand *command
         case SHELL_COMMAND_SUBSHELL:
             shellAnalyzeProgramInternal(ctx, command->data.subshell.body);
             break;
+        case SHELL_COMMAND_BRACE_GROUP:
+            shellAnalyzeProgramInternal(ctx, command->data.brace_group.body);
+            break;
         case SHELL_COMMAND_LOOP:
             shellAnalyzeLoop(ctx, command->data.loop);
             break;


### PR DESCRIPTION
## Summary
- extend the shell AST to model brace-group compound commands and expose redirection accessors for non-simple commands
- track here-document payloads, descriptor-duplication targets, and explicit pipeline negation with dedicated helpers and JSON encoding
- update parser, semantics, and code generation to use the new helpers and free the additional allocations

## Testing
- cmake -S . -B build
- cmake --build build


------
https://chatgpt.com/codex/tasks/task_b_68e09cf8a340832993114972984c202b