### PR TITLE
Require NAME tokens after shell for loops

### DIFF
--- a/Tests/shell/tests/manifest.json
+++ b/Tests/shell/tests/manifest.json
@@ -191,6 +191,24 @@
             "script": "Tests/shell/tests/for_case_layouts.psh",
             "expect": "runtime_ok",
             "expected_stdout": "for-case:start\ncase:one\ncase:two-three:two\ncase:two-three:three\ncase:quoted:quoted value\ncase:rest:four\nfor-case:end"
+        },
+        {
+            "id": "grammar_for_valid_name",
+            "name": "For loops require valid shell names",
+            "category": "grammar",
+            "description": "Simple for loop with a valid name parses and executes.",
+            "script": "Tests/shell/tests/parser_for_valid_name.psh",
+            "expect": "runtime_ok",
+            "expected_stdout": "parser-for-valid:start\nparser-for-valid:body:one\nparser-for-valid:body:two\nparser-for-valid:body:three\nparser-for-valid:end"
+        },
+        {
+            "id": "grammar_for_invalid_name",
+            "name": "For loops reject invalid names",
+            "category": "grammar",
+            "description": "Parser emits a syntax error when the loop variable is not a name token.",
+            "script": "Tests/shell/tests/parser_for_invalid_name.psh",
+            "expect": "parse_error",
+            "expected_stderr_substring": "Expected name after 'for'"
         }
     ]
 }

--- a/Tests/shell/tests/parser_for_invalid_name.psh
+++ b/Tests/shell/tests/parser_for_invalid_name.psh
@@ -1,0 +1,7 @@
+echo "parser-for-invalid:start"
+
+for 1bad in one two; do
+  echo "parser-for-invalid:body"
+done
+
+echo "parser-for-invalid:end"

--- a/Tests/shell/tests/parser_for_valid_name.psh
+++ b/Tests/shell/tests/parser_for_valid_name.psh
@@ -1,0 +1,7 @@
+echo "parser-for-valid:start"
+
+for foo in one two three; do
+  echo "parser-for-valid:body:$foo"
+done
+
+echo "parser-for-valid:end"

--- a/src/shell/parser.c
+++ b/src/shell/parser.c
@@ -947,7 +947,7 @@ static ShellCommand *parseForClause(ShellParser *parser) {
 
     parserScheduleRuleMask(parser, RULE_MASK_FOR_NAME);
     shellParserAdvance(parser);
-    if (parser->previous.type != SHELL_TOKEN_NAME && parser->previous.type != SHELL_TOKEN_WORD) {
+    if (parser->previous.type != SHELL_TOKEN_NAME) {
         parserErrorAt(parser, &parser->previous, "Expected name after 'for'");
         return NULL;
     }


### PR DESCRIPTION
## Summary
- restrict the shell parser to accept only NAME tokens immediately after the `for` keyword
- add regression fixtures for valid and invalid `for` loop names in the shell test suite

## Testing
- python3 Tests/shell/shell_test_harness.py --only grammar_for_valid_name *(fails: exsh executable not built in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e18341027483299614eed917b30591