### PR TITLE
Enforce shell function keyword syntax

### DIFF
--- a/Tests/shell/tests/manifest.json
+++ b/Tests/shell/tests/manifest.json
@@ -209,6 +209,33 @@
             "script": "Tests/shell/tests/parser_for_invalid_name.psh",
             "expect": "parse_error",
             "expected_stderr_substring": "Expected name after 'for'"
+        },
+        {
+            "id": "grammar_function_valid_keyword",
+            "name": "function keyword requires parentheses",
+            "category": "grammar",
+            "description": "function foo() form registers and executes a shell function.",
+            "script": "Tests/shell/tests/parser_function_valid_keyword.psh",
+            "expect": "runtime_ok",
+            "expected_stdout": "parser-function-valid:start\nparser-function-valid:body\nparser-function-valid:end"
+        },
+        {
+            "id": "grammar_function_invalid_name",
+            "name": "function keyword rejects invalid names",
+            "category": "grammar",
+            "description": "Parser emits a syntax error when function names are not NAME tokens.",
+            "script": "Tests/shell/tests/parser_function_invalid_name.psh",
+            "expect": "parse_error",
+            "expected_stderr_substring": "Expected function name"
+        },
+        {
+            "id": "grammar_function_missing_parens",
+            "name": "function keyword requires parentheses before body",
+            "category": "grammar",
+            "description": "Missing parentheses before the function body triggers a parse error.",
+            "script": "Tests/shell/tests/parser_function_missing_parens.psh",
+            "expect": "parse_error",
+            "expected_stderr_substring": "Expected '(' after function name"
         }
     ]
 }

--- a/Tests/shell/tests/parser_function_invalid_name.psh
+++ b/Tests/shell/tests/parser_function_invalid_name.psh
@@ -1,0 +1,7 @@
+echo "parser-function-invalid-name:start"
+
+function 1bad() {
+  echo "parser-function-invalid-name:body"
+}
+
+echo "parser-function-invalid-name:end"

--- a/Tests/shell/tests/parser_function_missing_parens.psh
+++ b/Tests/shell/tests/parser_function_missing_parens.psh
@@ -1,0 +1,7 @@
+echo "parser-function-missing-parens:start"
+
+function greet {
+  echo "parser-function-missing-parens:body"
+}
+
+echo "parser-function-missing-parens:end"

--- a/Tests/shell/tests/parser_function_valid_keyword.psh
+++ b/Tests/shell/tests/parser_function_valid_keyword.psh
@@ -1,0 +1,9 @@
+echo "parser-function-valid:start"
+
+function greet() {
+  echo "parser-function-valid:body"
+}
+
+greet
+
+echo "parser-function-valid:end"

--- a/src/shell/parser.c
+++ b/src/shell/parser.c
@@ -1154,7 +1154,7 @@ static ShellCommand *parseFunctionDefinition(ShellParser *parser) {
 
     parserScheduleRuleMask(parser, RULE_MASK_FUNCTION_NAME);
     shellParserAdvance(parser);
-    if (parser->previous.type != SHELL_TOKEN_NAME && parser->previous.type != SHELL_TOKEN_WORD) {
+    if (parser->previous.type != SHELL_TOKEN_NAME) {
         parserErrorAt(parser, &parser->previous, "Expected function name");
         return NULL;
     }
@@ -1165,11 +1165,15 @@ static ShellCommand *parseFunctionDefinition(ShellParser *parser) {
         return NULL;
     }
 
-    if (parser->current.type == SHELL_TOKEN_LPAREN) {
-        parserScheduleRuleMask(parser, RULE_MASK_COMMAND_START);
-        shellParserAdvance(parser);
-        shellParserConsume(parser, SHELL_TOKEN_RPAREN, "Expected ')' after function name");
-        parseLinebreak(parser);
+    parserScheduleRuleMask(parser, RULE_MASK_COMMAND_START);
+    shellParserConsume(parser, SHELL_TOKEN_LPAREN, "Expected '(' after function name");
+    parserScheduleRuleMask(parser, RULE_MASK_COMMAND_START);
+    shellParserConsume(parser, SHELL_TOKEN_RPAREN, "Expected ')' after function name");
+    parseLinebreak(parser);
+
+    if (parser->had_error) {
+        free(name_copy);
+        return NULL;
     }
 
     ShellCommand *body_command = parseCompoundCommand(parser);


### PR DESCRIPTION
## Summary
- require shell function definitions declared with the function keyword to use NAME tokens and parentheses
- add parser regression tests for valid and invalid function keyword usages

## Testing
- python3 Tests/shell/shell_test_harness.py --only grammar_function *(fails: exsh executable not built)*

------
https://chatgpt.com/codex/tasks/task_b_68e186dec0a88329bd2075b2bf34f064