### PR TITLE
Fix export assignment parsing in exsh

### DIFF
--- a/src/backend_ast/shell.c
+++ b/src/backend_ast/shell.c
@@ -4808,6 +4808,14 @@ static bool shellAddArg(ShellCommand *cmd, const char *arg, bool *saw_command_wo
             }
             return true;
         }
+    } else if ((flags & SHELL_WORD_FLAG_ASSIGNMENT) && shellLooksLikeAssignment(expanded)) {
+        if (!shellCommandAppendArgOwned(cmd, expanded)) {
+            return false;
+        }
+        if (saw_command_word) {
+            *saw_command_word = true;
+        }
+        return true;
     }
     char **fields = NULL;
     size_t field_count = 0;


### PR DESCRIPTION
## Summary
- restore inline PS1 export in the default exshrc template so the prompt definition matches bash
- ensure shellAddArg keeps assignment-style arguments intact after the command, allowing `export NAME=value` to pass through unchanged

## Testing
- cmake -S . -B build
- cmake --build build --target exsh

------
https://chatgpt.com/codex/tasks/task_b_68e2fc7f37c88329b25473cb1e72a6c2