### PR TITLE
Fix exsh if/elif parsing bug

### DIFF
--- a/src/shell/parser.c
+++ b/src/shell/parser.c
@@ -932,8 +932,6 @@ static ShellCommand *parseIfClause(ShellParser *parser) {
         ShellCommand *elif_cmd = parseIfClause(parser);
         else_block = shellCreateProgram();
         shellProgramAddCommand(else_block, elif_cmd);
-        parserReclassifyCurrentToken(parser, RULE_MASK_COMMAND_START);
-        shellParserConsume(parser, SHELL_TOKEN_FI, "Expected 'fi' to close if");
     } else if (parser->current.type == SHELL_TOKEN_ELSE) {
         parserScheduleRuleMask(parser, RULE_MASK_COMMAND_START);
         shellParserAdvance(parser);


### PR DESCRIPTION
## Summary
- stop consuming the closing `fi` token after recursively parsing an `elif` branch
- allow `if` statements with `elif` chains to parse like bash

## Testing
- `Tests/run_shell_tests.sh` *(fails: exsh executable not built in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e1f03c836c83298254f0209412ace3