### PR TITLE
Fix shell lexer parsing for special parameter tokens

### DIFF
--- a/src/shell/lexer.c
+++ b/src/shell/lexer.c
@@ -229,9 +229,13 @@ static ShellToken scanParameter(ShellLexer *lexer) {
             }
         }
     } else {
-        while (isalnum(c) || c == '_' || c == '#') {
+        if (c == '?' || c == '@' || c == '*' || c == '!' || c == '-' || c == '$') {
             advanceChar(lexer);
-            c = peekChar(lexer);
+        } else {
+            while (isalnum(c) || c == '_' || c == '#') {
+                advanceChar(lexer);
+                c = peekChar(lexer);
+            }
         }
     }
     size_t end = lexer->pos;
@@ -430,7 +434,7 @@ static ShellToken scanWord(ShellLexer *lexer) {
                 eqSuppressDepth--;
                 continue;
             } else {
-                while (isalnum(next) || next == '_' || next == '#') {
+                if (next == '?' || next == '@' || next == '*' || next == '!' || next == '-' || next == '$') {
                     if (bufLen + 1 >= bufCap) {
                         bufCap = bufCap ? bufCap * 2 : 32;
                         char *tmp3 = (char *)realloc(buffer, bufCap);
@@ -441,7 +445,20 @@ static ShellToken scanWord(ShellLexer *lexer) {
                         buffer = tmp3;
                     }
                     buffer[bufLen++] = (char)advanceChar(lexer);
-                    next = peekChar(lexer);
+                } else {
+                    while (isalnum(next) || next == '_' || next == '#') {
+                        if (bufLen + 1 >= bufCap) {
+                            bufCap = bufCap ? bufCap * 2 : 32;
+                            char *tmp3 = (char *)realloc(buffer, bufCap);
+                            if (!tmp3) {
+                                free(buffer);
+                                return makeErrorToken(lexer, "Out of memory while scanning word");
+                            }
+                            buffer = tmp3;
+                        }
+                        buffer[bufLen++] = (char)advanceChar(lexer);
+                        next = peekChar(lexer);
+                    }
                 }
                 continue;
             }


### PR DESCRIPTION
## Summary
- ensure the shell lexer keeps special parameters such as `$?`, `$@`, `$*`, `$-`, `$!`, and `$$` inside a single token
- allow scripts using these parameters to expand correctly instead of splitting them into separate words

## Testing
- build/bin/exsh /tmp/test2.psh

------
https://chatgpt.com/codex/tasks/task_b_68e14be647748329bc25aed93c4f9469