### PR TITLE
Fix SDL cleanup link error when 3D builtins are disabled

### DIFF
--- a/src/backend_ast/sdl.c
+++ b/src/backend_ast/sdl.c
@@ -25,7 +25,11 @@
 #include <string.h>
 #include <strings.h>
 
+#ifdef ENABLE_EXT_BUILTIN_3D
 extern void cleanupBalls3DRenderingResources(void);
+#else
+static void cleanupBalls3DRenderingResources(void) {}
+#endif
 
 #ifdef SDL_VIDEO_DRIVER_X11
 #include <X11/Xlib.h>


### PR DESCRIPTION
## Summary
- provide a local stub for cleanupBalls3DRenderingResources when the 3D builtins are not compiled so SDL cleanup can always link

## Testing
- cmake -S . -B build -DSDL=OFF
- cmake --build build


------
https://chatgpt.com/codex/tasks/task_b_68e2b05d48c08329b6426ea60faad598