### PR TITLE
Remove help overview adjustments

### DIFF
--- a/src/shell/lexer.c
+++ b/src/shell/lexer.c
@@ -309,6 +309,8 @@ static ShellToken scanWord(ShellLexer *lexer) {
     bool hasCommand = false;
     bool hasArithmetic = false;
 
+    bool allowStructuralLiterals = lexerAllowsStructuralWordLiterals(lexer);
+
     bool inArrayLiteral = false;
     int arrayParenDepth = 0;
 
@@ -343,9 +345,10 @@ static ShellToken scanWord(ShellLexer *lexer) {
 
             if (!(startingArrayLiteral || (inArrayLiteral && arrayParenDepth > 0 && (c == '(' || c == ')')))) {
                 bool treat_as_operator = isOperatorDelimiter(c);
-                if (treat_as_operator && isStructuralWordCandidate(c) &&
-                    (lexer->rule_mask & SHELL_LEXER_RULE_1) == 0) {
-                    treat_as_operator = false;
+                if (treat_as_operator && isStructuralWordCandidate(c)) {
+                    if (allowStructuralLiterals && (lexer->rule_mask & SHELL_LEXER_RULE_1) == 0) {
+                        treat_as_operator = false;
+                    }
                 }
                 if (treat_as_operator) {
                     break;


### PR DESCRIPTION
## Summary
- prevent case pattern tokens from consuming closing parens so grouped patterns without whitespace parse correctly
- remove the help overview wording adjustments per follow-up request

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e2f6f05c748329ac657ce465a16be4