### PR TITLE
Add help builtin to exsh interactive mode

### DIFF
--- a/Docs/exsh_overview.md
+++ b/Docs/exsh_overview.md
@@ -117,7 +117,8 @@ extends it with orchestration helpers implemented in
 `backend_ast/shell.c`. The following categories are available out of the box:
 
 - Shell control builtins (`cd`, `pwd`, `exit`, `alias`, `export`, `setenv`,
-  `unset`, `unsetenv`).
+  `unset`, `unsetenv`) and an interactive `help` builtin for listing and
+  describing available commands.
 - Pipeline helpers (`__shell_exec`, `__shell_pipeline`, `__shell_and`,
   `__shell_or`, `__shell_subshell`, `__shell_loop`, `__shell_if`).
 - The complete PSCAL builtin catalog (HTTP, sockets, JSON, extended math/string

--- a/Tests/exsh/tests/help_builtin.psh
+++ b/Tests/exsh/tests/help_builtin.psh
@@ -1,0 +1,4 @@
+#!/usr/bin/env exsh
+help
+help source
+help .

--- a/Tests/exsh/tests/manifest.json
+++ b/Tests/exsh/tests/manifest.json
@@ -74,6 +74,15 @@
             "expected_stdout": "source-dot:start\nsource-dot-helper:start\nsource-dot-helper:end\nafter:from-dot\nsource-dot:end"
         },
         {
+            "id": "help_builtin",
+            "name": "help lists shell builtins",
+            "category": "builtins",
+            "description": "help without arguments lists builtins; help name shows details and honours aliases.",
+            "script": "Tests/exsh/tests/help_builtin.psh",
+            "expect": "runtime_ok",
+            "expected_stdout": "exsh builtins. Type 'help name' for detailed usage.\n\nBuiltin     Summary\n------      -------\nalias       Define or display shell aliases.\nbg          Resume a stopped job in the background.\nbreak       Exit from the innermost loop(s).\nbuiltin     Invoke a PSCAL VM builtin directly.\ncd          Change the current working directory.\ncontinue    Skip to the next loop iteration.\neval        Execute words as an inline script.\nexit        Request that the shell terminate.\nexport      Set environment variables or print the environment.\nfg          Move a job to the foreground.\nfinger      Display basic account information.\nhelp        List builtins or describe a specific builtin.\nhistory     Print the interactive history list.\njobs        List active background jobs.\nlocal       Activate the shell's local scope flag.\npwd         Print the current working directory.\nread        Read a line from standard input.\nreturn      Return from the current shell function.\nset         Update shell option flags.\nsetenv      Set or print environment variables.\nshift       Rotate positional parameters to the left.\nsource (.)  Execute a file in the current shell environment.\ntrap        Toggle the shell's trap flag.\nunset       Remove variables from the environment.\nunsetenv    Alias for unset.\nwait        Wait for a job to change state.\n:           Do nothing and succeed.\nsource - Execute a file in the current shell environment.\nAliases: .\nUsage: source file [args ...]\n\nLoads the named file and executes it without spawning a subshell. Positional parameters are temporarily replaced when arguments are supplied. The '.' builtin is an alias.\nsource - Execute a file in the current shell environment.\nAliases: .\nUsage: source file [args ...]\n\nLoads the named file and executes it without spawning a subshell. Positional parameters are temporarily replaced when arguments are supplied. The '.' builtin is an alias.\n"
+        },
+        {
             "id": "pipeline_cache_hit",
             "name": "Pipeline cache reuse emits notice",
             "category": "cache",

--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -143,6 +143,7 @@ Value vmBuiltinShellBuiltin(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellColon(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellFinger(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellReturn(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinShellHelp(struct VM_s* vm, int arg_count, Value* args);
 Value vmHostShellLastStatus(struct VM_s* vm);
 Value vmHostShellLoopAdvance(struct VM_s* vm);
 Value vmHostShellLoopIsReady(struct VM_s* vm);

--- a/src/ext_builtins/shell_frontend.c
+++ b/src/ext_builtins/shell_frontend.c
@@ -53,6 +53,7 @@ void registerShellFrontendBuiltins(void) {
     registerShellBuiltin(category, command_group, "fg", vmBuiltinShellFg);
     registerShellBuiltin(category, command_group, "bg", vmBuiltinShellBg);
     registerShellBuiltin(category, command_group, "wait", vmBuiltinShellWait);
+    registerShellBuiltin(category, command_group, "help", vmBuiltinShellHelp);
     registerShellBuiltin(category, command_group, "builtin", vmBuiltinShellBuiltin);
     registerShellBuiltin(category, command_group, ":", vmBuiltinShellColon);
 }

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -43,6 +43,7 @@ static const ShellBuiltinEntry kShellBuiltins[] = {
     {"eval", "eval", 27},
     {"return", "return", 28},
     {"finger", "finger", 29},
+    {"help", "help", 30},
     {"__shell_exec", "__shell_exec", 1001},
     {"__shell_pipeline", "__shell_pipeline", 1002},
     {"__shell_and", "__shell_and", 1003},


### PR DESCRIPTION
## Summary
- add a help builtin that lists supported shell commands and prints usage details for individual topics
- register the builtin in the shell frontend and document it in the exsh overview
- add a regression script that checks the help output and alias handling

## Testing
- Tests/run_shell_tests.sh --only help_builtin

------
https://chatgpt.com/codex/tasks/task_b_68e2960df2b483298133b9d88afc1ff3