### PR TITLE
Fix parser state fields and heredoc redirection encoding

### DIFF
--- a/src/shell/parser.h
+++ b/src/shell/parser.h
@@ -9,12 +9,16 @@
 extern "C" {
 #endif
 
+struct ShellPendingHereDocArray;
+
 typedef struct {
     ShellLexer lexer;
     ShellToken current;
     ShellToken previous;
     bool had_error;
     bool panic_mode;
+    unsigned int next_rule_mask;
+    struct ShellPendingHereDocArray *pending_here_docs;
 } ShellParser;
 
 ShellProgram *shellParseString(const char *source, ShellParser *parser);


### PR DESCRIPTION
## Summary
- extend the shell parser struct with the fields used to track rule masks and pending here-docs
- hex-encode here-document bodies into redirection metadata so runtime execution receives their payloads

## Testing
- cmake --build build --target exsh

------
https://chatgpt.com/codex/tasks/task_b_68e0f35f657083298cbbb4febecbba9b