### PR TITLE
Add RANDOM parameter support to exsh

### DIFF
--- a/Tests/exsh/tests/manifest.json
+++ b/Tests/exsh/tests/manifest.json
@@ -139,6 +139,15 @@
             "expected_stdout": "arithmetic:start\nmath:14\nvars:10\ndollar:6\nnested:3\nbad:$((BAR+))\nstatus:1\narithmetic:end"
         },
         {
+            "id": "random_parameter",
+            "name": "RANDOM parameter generates seeded pseudo-random values",
+            "category": "expansion",
+            "description": "RANDOM supports seeding and yields 0-32767 values rather than a constant.",
+            "script": "Tests/exsh/tests/random_parameter.psh",
+            "expect": "runtime_ok",
+            "expected_stdout": "random:test-start\nrandom:first:16838\nrandom:second:5758\nrandom:reset:16838\nrandom:test-end"
+        },
+        {
             "id": "jobs_foreground",
             "name": "jobs lists and fg reaps background work",
             "category": "jobs",

--- a/Tests/exsh/tests/random_parameter.psh
+++ b/Tests/exsh/tests/random_parameter.psh
@@ -1,0 +1,13 @@
+#!/usr/bin/env exsh
+
+echo "random:test-start"
+RANDOM=1
+first=$RANDOM
+second=$RANDOM
+echo "random:first:$first"
+echo "random:second:$second"
+RANDOM=1
+reset=$RANDOM
+echo "random:reset:$reset"
+echo "random:test-end"
+


### PR DESCRIPTION
## Summary
- implement the RANDOM special parameter in exsh with a seeded pseudo-random generator and assignment handling
- skip exporting RANDOM assignments into the environment while allowing reseeding semantics
- add a regression script and manifest entry to verify RANDOM produces deterministic seeded values

## Testing
- cmake --build build --target exsh
- Tests/run_shell_tests.sh --only random_parameter

------
https://chatgpt.com/codex/tasks/task_b_68e29354eea4832999b1735c23bdd213