### PR TITLE
Add read builtin to exsh runtime

### DIFF
--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -122,6 +122,7 @@ Value vmBuiltinShellPwd(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellSource(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellEval(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellExit(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinShellRead(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellSetenv(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellExport(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellUnset(struct VM_s* vm, int arg_count, Value* args);

--- a/src/ext_builtins/shell_frontend.c
+++ b/src/ext_builtins/shell_frontend.c
@@ -32,6 +32,7 @@ void registerShellFrontendBuiltins(void) {
     registerShellBuiltin(category, command_group, "cd", vmBuiltinShellCd);
     registerShellBuiltin(category, command_group, "pwd", vmBuiltinShellPwd);
     registerShellBuiltin(category, command_group, "source", vmBuiltinShellSource);
+    registerShellBuiltin(category, command_group, "read", vmBuiltinShellRead);
     registerShellBuiltin(category, command_group, "eval", vmBuiltinShellEval);
     registerShellBuiltin(category, command_group, "exit", vmBuiltinShellExit);
     registerShellBuiltin(category, command_group, "set", vmBuiltinShellSet);


### PR DESCRIPTION
## Summary
- add a VM builtin that implements the shell `read` command, including prompt handling and variable assignment
- register the new builtin so the shell runtime invokes it instead of spawning an external process

## Testing
- cmake -S . -B build
- cmake --build build --target exsh
- printf 'Mike\n' | build/bin/exsh /tmp/four
- printf 'Mike\n' | bash /tmp/four


------
https://chatgpt.com/codex/tasks/task_b_68e1be530b108329b53ed8e893564ac8