### PR TITLE
Fix exsh ':' builtin lookup

### DIFF
--- a/Tests/exsh/tests/colon_builtin.psh
+++ b/Tests/exsh/tests/colon_builtin.psh
@@ -1,0 +1,7 @@
+#!/usr/bin/env exsh
+# Ensure the ':' builtin executes in-place without spawning a process.
+: "first no-op"
+while :; do
+    echo "tick"
+    break
+done

--- a/Tests/exsh/tests/manifest.json
+++ b/Tests/exsh/tests/manifest.json
@@ -38,6 +38,15 @@
             "expected_stdout": "loop:start\nwhile:0\nwhile:1\nwhile:2\nuntil:0\nuntil:1\nfor:one\nfor:two\nloop:end"
         },
         {
+            "id": "loop_colon_builtin",
+            "name": "Colon builtin drives control flow",
+            "category": "control",
+            "description": "The ':' builtin executes in-place so while loops can spin without launching processes.",
+            "script": "Tests/exsh/tests/colon_builtin.psh",
+            "expect": "runtime_ok",
+            "expected_stdout": "tick"
+        },
+        {
             "id": "builtin_functions",
             "name": "Builtins update environment and status",
             "category": "builtins",

--- a/src/backend_ast/shell.c
+++ b/src/backend_ast/shell.c
@@ -4143,7 +4143,7 @@ static bool shellIsRuntimeBuiltin(const char *name) {
     static const char *kBuiltins[] = {"cd",     "pwd",     "exit",    "export",  "unset",    "setenv",  "unsetenv",
                                       "set",    "trap",    "local",   "break",   "continue", "alias",   "history",
                                       "jobs",   "fg",      "finger",  "bg",      "wait",    "builtin",  "source",
-                                      "read",   "shift",   "return",  "help"};                                                                                  
+                                      "read",   "shift",   "return",  "help",    ":"};
 
     size_t count = sizeof(kBuiltins) / sizeof(kBuiltins[0]);
     const char *canonical = shellBuiltinCanonicalName(name);


### PR DESCRIPTION
## Summary
- include the ':' builtin in the runtime lookup table so exsh handles it without spawning a process
- add a regression script and manifest entry that exercises a while loop driven by ':'

## Testing
- cmake -S . -B build
- cmake --build build --target exsh
- python3 Tests/exsh/shell_test_harness.py --only loop_colon_builtin


------
https://chatgpt.com/codex/tasks/task_b_68e2c4f12b548329b15e0555ff27180f