### PR TITLE
Improve exsh tab completion and add finger builtin

### DIFF
--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -141,6 +141,7 @@ Value vmBuiltinShellBg(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellWait(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellBuiltin(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellColon(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinShellFinger(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellReturn(struct VM_s* vm, int arg_count, Value* args);
 Value vmHostShellLastStatus(struct VM_s* vm);
 Value vmHostShellLoopAdvance(struct VM_s* vm);

--- a/src/ext_builtins/shell_frontend.c
+++ b/src/ext_builtins/shell_frontend.c
@@ -42,6 +42,7 @@ void registerShellFrontendBuiltins(void) {
     registerShellBuiltin(category, command_group, "unset", vmBuiltinShellUnset);
     registerShellBuiltin(category, command_group, "unsetenv", vmBuiltinShellUnsetenv);
     registerShellBuiltin(category, command_group, "return", vmBuiltinShellReturn);
+    registerShellBuiltin(category, command_group, "finger", vmBuiltinShellFinger);
     registerShellBuiltin(category, command_group, "trap", vmBuiltinShellTrap);
     registerShellBuiltin(category, command_group, "local", vmBuiltinShellLocal);
     registerShellBuiltin(category, command_group, "break", vmBuiltinShellBreak);

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -42,6 +42,7 @@ static const ShellBuiltinEntry kShellBuiltins[] = {
     {":", ":", 26},
     {"eval", "eval", 27},
     {"return", "return", 28},
+    {"finger", "finger", 29},
     {"__shell_exec", "__shell_exec", 1001},
     {"__shell_pipeline", "__shell_pipeline", 1002},
     {"__shell_and", "__shell_and", 1003},

--- a/src/shell/main.c
+++ b/src/shell/main.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <signal.h>
 #include <termios.h>
 #include <time.h>
@@ -1117,6 +1118,56 @@ static size_t interactiveFindWordStart(const char *buffer, size_t length) {
     return index;
 }
 
+static bool interactiveExtractCommandToken(const char *buffer,
+                                           size_t length,
+                                           size_t word_start,
+                                           size_t *out_start,
+                                           size_t *out_len) {
+    if (!buffer || word_start > length) {
+        return false;
+    }
+
+    size_t command_start = 0;
+    for (size_t i = 0; i < word_start; ++i) {
+        unsigned char c = (unsigned char)buffer[i];
+        if (c == ';' || c == '&' || c == '|' || c == '\n' || c == '\r' ||
+            c == '(' || c == ')') {
+            command_start = i + 1;
+        }
+    }
+
+    while (command_start < word_start &&
+           isspace((unsigned char)buffer[command_start])) {
+        command_start++;
+    }
+
+    if (command_start >= length) {
+        return false;
+    }
+
+    size_t command_end = command_start;
+    while (command_end < length) {
+        unsigned char c = (unsigned char)buffer[command_end];
+        if (isspace(c) || c == ';' || c == '&' || c == '|' ||
+            c == '(' || c == ')') {
+            break;
+        }
+        command_end++;
+    }
+
+    if (command_end <= command_start) {
+        return false;
+    }
+
+    if (out_start) {
+        *out_start = command_start;
+    }
+    if (out_len) {
+        *out_len = command_end - command_start;
+    }
+    return true;
+}
+
 static bool interactiveWordLooksDynamic(const char *word) {
     if (!word || !*word) {
         return false;
@@ -1177,9 +1228,6 @@ static bool interactiveHandleTabCompletion(const char *prompt,
         return false;
     }
     size_t word_start = interactiveFindWordStart(*buffer, *length);
-    if (word_start >= *length) {
-        return false;
-    }
     char *word = *buffer + word_start;
     size_t word_len = *length - word_start;
     if (interactiveWordLooksDynamic(word)) {
@@ -1208,6 +1256,42 @@ static bool interactiveHandleTabCompletion(const char *prompt,
     if (glob_status != 0 || results.gl_pathc == 0) {
         globfree(&results);
         return false;
+    }
+
+    size_t command_start = 0;
+    size_t command_len = 0;
+    bool command_is_cd = false;
+    if (interactiveExtractCommandToken(*buffer,
+                                       *length,
+                                       word_start,
+                                       &command_start,
+                                       &command_len) &&
+        word_start > command_start) {
+        const char *command = *buffer + command_start;
+        if (command_len == 2) {
+            if (strncasecmp(command, "cd", command_len) == 0) {
+                command_is_cd = true;
+            }
+        }
+    }
+
+    if (command_is_cd) {
+        size_t write_index = 0;
+        for (size_t i = 0; i < results.gl_pathc; ++i) {
+            const char *match = results.gl_pathv[i];
+            if (!match) {
+                continue;
+            }
+            size_t match_len = strlen(match);
+            if (match_len > 0 && match[match_len - 1] == '/') {
+                results.gl_pathv[write_index++] = results.gl_pathv[i];
+            }
+        }
+        results.gl_pathc = write_index;
+        if (results.gl_pathc == 0) {
+            globfree(&results);
+            return false;
+        }
     }
 
     size_t replacement_len = 0;
@@ -1257,11 +1341,7 @@ static bool interactiveHandleTabCompletion(const char *prompt,
         return false;
     }
 
-    if (results.gl_pathc == 1) {
-        memcpy(*buffer + word_start, results.gl_pathv[0], replacement_len);
-    } else {
-        memcpy(*buffer + word_start, results.gl_pathv[0], replacement_len);
-    }
+    memcpy(*buffer + word_start, results.gl_pathv[0], replacement_len);
     if (append_space) {
         (*buffer)[word_start + replacement_len] = ' ';
         replacement_len += 1;


### PR DESCRIPTION
## Summary
- allow interactive tab completion to surface empty-word matches so `ls <tab>` lists entries and `cd <tab>` filters to directories
- add a basic `finger` builtin that reports passwd information and register it with the exsh frontend

## Testing
- `Tests/run_shell_tests.sh` *(fails: exsh executable not found in build/bin)*

------
https://chatgpt.com/codex/tasks/task_b_68e2893a5740832992ece7773b21bd24