### PR TITLE
Fix array literal lexing across newlines

### DIFF
--- a/Tests/exsh/tests/array_assignment_multiline.psh
+++ b/Tests/exsh/tests/array_assignment_multiline.psh
@@ -1,0 +1,9 @@
+#!/usr/bin/env exsh
+
+declare -A prompt_colors=(
+    [primary]="blue"
+    [secondary]="green"
+)
+
+printf 'primary=%s\n' "${prompt_colors[primary]}"
+printf 'len=%s\n' "${#prompt_colors[@]}"

--- a/Tests/exsh/tests/manifest.json
+++ b/Tests/exsh/tests/manifest.json
@@ -201,6 +201,15 @@
             "expected_stdout": "lexer-array-assignment:ok"
         },
         {
+            "id": "lexer_array_assignment_multiline",
+            "name": "Array assignments allow embedded newlines",
+            "category": "lexer",
+            "description": "name=(...) spanning multiple lines should remain a single assignment word.",
+            "script": "Tests/exsh/tests/array_assignment_multiline.psh",
+            "expect": "runtime_ok",
+            "expected_stdout": "primary=blue\nlen=2"
+        },
+        {
             "id": "array_assignment_expansion_scalar",
             "name": "Scalar assignments with parentheses stay scalars",
             "category": "builtins",

--- a/src/shell/lexer.c
+++ b/src/shell/lexer.c
@@ -399,6 +399,9 @@ static ShellToken scanWord(ShellLexer *lexer) {
 
             if (!(startingArrayLiteral || (inArrayLiteral && arrayParenDepth > 0 && (c == '(' || c == ')')))) {
                 bool treat_as_operator = isOperatorDelimiter(c);
+                if (treat_as_operator && inArrayLiteral && arrayParenDepth > 0 && c == '\n') {
+                    treat_as_operator = false;
+                }
                 if (treat_as_operator && isStructuralWordCandidate(c)) {
                     if (allowStructuralLiterals && (lexer->rule_mask & SHELL_LEXER_RULE_1) == 0) {
                         treat_as_operator = false;


### PR DESCRIPTION
## Summary
- keep newline characters inside array literals from being treated as command delimiters so multi-line declare assignments stay intact
- add a regression script and manifest entry that exercises multi-line associative array initialisation

## Testing
- Tests/run_exsh_tests.sh --only lexer_array_assignment_multiline

------
https://chatgpt.com/codex/tasks/task_b_68e4ee93d2c88329a613b76a4b764d15