### PR TITLE
Implement times builtin for exsh shell

### DIFF
--- a/Docs/exsh_bash_builtin_coverage.txt
+++ b/Docs/exsh_bash_builtin_coverage.txt
@@ -11,7 +11,7 @@ cd pwd dirs pushd popd echo exit exec true false set unset export read printf te
 
 Bash builtins missing from exsh
 -------------------------------
-caller compgen complete compopt enable fc getopts hash kill mapfile readarray suspend times ulimit
+caller compgen complete compopt enable fc getopts hash kill mapfile readarray suspend ulimit
 
 Plans to address missing builtins
 ---------------------------------
@@ -71,10 +71,10 @@ Plans to address missing builtins
     - Registered printf across the runtime, frontend registry, builtin catalogue, and help topics so scripts and interactive sessions can invoke it.
     - Introduced regression coverage that exercises numeric, string, escape handling, and usage errors alongside Bash for parity.
 
-12) times builtin:
-    - Track cumulative user and system CPU times for the shell and child processes by sampling around shellSpawnProcess and storing totals in the runtime state.
-    - Implement vmBuiltinShellTimes to format and print the totals in a Bash compatible format and add documentation.
-    - Register the builtin and create tests that exercise it after running known workloads, comparing the results to Bash within tolerances.
+12) times builtin: Completed.
+    - Implemented vmBuiltinShellTimes using times(2) to gather cumulative shell and child CPU usage and format Bash-compatible minute/second output.
+    - Registered the builtin with the runtime, frontend registry, builtin catalogue, and help topics so it appears in help and dispatch tables.
+    - Added regression coverage that validates formatting and exit status while keeping behaviour aligned with Bash output expectations.
 
 13) ulimit and umask builtins:
     - Implemented vmBuiltinShellUmask to parse octal modes, support -S symbolic output, register documentation, and add regression coverage for numeric and failure flows.

--- a/Tests/exsh/tests/manifest.json
+++ b/Tests/exsh/tests/manifest.json
@@ -510,6 +510,15 @@
             "expect": "match_bash",
             "expected_stdout": "greeting:world:0007:3.5:A:%\nfirst-status:0\nusage-status:2",
             "expected_stderr_substring": "printf: usage"
+        },
+        {
+            "id": "times_builtin",
+            "name": "times reports CPU usage lines",
+            "category": "builtins",
+            "description": "Verify the times builtin prints two timing lines and succeeds without arguments.",
+            "script": "Tests/exsh/tests/times_builtin.psh",
+            "expect": "runtime_ok",
+            "expected_stdout": "status:0\nline_count:2\nfirst_format:ok\nsecond_format:ok\n"
         }
     ]
 }

--- a/Tests/exsh/tests/times_builtin.psh
+++ b/Tests/exsh/tests/times_builtin.psh
@@ -1,0 +1,36 @@
+#!/usr/bin/env exsh
+
+output=$(times)
+status=$?
+echo "status:${status}"
+
+line_count=0
+first_line=""
+second_line=""
+while IFS= read -r line; do
+    line_count=$((line_count + 1))
+    if [ $line_count -eq 1 ]; then
+        first_line="$line"
+    elif [ $line_count -eq 2 ]; then
+        second_line="$line"
+    fi
+done <<< "$output"
+echo "line_count:${line_count}"
+
+case "$first_line" in
+    [0-9]*m[0-9]*.[0-9][0-9][0-9]s\ [0-9]*m[0-9]*.[0-9][0-9][0-9]s)
+        echo "first_format:ok"
+        ;;
+    *)
+        echo "first_format:bad:${first_line}"
+        ;;
+esac
+
+case "$second_line" in
+    [0-9]*m[0-9]*.[0-9][0-9][0-9]s\ [0-9]*m[0-9]*.[0-9][0-9][0-9]s)
+        echo "second_format:ok"
+        ;;
+    *)
+        echo "second_format:bad:${second_line}"
+        ;;
+esac

--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -136,6 +136,7 @@ Value vmBuiltinShellShift(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellSetenv(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellExport(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellUmask(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinShellTimes(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellCommand(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellUnset(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellUnsetenv(struct VM_s* vm, int arg_count, Value* args);

--- a/src/backend_ast/shell/shell_builtins.inc
+++ b/src/backend_ast/shell/shell_builtins.inc
@@ -3598,6 +3598,56 @@ Value vmBuiltinShellUmask(VM *vm, int arg_count, Value *args) {
     return makeVoid();
 }
 
+static void shellTimesFormatValue(char *buffer, size_t buffer_size, clock_t ticks, long ticks_per_second) {
+    if (!buffer || buffer_size == 0) {
+        return;
+    }
+    if (ticks_per_second <= 0) {
+        ticks_per_second = 100;
+    }
+    double total_seconds = (double)ticks / (double)ticks_per_second;
+    if (total_seconds < 0.0) {
+        total_seconds = 0.0;
+    }
+    long minutes = (long)(total_seconds / 60.0);
+    double seconds = total_seconds - (double)minutes * 60.0;
+    if (seconds < 0.0) {
+        seconds = 0.0;
+    }
+    double rounded = floor(seconds * 1000.0 + 0.5) / 1000.0;
+    if (rounded >= 60.0) {
+        minutes += 1;
+        rounded = 0.0;
+    }
+    snprintf(buffer, buffer_size, "%ldm%0.3fs", minutes, rounded);
+    buffer[buffer_size - 1] = '\0';
+}
+
+Value vmBuiltinShellTimes(VM *vm, int arg_count, Value *args) {
+    (void)args;
+    (void)arg_count;
+    struct tms time_info;
+    clock_t result = times(&time_info);
+    if (result == (clock_t)-1) {
+        runtimeError(vm, "times: %s", strerror(errno));
+        shellUpdateStatus(errno ? errno : 1);
+        return makeVoid();
+    }
+    long ticks_per_second = sysconf(_SC_CLK_TCK);
+    char shell_user[32];
+    char shell_system[32];
+    char child_user[32];
+    char child_system[32];
+    shellTimesFormatValue(shell_user, sizeof(shell_user), time_info.tms_utime, ticks_per_second);
+    shellTimesFormatValue(shell_system, sizeof(shell_system), time_info.tms_stime, ticks_per_second);
+    shellTimesFormatValue(child_user, sizeof(child_user), time_info.tms_cutime, ticks_per_second);
+    shellTimesFormatValue(child_system, sizeof(child_system), time_info.tms_cstime, ticks_per_second);
+    printf("%s %s\n", shell_user, shell_system);
+    printf("%s %s\n", child_user, child_system);
+    shellUpdateStatus(0);
+    return makeVoid();
+}
+
 Value vmBuiltinShellCommand(VM *vm, int arg_count, Value *args) {
     bool parsing_options = true;
     bool list_all = false;
@@ -4647,6 +4697,16 @@ static const ShellHelpTopic kShellHelpTopics[] = {
         "Calling trap with arguments enables the runtime trap flag; running it"
         " with no arguments clears the flag. Trap handlers are not yet"
         " parameterised per signal.",
+        NULL,
+        0
+    },
+    {
+        "times",
+        "Display accumulated CPU usage statistics.",
+        "times",
+        "Prints two lines of timing data: the shell's user and system time"
+        " followed by the cumulative user and system time of terminated child"
+        " processes. Values are reported as minutes and fractional seconds.",
         NULL,
         0
     },

--- a/src/backend_ast/shell/shell_runtime_state.inc
+++ b/src/backend_ast/shell/shell_runtime_state.inc
@@ -16,6 +16,7 @@
 #include <fnmatch.h>
 #include <glob.h>
 #include <limits.h>
+#include <math.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <regex.h>
@@ -29,6 +30,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
+#include <sys/times.h>
 #include <termios.h>
 #include <unistd.h>
 #include <pwd.h>

--- a/src/backend_ast/shell/shell_word_expansion.inc
+++ b/src/backend_ast/shell/shell_word_expansion.inc
@@ -2229,7 +2229,7 @@ static bool shellIsRuntimeBuiltin(const char *name) {
                                       "unsetenv", "set",      "declare", "typeset", "readonly", "umask",   "command", "trap",     "local",    "let",      "break",   "continue",
                                       "alias",   "bind",     "shopt",   "history", "jobs",     "disown",   "fg",       "finger",   "bg",       "wait",
                                       "builtin", "source",   "read",    "printf",  "shift",   "return",   "help",     "type",    ":",       "unalias",
-                                      "__shell_double_bracket"};
+                                     "__shell_double_bracket", "times"};
 
     size_t count = sizeof(kBuiltins) / sizeof(kBuiltins[0]);
     const char *canonical = shellBuiltinCanonicalName(name);

--- a/src/ext_builtins/shell_frontend.c
+++ b/src/ext_builtins/shell_frontend.c
@@ -74,4 +74,5 @@ void registerShellFrontendBuiltins(void) {
     registerShellBuiltin(category, command_group, "bind", vmBuiltinShellBind);
     registerShellBuiltin(category, command_group, "shopt", vmBuiltinShellShopt);
     registerShellBuiltin(category, command_group, "umask", vmBuiltinShellUmask);
+    registerShellBuiltin(category, command_group, "times", vmBuiltinShellTimes);
 }

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -59,6 +59,7 @@ static const ShellBuiltinEntry kShellBuiltins[] = {
     {"popd", "popd", 37},
     {"let", "let", 39},
     {"umask", "umask", 43},
+    {"times", "times", 47},
     {"logout", "logout", 44},
     {"disown", "disown", 45},
     {"__shell_exec", "__shell_exec", 1001},


### PR DESCRIPTION
## Summary
- implement the `times` builtin in the exsh runtime using `times(2)` and expose it through the frontend, builtin registry, and help topics
- document the completed builtin in the coverage tracker and add a regression test that validates its output formatting

## Testing
- python Tests/exsh/exsh_test_harness.py --only times_builtin
- python Tests/exsh/exsh_test_harness.py

------
https://chatgpt.com/codex/tasks/task_b_68e7b64426648329be17c8488d72a58f