### PR TITLE
Fix CI target detection for impacted binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
           CHANGED_FILES_JSON: ${{ steps.changed-files.outputs.all_changed_files_json }}
         run: |
           python3 - <<'PY'
-          import fnmatch
           import json
           import os
+          from pathlib import PurePosixPath
 
           raw = os.environ.get("CHANGED_FILES_JSON", "[]")
           raw = raw.strip() or "[]"
@@ -33,68 +33,76 @@ jobs:
               print(f"Unable to parse changed files payload: {raw}")
               changed = []
 
+          def normalize(path: str) -> PurePosixPath:
+              normalized = path.replace("\\", "/")
+              if normalized.startswith("./"):
+                  normalized = normalized[2:]
+              return PurePosixPath(normalized)
+
+          changed_paths = [normalize(path) for path in changed]
+
           frontends = {
               "clike": [
-                  "src/clike/*",
-                  "Tests/clike/*",
-                  "Tests/libs/clike/*",
+                  "src/clike/**",
+                  "Tests/clike/**",
+                  "Tests/libs/clike/**",
                   "Tests/run_clike_tests.sh",
-                  "Tests/scope_verify/clike/*",
-                  "Examples/clike/*",
-                  "lib/clike/*",
+                  "Tests/scope_verify/clike/**",
+                  "Examples/clike/**",
+                  "lib/clike/**",
               ],
               "exsh": [
-                  "src/shell/*",
-                  "Tests/exsh/*",
+                  "src/shell/**",
+                  "Tests/exsh/**",
                   "Tests/run_shell_tests.sh",
-                  "Examples/exsh/*",
+                  "Examples/exsh/**",
               ],
               "pascal": [
-                  "src/Pascal/*",
-                  "Tests/Pascal/*",
-                  "Tests/libs/pascal/*",
+                  "src/Pascal/**",
+                  "Tests/Pascal/**",
+                  "Tests/libs/pascal/**",
                   "Tests/run_pascal_tests.sh",
-                  "Tests/scope_verify/pascal/*",
-                  "Examples/Pascal/*",
-                  "lib/pascal/*",
+                  "Tests/scope_verify/pascal/**",
+                  "Examples/pascal/**",
+                  "lib/pascal/**",
               ],
               "rea": [
-                  "src/rea/*",
-                  "Tests/rea/*",
-                  "Tests/rea_negatives/*",
-                  "Tests/libs/rea/*",
+                  "src/rea/**",
+                  "Tests/rea/**",
+                  "Tests/rea_negatives/**",
+                  "Tests/libs/rea/**",
                   "Tests/run_rea_tests.sh",
-                  "Tests/scope_verify/rea/*",
-                  "Examples/rea/*",
-                  "lib/rea/*",
+                  "Tests/scope_verify/rea/**",
+                  "Examples/rea/**",
+                  "lib/rea/**",
               ],
           }
 
           core_patterns = [
               "CMakeLists.txt",
-              "cmake/*",
-              "src/core/*",
-              "src/compiler/*",
-              "src/ast/*",
-              "src/backend_ast/*",
-              "src/ext_builtins/*",
-              "src/symbol/*",
-              "src/tools/*",
-              "src/vm/*",
-              "src/third_party/*",
-              "lib/misc/*",
-              "lib/sounds/*",
+              "cmake/**",
+              "src/core/**",
+              "src/compiler/**",
+              "src/ast/**",
+              "src/backend_ast/**",
+              "src/ext_builtins/**",
+              "src/symbol/**",
+              "src/tools/**",
+              "src/vm/**",
+              "src/third_party/**",
+              "lib/misc/**",
+              "lib/sounds/**",
               "Tests/run_all_tests",
               "Tests/run_all_suites.py",
               "Tests/run_json2bc_tests.sh",
-              "Tests/tools/*",
-              "tools/*",
-              "fonts/*",
-              "Examples/shared/*",
+              "Tests/tools/**",
+              "tools/**",
+              "fonts/**",
+              "Examples/shared/**",
           ]
 
           docs_patterns = [
-              "Docs/*",
+              "Docs/**",
               "README.md",
               "CHANGELOG.md",
               "CONTRIBUTING.md",
@@ -104,18 +112,41 @@ jobs:
           ]
 
           workflow_patterns = [
-              ".github/*",
+              ".github/**",
           ]
 
-          def matches(path: str, patterns: list[str]) -> bool:
-              return any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
+          def matches(path: PurePosixPath, patterns: list[str]) -> bool:
+              for pattern in patterns:
+                  normalized_pattern = pattern.replace("\\", "/")
+
+                  if normalized_pattern.endswith("/**"):
+                      root = PurePosixPath(normalized_pattern[:-3])
+                      if root == path or root in path.parents:
+                          return True
+                      continue
+
+                  if normalized_pattern.endswith("/*"):
+                      root = PurePosixPath(normalized_pattern[:-2])
+                      if root == path or root in path.parents:
+                          return True
+                      continue
+
+                  if any(ch in normalized_pattern for ch in "*?["):
+                      if path.match(normalized_pattern):
+                          return True
+                      continue
+
+                  if path == PurePosixPath(normalized_pattern):
+                      return True
+
+              return False
 
           run_frontend = {name: False for name in frontends}
           run_ctest = False
           unclassified = False
           any_code_changes = False
 
-          for path in changed:
+          for path in changed_paths:
               if matches(path, docs_patterns) or matches(path, workflow_patterns):
                   continue
 


### PR DESCRIPTION
## Summary
- normalize changed file paths before matching so CI targets detect Windows-style paths and ./ prefixes
- use recursive pattern matching for frontend/core directories and fix Pascal example path casing to catch nested sources
- leave fallback logic intact so affected binaries are rebuilt instead of being skipped

## Testing
- not run (workflow logic update only)


------
https://chatgpt.com/codex/tasks/task_b_68e2c42be6cc83299b34e4e8eb239347