### PR TITLE
Fix function name retention and pipeline negation

### DIFF
--- a/Tests/shell/tests/parser_negated_pipeline.psh
+++ b/Tests/shell/tests/parser_negated_pipeline.psh
@@ -1,0 +1,26 @@
+echo "bang:start"
+if ! false; then
+  echo "negate-false"
+fi
+
+if ! true; then
+  echo "negate-true"
+else
+  echo "negate-true-else"
+fi
+
+if ! ! true; then
+  echo "double-negation"
+fi
+
+if ! printf 'foo\n' | grep -q foo; then
+  echo "pipeline-negated"
+else
+  echo "pipeline-negated-else"
+fi
+
+! printf 'status\n' >/dev/null
+if [ "$?" -ne 0 ]; then
+  echo "negated-pipeline-status"
+fi
+echo "bang:end"


### PR DESCRIPTION
## Summary
- duplicate function definition names during parsing so tokens remain valid through AST construction
- apply pipeline negation semantics when single-stage pipelines run builtins or assignments
- quote the status check in the negated pipeline fixture to cover the new behavior

## Testing
- cmake --build build --target exsh
- python3 Tests/shell/shell_test_harness.py --only parser_negated_pipeline
- python3 Tests/shell/shell_test_harness.py --only shell_function_definition

------
https://chatgpt.com/codex/tasks/task_b_68e0a151b74c8329b99d9caf9c71f97f