### PR TITLE
Fix exsh handling of double-bracket tests

### DIFF
--- a/src/backend_ast/shell.c
+++ b/src/backend_ast/shell.c
@@ -958,6 +958,35 @@ static bool shellCommandAppendArgOwned(ShellCommand *cmd, char *value) {
     return true;
 }
 
+static void shellRewriteDoubleBracketTest(ShellCommand *cmd) {
+    if (!cmd || cmd->argc < 2 || !cmd->argv) {
+        return;
+    }
+    char *first = cmd->argv[0];
+    if (!first || strcmp(first, "[[") != 0) {
+        return;
+    }
+    size_t last_index = cmd->argc - 1;
+    char *last = cmd->argv[last_index];
+    if (!last || strcmp(last, "]]") != 0) {
+        return;
+    }
+
+    free(last);
+    cmd->argv[last_index] = NULL;
+    cmd->argc = last_index;
+
+    if (cmd->argv) {
+        cmd->argv[cmd->argc] = NULL;
+    }
+
+    char *replacement = strdup("test");
+    if (replacement) {
+        free(first);
+        cmd->argv[0] = replacement;
+    }
+}
+
 static bool shellCommandAppendAssignmentOwned(ShellCommand *cmd, char *value) {
     if (!cmd || !value) {
         free(value);
@@ -4718,6 +4747,7 @@ static bool shellBuildCommand(VM *vm, int arg_count, Value *args, ShellCommand *
             }
         }
     }
+    shellRewriteDoubleBracketTest(out_cmd);
     return true;
 }
 


### PR DESCRIPTION
## Summary
- add a helper that rewrites [[ … ]] commands into plain test invocations before execution
- call the helper during command construction so double-bracket conditions no longer try to spawn a [[ binary

## Testing
- cmake --build build --target exsh
- build/bin/exsh --dump-bytecode /tmp/five /etc/passwd

------
https://chatgpt.com/codex/tasks/task_b_68e2750f975c8329af896106861eaf10