### PR TITLE
Ensure non-interactive shell exits on signals

### DIFF
--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -156,6 +156,8 @@ const char *shellRuntimeGetArg0(void);
 void shellRuntimeInitJobControl(void);
 void shellRuntimeInitSignals(void);
 void shellRuntimeProcessPendingSignals(void);
+void shellRuntimeSetExitOnSignal(bool enabled);
+bool shellRuntimeExitOnSignal(void);
 size_t shellRuntimeHistoryCount(void);
 bool shellRuntimeHistoryGetEntry(size_t reverse_index, char **out_line);
 bool shellRuntimeExpandHistoryReference(const char *input,

--- a/src/shell/main.c
+++ b/src/shell/main.c
@@ -2609,6 +2609,7 @@ static int runInteractiveSession(const ShellRunOptions *options) {
     ShellRunOptions exec_opts = *options;
     exec_opts.no_cache = 1;
     exec_opts.quiet = true;
+    exec_opts.exit_on_signal = false;
 
     int last_status = shellRuntimeLastStatus();
     bool tty = isatty(STDIN_FILENO);
@@ -2765,7 +2766,9 @@ int main(int argc, char **argv) {
         }
         shellRuntimeSetArg0(path);
         bool exit_requested = false;
-        int status = shellRunSource(src, path, &options, &exit_requested);
+        ShellRunOptions script_options = options;
+        script_options.exit_on_signal = true;
+        int status = shellRunSource(src, path, &script_options, &exit_requested);
         (void)exit_requested;
         free(src);
         shellRuntimeSetArg0(options.frontend_path);
@@ -2793,6 +2796,7 @@ int main(int argc, char **argv) {
     ShellRunOptions stdin_opts = options;
     stdin_opts.no_cache = 1;
     stdin_opts.quiet = true;
+    stdin_opts.exit_on_signal = true;
     bool exit_requested = false;
     int status = shellRunSource(stdin_src, "<stdin>", &stdin_opts, &exit_requested);
     (void)exit_requested;

--- a/src/shell/runner.c
+++ b/src/shell/runner.c
@@ -71,6 +71,11 @@ int shellRunSource(const char *source,
     int define_count = 0;
     char *pre_src = preprocessConditionals(source, defines, define_count);
 
+    bool previous_exit_on_signal = shellRuntimeExitOnSignal();
+    if (options->exit_on_signal) {
+        shellRuntimeSetExitOnSignal(true);
+    }
+
     globalSymbols = createHashTable();
     constGlobalSymbols = createHashTable();
     procedure_table = createHashTable();
@@ -175,6 +180,7 @@ int shellRunSource(const char *source,
     exit_code = (result == INTERPRET_OK) ? last_status : EXIT_FAILURE;
 
 cleanup:
+    shellRuntimeSetExitOnSignal(previous_exit_on_signal);
     if (out_exit_requested) {
         *out_exit_requested = exit_flag;
     } else {

--- a/src/shell/runner.h
+++ b/src/shell/runner.h
@@ -15,6 +15,7 @@ typedef struct ShellRunOptions {
     int vm_trace_head;
     bool quiet;
     bool verbose_errors;
+    bool exit_on_signal;
     const char *frontend_path;
 } ShellRunOptions;
 


### PR DESCRIPTION
## Summary
- add an exit-on-signal option to shell runs and propagate it through the runtime API
- make non-interactive SIGINT/SIGQUIT/SIGTSTP fall back to default handling so scripts terminate or suspend correctly
- ensure sourced/evaled scripts inherit the active signal policy and interactive runs leave it disabled

## Testing
- cmake --build build --target exsh

------
https://chatgpt.com/codex/tasks/task_b_68e2d82109b4832986719632f9518081