### PR TITLE
Normalize bytecode spelling

### DIFF
--- a/Examples/clike/base/README.md
+++ b/Examples/clike/base/README.md
@@ -3,7 +3,7 @@
 This folder contains sample programs for the Pscal CLike front end.
 
 Clike files can be run by running the 'clike' binary, which will compile them 
-byte code and execute the byte code in the PSCAL VM.
+bytecode and execute the bytecode in the PSCAL VM.
 
 C-like examples (`.cl`) can be executed with the native clike compiler built in
 `build/bin`:

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The example source lives at `Examples/pascal/base/ThreadsProcPtrDemo`.
 
 A minimal compiler for a small educational language, often called *tiny*, is
 provided in `tools/tiny`.  It is written in Python and provides an example of 
-how to add a custom stand alone front end that can generate byte code that the
+how to add a custom stand alone front end that can generate bytecode that the
 pscal VM/back end can execute.  It compiles source code that follows the grammar
 described in the project documentation and emits bytecode that can be executed
 by the virtual machine.
@@ -123,7 +123,7 @@ language can be found in `Examples/tiny`.
 
 ## CLike front end
 
-`build/bin/clike` implements a compact C-like byte code compiler that integrates
+`build/bin/clike` implements a compact C-like bytecode compiler that integrates
 with the pscal vm.  The grammar covers variable and function declarations,
 conditionals, loops and expressions. VM builtins can be invoked simply by
 calling a function name that lacks a user definition.

--- a/Tests/exsh/exsh_test_harness.py
+++ b/Tests/exsh/exsh_test_harness.py
@@ -19,7 +19,7 @@ DEFAULT_MANIFEST = HARNESS_ROOT / "tests" / "manifest.json"
 DEFAULT_TIMEOUT = 20.0
 IGNORED_PARITY_STDERR_PREFIXES = (
     "Compilation successful.",
-    "Loaded cached byte code",
+    "Loaded cached bytecode",
     "Loaded cached bytecode",
 )
 

--- a/Tests/run_clike_tests.sh
+++ b/Tests/run_clike_tests.sh
@@ -108,7 +108,7 @@ normalise_clike_stdout() {
 
 normalise_clike_stderr() {
     strip_ansi_inplace "$1"
-    perl -0 -pe 's/^Compilation successful.*\n//m; s/^Loaded cached byte code.*\n//m' "$1" > "$1.clean"
+    perl -0 -pe 's/^Compilation successful.*\n//m; s/^Loaded cached bytecode.*\n//m' "$1" > "$1.clean"
     mv "$1.clean" "$1"
     head -n 2 "$1" > "$1.trim"
     mv "$1.trim" "$1"
@@ -353,7 +353,7 @@ run_clike_fixture() {
         local disasm_status=$?
         set -e
         strip_ansi_inplace "$disasm_stderr"
-        perl -0 -pe 's/^Compilation successful.*\n//m; s/^Loaded cached byte code.*\n//m' "$disasm_stderr" > "$disasm_stderr.clean"
+        perl -0 -pe 's/^Compilation successful.*\n//m; s/^Loaded cached bytecode.*\n//m' "$disasm_stderr" > "$disasm_stderr.clean"
         mv "$disasm_stderr.clean" "$disasm_stderr"
         rel_src="Tests/clike/$test_name.cl"
         sed -i.bak "s|$src|$rel_src|" "$disasm_stderr" 2>/dev/null || true
@@ -539,8 +539,8 @@ EOF
         set -e
         if [ $status2 -ne 0 ]; then
             issues+=("Cached compile exited with $status2")
-        elif ! grep -q 'Loaded cached byte code' "$tmp_home/err2"; then
-            issues+=("Expected cached byte code notice missing")
+        elif ! grep -q 'Loaded cached bytecode' "$tmp_home/err2"; then
+            issues+=("Expected cached bytecode notice missing")
         fi
     fi
 
@@ -584,7 +584,7 @@ EOF
         set -e
         if [ $status2 -ne 0 ]; then
             issues+=("Recompile after binary touch exited with $status2")
-        elif grep -q 'Loaded cached byte code' "$tmp_home/err2"; then
+        elif grep -q 'Loaded cached bytecode' "$tmp_home/err2"; then
             issues+=("Cache should have been invalidated after binary change")
         fi
     fi

--- a/Tests/run_pascal_tests.sh
+++ b/Tests/run_pascal_tests.sh
@@ -64,7 +64,7 @@ normalise_pascal_stdout() {
 normalise_pascal_stderr() {
     local path="$1"
     strip_ansi_inplace "$path"
-    perl -0 -pe 's/^Compilation successful.*\n//m; s/^Loaded cached byte code.*\n//m' "$path" > "$path.clean"
+    perl -0 -pe 's/^Compilation successful.*\n//m; s/^Loaded cached bytecode.*\n//m' "$path" > "$path.clean"
     mv "$path.clean" "$path"
     perl -ne 'print unless /Warning: user-defined .* overrides builtin/' "$path" > "$path.clean"
     mv "$path.clean" "$path"
@@ -302,7 +302,7 @@ run_pascal_fixture() {
         local disasm_status=$?
         set -e
         strip_ansi_inplace "$disasm_stderr"
-        perl -ne 'print unless /^Loaded cached byte code/' "$disasm_stderr" > "$disasm_stderr.clean"
+        perl -ne 'print unless /^Loaded cached bytecode/' "$disasm_stderr" > "$disasm_stderr.clean"
         mv "$disasm_stderr.clean" "$disasm_stderr"
         if [ $disasm_status -ne 0 ]; then
             status="FAIL"

--- a/Tests/run_rea_tests.sh
+++ b/Tests/run_rea_tests.sh
@@ -48,7 +48,7 @@ normalise_rea_stdout() {
 
 normalise_rea_stderr() {
     strip_ansi_inplace "$1"
-    perl -0 -pe 's/^Compilation successful.*\n//m; s/^Loaded cached byte code.*\n//m' "$1" > "$1.clean"
+    perl -0 -pe 's/^Compilation successful.*\n//m; s/^Loaded cached bytecode.*\n//m' "$1" > "$1.clean"
     mv "$1.clean" "$1"
 }
 
@@ -355,7 +355,7 @@ run_rea_fixture() {
         local disasm_status=$?
         set -e
         strip_ansi_inplace "$disasm_stderr"
-        perl -0 -pe 's/^Compilation successful.*\n//m; s/^Loaded cached byte code.*\n//m' "$disasm_stderr" > "$disasm_stderr.clean"
+        perl -0 -pe 's/^Compilation successful.*\n//m; s/^Loaded cached bytecode.*\n//m' "$disasm_stderr" > "$disasm_stderr.clean"
         mv "$disasm_stderr.clean" "$disasm_stderr"
         rel_src="Tests/rea/$test_name.rea"
         sed -i.bak "s|$src|$rel_src|" "$disasm_stderr" 2>/dev/null || true
@@ -529,8 +529,8 @@ EOF
         set -e
         if [ $status2 -ne 0 ]; then
             issues+=("Cached compile exited with $status2")
-        elif ! grep -q 'Loaded cached byte code' "$tmp_home/err2"; then
-            issues+=("Expected cached byte code notice missing")
+        elif ! grep -q 'Loaded cached bytecode' "$tmp_home/err2"; then
+            issues+=("Expected cached bytecode notice missing")
         fi
     fi
 
@@ -571,7 +571,7 @@ EOF
         set -e
         if [ $status2 -ne 0 ]; then
             issues+=("Recompile after binary touch exited with $status2")
-        elif grep -q 'Loaded cached byte code' "$tmp_home/err2"; then
+        elif grep -q 'Loaded cached bytecode' "$tmp_home/err2"; then
             issues+=("Cache should have been invalidated after binary change")
         fi
     fi

--- a/Tests/scope_verify/exsh/exsh_scope_test_harness.py
+++ b/Tests/scope_verify/exsh/exsh_scope_test_harness.py
@@ -37,7 +37,7 @@ DEFAULT_OUT_DIR = HARNESS_ROOT / "out"
 DEFAULT_TIMEOUT = 20.0
 IGNORED_PARITY_STDERR_PREFIXES = (
     "Compilation successful.",
-    "Loaded cached byte code",
+    "Loaded cached bytecode",
     "Loaded cached bytecode",
 )
 

--- a/src/Pascal/main.c
+++ b/src/Pascal/main.c
@@ -63,7 +63,7 @@ typedef struct {
 } CachedMessageScannerState;
 
 static bool bufferContainsCachedMessage(const char *buf, size_t len, CachedMessageScannerState *state) {
-    static const char cached_msg[] = "Loaded cached byte code";
+    static const char cached_msg[] = "Loaded cached bytecode";
     const size_t needle_len = sizeof(cached_msg) - 1;
 
     if (!state || needle_len == 0) {
@@ -232,7 +232,7 @@ int runProgram(const char *source, const char *programName, const char *frontend
                     finalizeBytecode(&chunk);
                     saveBytecodeToCache(programName, kPascalCompilerId, &chunk);
                     // Silence successful compilation message for cleaner test stderr.
-                    // fprintf(stderr, "Compilation successful. Byte code size: %d bytes, Constants: %d\n", chunk.count, chunk.constants_count);
+                    // fprintf(stderr, "Compilation successful. Bytecode size: %d bytes, Constants: %d\n", chunk.count, chunk.constants_count);
                     if (dump_bytecode_flag) {
                         disassembleBytecodeChunk(&chunk, programName ? programName : "CompiledChunk", procedure_table);
                         if (!dump_bytecode_only_flag) {
@@ -243,7 +243,7 @@ int runProgram(const char *source, const char *programName, const char *frontend
             } else {
                 // Always emit the cache message so callers can detect cache reuse;
                 // the top-level stderr capture in main() will decide whether to replay.
-                fprintf(stderr, "Loaded cached byte code. Byte code size: %d bytes, Constants: %d\n", chunk.count, chunk.constants_count);
+                fprintf(stderr, "Loaded cached bytecode. Bytecode size: %d bytes, Constants: %d\n", chunk.count, chunk.constants_count);
                 if (dump_bytecode_flag) {
                     disassembleBytecodeChunk(&chunk, programName ? programName : "CompiledChunk", procedure_table);
                     if (!dump_bytecode_only_flag) {

--- a/src/clike/main.c
+++ b/src/clike/main.c
@@ -294,7 +294,7 @@ int main(int argc, char **argv) {
     if (!used_cache) {
         clikeCompile(prog, &chunk);
         saveBytecodeToCache(path, kClikeCompilerId, &chunk);
-        fprintf(stderr, "Compilation successful. Byte code size: %d bytes, Constants: %d\n",
+        fprintf(stderr, "Compilation successful. Bytecode size: %d bytes, Constants: %d\n",
                 chunk.count, chunk.constants_count);
         if (dump_bytecode_flag) {
             fprintf(stderr, "--- Compiling Main Program AST to Bytecode ---\n");
@@ -304,7 +304,7 @@ int main(int argc, char **argv) {
             }
         }
     } else {
-        fprintf(stderr, "Loaded cached byte code. Byte code size: %d bytes, Constants: %d\n",
+        fprintf(stderr, "Loaded cached bytecode. Bytecode size: %d bytes, Constants: %d\n",
                 chunk.count, chunk.constants_count);
         if (dump_bytecode_flag) {
             disassembleBytecodeChunk(&chunk, path ? path : "CompiledChunk", procedure_table);

--- a/src/rea/main.c
+++ b/src/rea/main.c
@@ -441,7 +441,7 @@ int main(int argc, char **argv) {
         if (compilation_ok) {
             finalizeBytecode(&chunk);
             saveBytecodeToCache(path, kReaCompilerId, &chunk);
-            fprintf(stderr, "Compilation successful. Byte code size: %d bytes, Constants: %d\n",
+        fprintf(stderr, "Compilation successful. Bytecode size: %d bytes, Constants: %d\n",
                     chunk.count, chunk.constants_count);
             if (dump_bytecode_flag) {
                 fprintf(stderr, "--- Compiling Main Program AST to Bytecode ---\n");
@@ -456,7 +456,7 @@ int main(int argc, char **argv) {
             fprintf(stderr, "Compilation failed with errors.\n");
         }
     } else {
-        fprintf(stderr, "Loaded cached byte code. Byte code size: %d bytes, Constants: %d\n",
+        fprintf(stderr, "Loaded cached bytecode. Bytecode size: %d bytes, Constants: %d\n",
                 chunk.count, chunk.constants_count);
         if (dump_bytecode_flag) {
             disassembleBytecodeChunk(&chunk, path ? path : "CompiledChunk", procedure_table);

--- a/src/shell/runner.c
+++ b/src/shell/runner.c
@@ -140,7 +140,7 @@ int shellRunSource(const char *source,
             saveBytecodeToCache(path, kShellCompilerId, &chunk);
         }
         if (!options->quiet) {
-            fprintf(stderr, "Compilation successful. Byte code size: %d bytes, Constants: %d\n",
+            fprintf(stderr, "Compilation successful. Bytecode size: %d bytes, Constants: %d\n",
                     chunk.count, chunk.constants_count);
         }
         if (options->dump_bytecode) {
@@ -152,7 +152,7 @@ int shellRunSource(const char *source,
         }
     } else {
         if (!options->quiet) {
-            fprintf(stderr, "Loaded cached bytecode. Byte code size: %d bytes, Constants: %d\n",
+            fprintf(stderr, "Loaded cached bytecode. Bytecode size: %d bytes, Constants: %d\n",
                     chunk.count, chunk.constants_count);
         }
         if (options->dump_bytecode) {


### PR DESCRIPTION
## Summary
- replace all remaining references to "byte code" with "bytecode" across documentation, test scripts, and compilers to ensure consistent terminology

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e569300e8883299b1258fef2b30cfe