### PR TITLE
Add regression coverage for double bracket file-test operators

### DIFF
--- a/Tests/exsh/tests/manifest.json
+++ b/Tests/exsh/tests/manifest.json
@@ -327,6 +327,15 @@
             "expected_stdout": "double-bracket:start\nbranch:missing\nbranch:now-present\ndouble-bracket:end"
         },
         {
+            "id": "grammar_double_bracket_file_tests",
+            "name": "[[ ]] handles file-test operators",
+            "category": "grammar",
+            "description": "File-test operators like -e, -f, -d, -L, -s, -nt, -ot, and -ef evaluate correctly within double brackets.",
+            "script": "Tests/exsh/tests/parser_double_bracket_file_tests.psh",
+            "expect": "runtime_ok",
+            "expected_stdout": "file-tests:start\nmissing-before\nexists-after\nis-regular\nis-directory\nis-symlink\nempty-before\nnon-empty-after\nnot-newer-before\nolder-before\nnewer-after\nnot-older-after\nsame-inode\nfile-tests:end"
+        },
+        {
             "id": "lexer_structural_words",
             "name": "Structural tokens can be literal words",
             "category": "lexer",

--- a/Tests/exsh/tests/parser_double_bracket_file_tests.psh
+++ b/Tests/exsh/tests/parser_double_bracket_file_tests.psh
@@ -1,0 +1,84 @@
+echo "file-tests:start"
+FILE="tmp_exsh_file_test.txt"
+OTHER="tmp_exsh_file_other.txt"
+HARD="tmp_exsh_file_hard.txt"
+DIR="tmp_exsh_file_dir"
+LINK="tmp_exsh_file_link.txt"
+rm -f "$FILE" "$OTHER" "$HARD" "$LINK"
+rm -rf "$DIR"
+if [[ -e "$FILE" ]]; then
+  echo "exists-before"
+else
+  echo "missing-before"
+fi
+
+touch "$FILE"
+if [[ -e "$FILE" ]]; then
+  echo "exists-after"
+fi
+if [[ -f "$FILE" ]]; then
+  echo "is-regular"
+else
+  echo "not-regular"
+fi
+
+mkdir "$DIR"
+if [[ -d "$DIR" ]]; then
+  echo "is-directory"
+fi
+
+ln -s "$FILE" "$LINK"
+if [[ -L "$LINK" ]]; then
+  echo "is-symlink"
+else
+  echo "not-symlink"
+fi
+
+if [[ -s "$FILE" ]]; then
+  echo "non-empty-before"
+else
+  echo "empty-before"
+fi
+printf 'data' > "$FILE"
+if [[ -s "$FILE" ]]; then
+  echo "non-empty-after"
+else
+  echo "still-empty"
+fi
+
+sleep 1
+touch "$OTHER"
+if [[ "$FILE" -nt "$OTHER" ]]; then
+  echo "newer-before"
+else
+  echo "not-newer-before"
+fi
+if [[ "$FILE" -ot "$OTHER" ]]; then
+  echo "older-before"
+else
+  echo "not-older-before"
+fi
+
+sleep 1
+touch "$FILE"
+if [[ "$FILE" -nt "$OTHER" ]]; then
+  echo "newer-after"
+else
+  echo "not-newer-after"
+fi
+if [[ "$FILE" -ot "$OTHER" ]]; then
+  echo "older-after"
+else
+  echo "not-older-after"
+fi
+
+ln "$FILE" "$HARD"
+if [[ "$FILE" -ef "$HARD" ]]; then
+  echo "same-inode"
+else
+  echo "different-inode"
+fi
+
+echo "file-tests:end"
+rm -f "$FILE" "$OTHER" "$HARD" "$LINK"
+rm -rf "$DIR"


### PR DESCRIPTION
## Summary
- add an exsh regression script that exercises [[ ]] file-test operators (e.g., -e, -f, -d, -L, -s, -nt, -ot, -ef)
- register the new script in the exsh manifest so it runs with the grammar suite

## Testing
- python3 Tests/exsh/exsh_test_harness.py --only grammar_double_bracket_file_tests
- python3 Tests/exsh/exsh_test_harness.py --only grammar_double_bracket_negation

------
https://chatgpt.com/codex/tasks/task_b_68e567188f0c8329bcdfd1341ffa94df