### PR TITLE
Fix exsh comment skipping to retain newlines

### DIFF
--- a/Tests/exsh/tests/manifest.json
+++ b/Tests/exsh/tests/manifest.json
@@ -254,6 +254,15 @@
             "script": "Tests/exsh/tests/parser_function_missing_parens.psh",
             "expect": "parse_error",
             "expected_stderr_substring": "Expected '(' after function name"
+        },
+        {
+            "id": "grammar_if_comment_boundary",
+            "name": "Comments between branches preserve newline separators",
+            "category": "grammar",
+            "description": "Ensures comments between then/elif do not remove the separating newline.",
+            "script": "Tests/exsh/tests/parser_if_comment_boundary.psh",
+            "expect": "runtime_ok",
+            "expected_stdout": "if-comment:start\nbranch:then\nif-comment:end"
         }
     ]
 }

--- a/Tests/exsh/tests/parser_if_comment_boundary.psh
+++ b/Tests/exsh/tests/parser_if_comment_boundary.psh
@@ -1,0 +1,10 @@
+echo "if-comment:start"
+if true; then
+  echo "branch:then"
+# comment bridging then/elif
+elif false; then
+  echo "branch:elif"
+else
+  echo "branch:else"
+fi
+echo "if-comment:end"

--- a/src/shell/lexer.c
+++ b/src/shell/lexer.c
@@ -44,6 +44,21 @@ static int advanceChar(ShellLexer *lexer) {
     return c;
 }
 
+static void skipCommentToNewline(ShellLexer *lexer) {
+    if (!lexer) {
+        return;
+    }
+    // The caller peeked '#' but has not consumed it yet.
+    advanceChar(lexer); // consume '#'
+    while (true) {
+        int next = peekChar(lexer);
+        if (next == '\n' || next == EOF) {
+            break;
+        }
+        advanceChar(lexer);
+    }
+}
+
 static void skipInlineWhitespace(ShellLexer *lexer) {
     while (true) {
         int c = peekChar(lexer);
@@ -52,10 +67,8 @@ static void skipInlineWhitespace(ShellLexer *lexer) {
             continue;
         }
         if (c == '#') {
-            // Shell comments: skip until newline
-            while (c != '\n' && c != EOF) {
-                c = advanceChar(lexer);
-            }
+            // Shell comments: skip until newline but preserve the newline itself.
+            skipCommentToNewline(lexer);
             continue;
         }
         break;
@@ -644,10 +657,8 @@ ShellToken shellNextToken(ShellLexer *lexer) {
             continue;
         }
         if (c == '#') {
-            // skip comment until newline
-            while (c != '\n' && c != EOF) {
-                c = advanceChar(lexer);
-            }
+            // Skip comment but leave newline for subsequent handling.
+            skipCommentToNewline(lexer);
             continue;
         }
         break;


### PR DESCRIPTION
## Summary
- keep newline tokens when skipping shell comments so compound conditionals continue parsing after comment lines
- add a regression test covering comments that sit between `then`/`elif` branches

## Testing
- cmake -S . -B build
- cmake --build build --target exsh
- Tests/run_shell_tests.sh --only comment_boundary

------
https://chatgpt.com/codex/tasks/task_b_68e1f3a9f3288329a0d0147599fe9178