### PR TITLE
Restore ShellParser state fields for heredoc handling

### DIFF
--- a/src/shell/parser.h
+++ b/src/shell/parser.h
@@ -9,12 +9,16 @@
 extern "C" {
 #endif
 
+typedef struct ShellPendingHereDocArray ShellPendingHereDocArray;
+
 typedef struct {
     ShellLexer lexer;
     ShellToken current;
     ShellToken previous;
     bool had_error;
     bool panic_mode;
+    unsigned int next_rule_mask;
+    ShellPendingHereDocArray *pending_here_docs;
 } ShellParser;
 
 ShellProgram *shellParseString(const char *source, ShellParser *parser);


### PR DESCRIPTION
## Summary
- add forward declaration for ShellPendingHereDocArray in the parser header
- restore ShellParser state fields for rule masks and pending here-doc tracking

## Testing
- cmake -S . -B build
- cmake --build build --target exsh

------
https://chatgpt.com/codex/tasks/task_b_68e0f69d3ce48329a3641c89847bc870