### PR TITLE
Initialize merge_pattern before early exits

### DIFF
--- a/src/backend_ast/shell.c
+++ b/src/backend_ast/shell.c
@@ -5144,6 +5144,7 @@ cleanup:
 Value vmBuiltinShellPipeline(VM *vm, int arg_count, Value *args) {
     VM *previous_vm = shellSwapCurrentVm(vm);
     Value result = makeVoid();
+    char *merge_pattern = NULL;
     if (arg_count != 1 || args[0].type != TYPE_STRING || !args[0].s_val) {
         runtimeError(vm, "shell pipeline: expected metadata string");
         goto cleanup;
@@ -5154,7 +5155,6 @@ Value vmBuiltinShellPipeline(VM *vm, int arg_count, Value *args) {
     const char *meta = args[0].s_val;
     size_t stages = 0;
     bool negated = false;
-    char *merge_pattern = NULL;
     char *copy = strdup(meta);
     if (!copy) {
         runtimeError(vm, "shell pipeline: out of memory");


### PR DESCRIPTION
## Summary
- initialize the shell pipeline merge_pattern pointer before early cleanup paths so it is always defined

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_b_68e1bd6c7f7c8329b93482d4369a701a