### PR TITLE
Handle bang tokens as words in exsh command bodies

### DIFF
--- a/Tests/exsh/tests/manifest.json
+++ b/Tests/exsh/tests/manifest.json
@@ -256,6 +256,15 @@
             "expected_stderr_substring": "Expected '(' after function name"
         },
         {
+            "id": "grammar_double_bracket_negation",
+            "name": "[[ ! -f ]] conditions accept unary negation",
+            "category": "grammar",
+            "description": "Double-bracket tests treat ! as part of the conditional expression when not at command start.",
+            "script": "Tests/exsh/tests/parser_double_bracket_negation.psh",
+            "expect": "runtime_ok",
+            "expected_stdout": "double-bracket:start\nbranch:missing\nbranch:now-present\ndouble-bracket:end"
+        },
+        {
             "id": "grammar_if_comment_boundary",
             "name": "Comments between branches preserve newline separators",
             "category": "grammar",

--- a/Tests/exsh/tests/parser_double_bracket_negation.psh
+++ b/Tests/exsh/tests/parser_double_bracket_negation.psh
@@ -1,0 +1,15 @@
+echo "double-bracket:start"
+FILE="tmp_exsh_double_bracket.txt"
+if [[ ! -f "$FILE" ]]; then
+  echo "branch:missing"
+else
+  echo "branch:present"
+fi
+touch "$FILE"
+if [[ ! -f "$FILE" ]]; then
+  echo "branch:still-missing"
+else
+  echo "branch:now-present"
+fi
+rm -f "$FILE"
+echo "double-bracket:end"

--- a/src/shell/lexer.c
+++ b/src/shell/lexer.c
@@ -704,8 +704,11 @@ ShellToken shellNextToken(ShellLexer *lexer) {
             return makeSimpleToken(lexer, SHELL_TOKEN_AMPERSAND, "&", 1);
         }
         case '!': {
-            advanceChar(lexer);
-            return makeSimpleToken(lexer, SHELL_TOKEN_BANG, "!", 1);
+            if ((lexer->rule_mask & SHELL_LEXER_RULE_1) != 0) {
+                advanceChar(lexer);
+                return makeSimpleToken(lexer, SHELL_TOKEN_BANG, "!", 1);
+            }
+            break;
         }
         case '|': {
             advanceChar(lexer);


### PR DESCRIPTION
## Summary
- make the lexer emit BANG tokens only at command starts so `!` can appear inside double-bracket tests
- add a regression script for `[[ ! -f ]]` conditionals and register it in the exsh manifest

## Testing
- Tests/run_shell_tests.sh --only grammar_double_bracket_negation

------
https://chatgpt.com/codex/tasks/task_b_68e2799197008329bf629154cb9a80e4