### PR TITLE
Allow case clauses to accept leading parens

### DIFF
--- a/Tests/exsh/tests/manifest.json
+++ b/Tests/exsh/tests/manifest.json
@@ -181,6 +181,15 @@
             "expected_stdout": "case:start\nmatch foo\nmatch group\nmatch default qux\ncase:end"
         },
         {
+            "id": "case_leading_paren",
+            "name": "Case clauses accept leading parentheses",
+            "category": "control",
+            "description": "case pattern lists accept an optional leading '(' and still honour alternation with |.",
+            "script": "Tests/exsh/tests/parser_case_leading_paren.psh",
+            "expect": "runtime_ok",
+            "expected_stdout": "case-leading-paren:start\ncase-leading-paren:match\ncase-leading-paren:end\n"
+        },
+        {
             "id": "command_substitution",
             "name": "Command substitution captures stdout",
             "category": "expansion",

--- a/Tests/exsh/tests/parser_case_leading_paren.psh
+++ b/Tests/exsh/tests/parser_case_leading_paren.psh
@@ -1,0 +1,13 @@
+echo "case-leading-paren:start"
+
+case foo in
+( foo | bar )
+  echo "case-leading-paren:match"
+  ;;
+(*)
+  echo "case-leading-paren:default"
+  ;;
+esac
+
+echo "case-leading-paren:end"
+

--- a/src/shell/parser.c
+++ b/src/shell/parser.c
@@ -1268,6 +1268,10 @@ static ShellCommand *parseCaseClause(ShellParser *parser) {
             return NULL;
         }
         parserScheduleRuleMask(parser, RULE_MASK_CASE_PATTERN);
+        if (parser->current.type == SHELL_TOKEN_LPAREN) {
+            shellParserAdvance(parser);
+            parserScheduleRuleMask(parser, RULE_MASK_CASE_PATTERN);
+        }
         while (parser->current.type == SHELL_TOKEN_WORD || parser->current.type == SHELL_TOKEN_NAME ||
                parser->current.type == SHELL_TOKEN_ASSIGNMENT_WORD || parser->current.type == SHELL_TOKEN_PARAMETER) {
             ShellWord *pattern = parseWordToken(parser, "Expected pattern");


### PR DESCRIPTION
## Summary
- allow the shell parser to skip an optional leading '(' token before case clause patterns while preserving alternation with '|'
- add an exsh fixture exercising the parenthesised case clause form and record it in the manifest

## Testing
- python Tests/exsh/exsh_test_harness.py --only case_leading_paren *(fails: exsh executable not built in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e83cc219f88329a33b5919d95010a0