### PR TITLE
Default 3D extended builtins on when SDL is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,16 @@ option(ENABLE_EXT_BUILTIN_SYSTEM "Enable extended system builtins" ON)
 option(ENABLE_EXT_BUILTIN_USER "Enable extended user builtins" ON)
 option(ENABLE_EXT_BUILTIN_YYJSON "Enable extended yyjson builtins" ON)
 option(ENABLE_EXT_BUILTIN_SQLITE "Enable extended sqlite builtins" ON)
-option(ENABLE_EXT_BUILTIN_3D "Enable extended 3D builtins" OFF)
+
+# Default the 3D extended builtins to ON whenever SDL support is enabled so
+# the bundled 3D demos (which rely on the physics helpers) continue to work
+# out of the box.  Respect explicit cache values when users override the
+# toggle on the command line.
+set(_ENABLE_EXT_BUILTIN_3D_DEFAULT OFF)
+if(SDL)
+    set(_ENABLE_EXT_BUILTIN_3D_DEFAULT ON)
+endif()
+option(ENABLE_EXT_BUILTIN_3D "Enable extended 3D builtins" ${_ENABLE_EXT_BUILTIN_3D_DEFAULT})
 option(ENABLE_EXT_BUILTIN_GRAPHICS "Enable extended graphics builtins" ON)
 option(ENABLE_EXT_BUILTIN_OPENAI "Enable extended OpenAI builtins" ON)
 

--- a/Docs/extended_builtins.md
+++ b/Docs/extended_builtins.md
@@ -29,7 +29,9 @@ The project currently ships several optional built‑in groups:
 | **OpenAI** | `src/ext_builtins/openai` | `chat` (`OpenAIChatCompletions`) |
 
 Individual categories can be enabled or disabled at configure time with
-the following CMake options (all default to `ON`):
+the following CMake options (all default to `ON`).  The 3D helpers follow the
+SDL toggle: they default to `ON` when SDL support is requested and `OFF`
+otherwise so headless builds avoid the extra surface area by default.
 
 ```
 -DENABLE_EXT_BUILTIN_MATH=ON/OFF


### PR DESCRIPTION
## Summary
- default the extended 3D builtin option to ON whenever SDL support is requested so the bundled demos keep their physics helpers without extra flags
- document that the 3D builtin default follows the SDL toggle in the extended builtin guide

## Testing
- cmake -S . -B build

------
https://chatgpt.com/codex/tasks/task_b_68e6697c663483298573ff3031bbe58f