### PR TITLE
Fix exsh Sierpinski threads worker startup

### DIFF
--- a/Examples/exsh/sierpinski_threads.psh
+++ b/Examples/exsh/sierpinski_threads.psh
@@ -14,18 +14,37 @@ run_exsh_builtin() {
     builtin "$@" 2>/dev/null
 }
 
-ensure_exsh() {
-    if have_exsh_builtin ScreenRows; then
+resolve_exsh_binary() {
+    if [ -n "$EXSH_BIN" ] && [ -x "$EXSH_BIN" ]; then
+        printf '%s\n' "$EXSH_BIN"
         return 0
     fi
 
-    if type exsh >/dev/null 2>&1; then
-        exec exsh "$0" "$@"
+    if command -v exsh >/dev/null 2>&1; then
+        EXSH_BIN="$(command -v exsh)"
+        printf '%s\n' "$EXSH_BIN"
+        return 0
     fi
 
+    local repo_root
     repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
     if [ -n "$repo_root" ] && [ -x "$repo_root/build/bin/exsh" ]; then
-        exec "$repo_root/build/bin/exsh" "$0" "$@"
+        EXSH_BIN="$repo_root/build/bin/exsh"
+        printf '%s\n' "$EXSH_BIN"
+        return 0
+    fi
+
+    return 1
+}
+
+ensure_exsh() {
+    if have_exsh_builtin ScreenRows; then
+        resolve_exsh_binary >/dev/null 2>&1 || :
+        return 0
+    fi
+
+    if exsh_path="$(resolve_exsh_binary)"; then
+        exec "$exsh_path" "$0" "$@"
     fi
 
     echo "sierpinski_threads.psh: this demo must be run with exsh." >&2
@@ -33,9 +52,65 @@ ensure_exsh() {
     exit 1
 }
 
+cleanup() {
+    run_exsh_builtin ShowCursor >/dev/null 2>&1 || :
+}
+
+draw_point() {
+    local x="$1"
+    local y="$2"
+    run_exsh_builtin GotoXY "int:$x" "int:$y"
+    run_exsh_builtin Write "str:$CHAR_TO_DRAW"
+}
+
+draw_sierpinski() {
+    local x1="$1"
+    local y1="$2"
+    local x2="$3"
+    local y2="$4"
+    local x3="$5"
+    local y3="$6"
+    local level="$7"
+
+    if [ "$level" -le 0 ]; then
+        draw_point "$x1" "$y1"
+        draw_point "$x2" "$y2"
+        draw_point "$x3" "$y3"
+        return
+    fi
+
+    local mx1=$(((x1 + x2) / 2))
+    local my1=$(((y1 + y2) / 2))
+    local mx2=$(((x2 + x3) / 2))
+    local my2=$(((y2 + y3) / 2))
+    local mx3=$(((x3 + x1) / 2))
+    local my3=$(((y3 + y1) / 2))
+    local next_level=$((level - 1))
+
+    draw_sierpinski "$x1" "$y1" "$mx1" "$my1" "$mx3" "$my3" "$next_level"
+    draw_sierpinski "$mx1" "$my1" "$x2" "$y2" "$mx2" "$my2" "$next_level"
+    draw_sierpinski "$mx3" "$my3" "$mx2" "$my2" "$x3" "$y3" "$next_level"
+}
+
 ensure_exsh "$@"
 
-CHAR_TO_DRAW="${SIERPINSKI_CHAR:-+}"
+if [ -z "${CHAR_TO_DRAW+x}" ]; then
+    CHAR_TO_DRAW="${SIERPINSKI_CHAR:-+}"
+fi
+export CHAR_TO_DRAW
+
+WORKER_MODE=${SIERPINSKI_WORKER:-0}
+
+if [ "$WORKER_MODE" = "1" ]; then
+    if [ "$#" -ne 7 ]; then
+        echo "sierpinski_threads.psh: worker expects 7 arguments." >&2
+        exit 1
+    fi
+
+    draw_sierpinski "$@"
+    exit 0
+fi
+
 MAX_LEVEL_RAW="${SIERPINSKI_LEVEL:-13}"
 
 case "$MAX_LEVEL_RAW" in
@@ -63,10 +138,6 @@ fi
 
 MAX_X=0
 MAX_Y=0
-
-cleanup() {
-    run_exsh_builtin ShowCursor >/dev/null 2>&1 || :
-}
 
 trap 'cleanup' EXIT INT TERM
 
@@ -134,51 +205,17 @@ MY2=$(((Y2 + Y3) / 2))
 MX3=$(((X3 + X1) / 2))
 MY3=$(((Y3 + Y1) / 2))
 
-draw_point() {
-    local x="$1"
-    local y="$2"
-    run_exsh_builtin GotoXY "int:$x" "int:$y"
-    run_exsh_builtin Write "str:$CHAR_TO_DRAW"
-}
+exsh_path="$(resolve_exsh_binary)"
+if [ -z "$exsh_path" ]; then
+    echo "sierpinski_threads.psh: unable to locate exsh binary for worker threads." >&2
+    exit 1
+fi
 
-draw_sierpinski() {
-    local x1="$1"
-    local y1="$2"
-    local x2="$3"
-    local y2="$4"
-    local x3="$5"
-    local y3="$6"
-    local level="$7"
-
-    if [ "$level" -le 0 ]; then
-        draw_point "$x1" "$y1"
-        draw_point "$x2" "$y2"
-        draw_point "$x3" "$y3"
-        return
-    fi
-
-    local mx1=$(((x1 + x2) / 2))
-    local my1=$(((y1 + y2) / 2))
-    local mx2=$(((x2 + x3) / 2))
-    local my2=$(((y2 + y3) / 2))
-    local mx3=$(((x3 + x1) / 2))
-    local my3=$(((y3 + y1) / 2))
-    local next_level=$((level - 1))
-
-    draw_sierpinski "$x1" "$y1" "$mx1" "$my1" "$mx3" "$my3" "$next_level"
-    draw_sierpinski "$mx1" "$my1" "$x2" "$y2" "$mx2" "$my2" "$next_level"
-    draw_sierpinski "$mx3" "$my3" "$mx2" "$my2" "$x3" "$y3" "$next_level"
-}
-
-sierpinski_thread() {
-    draw_sierpinski "$@"
-}
-
-sierpinski_thread "$X1" "$Y1" "$MX1" "$MY1" "$MX3" "$MY3" "$THREAD_LEVEL" &
+SIERPINSKI_WORKER=1 "$exsh_path" "$0" "$X1" "$Y1" "$MX1" "$MY1" "$MX3" "$MY3" "$THREAD_LEVEL" &
 PID0=$!
-sierpinski_thread "$MX1" "$MY1" "$X2" "$Y2" "$MX2" "$MY2" "$THREAD_LEVEL" &
+SIERPINSKI_WORKER=1 "$exsh_path" "$0" "$MX1" "$MY1" "$X2" "$Y2" "$MX2" "$MY2" "$THREAD_LEVEL" &
 PID1=$!
-sierpinski_thread "$MX3" "$MY3" "$MX2" "$MY2" "$X3" "$Y3" "$THREAD_LEVEL" &
+SIERPINSKI_WORKER=1 "$exsh_path" "$0" "$MX3" "$MY3" "$MX2" "$MY2" "$X3" "$Y3" "$THREAD_LEVEL" &
 PID2=$!
 
 wait "$PID0"


### PR DESCRIPTION
## Summary
- add a helper to resolve the exsh binary and reuse it when launching helper workers
- introduce a worker mode so recursive drawing happens inside exsh instead of /bin/sh processes
- keep cursor cleanup and console drawing logic unchanged for the main coordinator

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e34bd9c3fc83299884a4f90ef2d29b