### PR TITLE
Add runtime support for here-strings

### DIFF
--- a/Tests/exsh/tests/here_documents.psh
+++ b/Tests/exsh/tests/here_documents.psh
@@ -14,4 +14,6 @@ multiline
 content
 EOF
 
+cat <<<"inline"
+
 echo "heredoc:end"

--- a/Tests/exsh/tests/manifest.json
+++ b/Tests/exsh/tests/manifest.json
@@ -241,7 +241,7 @@
             "description": "Exercises unquoted, single-quoted, and multi-line here documents.",
             "script": "Tests/exsh/tests/here_documents.psh",
             "expect": "runtime_ok",
-            "expected_stdout": "heredoc:start\nplain:xyz\nliteral:$VALUE\nmultiline\ncontent\nheredoc:end"
+            "expected_stdout": "heredoc:start\nplain:xyz\nliteral:$VALUE\nmultiline\ncontent\ninline\nheredoc:end"
         },
         {
             "id": "arithmetic_expansion",

--- a/src/backend_ast/shell/shell_command_utils.inc
+++ b/src/backend_ast/shell/shell_command_utils.inc
@@ -453,6 +453,10 @@ static void shellRewriteDoubleBracketTest(ShellCommand *cmd) {
 
             free(redir->here_doc);
             redir->here_doc = NULL;
+            free(redir->here_string_literal);
+            redir->here_string_literal = NULL;
+            free(redir->here_string);
+            redir->here_string = NULL;
         }
 
         free(cmd->redirs);

--- a/src/backend_ast/shell/shell_execution.inc
+++ b/src/backend_ast/shell/shell_execution.inc
@@ -44,7 +44,8 @@ static bool shellBuildCommand(VM *vm, int arg_count, Value *args, ShellCommand *
 typedef enum {
     SHELL_REDIR_OP_OPEN,
     SHELL_REDIR_OP_DUP,
-    SHELL_REDIR_OP_HEREDOC
+    SHELL_REDIR_OP_HEREDOC,
+    SHELL_REDIR_OP_HERE_STRING
 } ShellRuntimeRedirOpType;
 
 typedef struct {
@@ -55,6 +56,7 @@ typedef struct {
     const char *here_body;
     size_t here_length;
     bool close_target;
+    bool append_newline;
 } ShellRuntimeRedirOp;
 
 static int shellSpawnProcess(VM *vm,
@@ -127,6 +129,26 @@ static int shellSpawnProcess(VM *vm,
                 op.write_fd = pipefd[1];
                 op.here_body = redir->here_doc ? redir->here_doc : "";
                 op.here_length = redir->here_doc_length;
+                op.append_newline = false;
+                break;
+            }
+            case SHELL_RUNTIME_REDIR_HERE_STRING: {
+                int pipefd[2];
+                if (pipe(pipefd) != 0) {
+                    prep_error = errno;
+                    goto spawn_cleanup;
+                }
+                op.type = SHELL_REDIR_OP_HERE_STRING;
+                op.source_fd = pipefd[0];
+                op.write_fd = pipefd[1];
+                const char *body = redir->here_string ? redir->here_string
+                                                      : (redir->here_string_literal ? redir->here_string_literal : "");
+                op.here_body = body;
+                op.here_length = redir->here_string_length;
+                if (op.here_length == 0 && body) {
+                    op.here_length = strlen(body);
+                }
+                op.append_newline = true;
                 break;
             }
             default:
@@ -197,7 +219,8 @@ static int shellSpawnProcess(VM *vm,
 
             for (size_t i = 0; i < op_count; ++i) {
                 ShellRuntimeRedirOp *op = &ops[i];
-                if (op->type == SHELL_REDIR_OP_HEREDOC && op->write_fd >= 0) {
+                if ((op->type == SHELL_REDIR_OP_HEREDOC || op->type == SHELL_REDIR_OP_HERE_STRING) &&
+                    op->write_fd >= 0) {
                     close(op->write_fd);
                     op->write_fd = -1;
                 }
@@ -208,6 +231,7 @@ static int shellSpawnProcess(VM *vm,
                 switch (op->type) {
                     case SHELL_REDIR_OP_OPEN:
                     case SHELL_REDIR_OP_HEREDOC:
+                    case SHELL_REDIR_OP_HERE_STRING:
                         if (dup2(op->source_fd, op->target_fd) < 0) {
                             int err = errno;
                             fprintf(stderr, "exsh: %s: %s\n", cmd->argv[0], strerror(err));
@@ -238,7 +262,8 @@ static int shellSpawnProcess(VM *vm,
 
             for (size_t i = 0; i < op_count; ++i) {
                 ShellRuntimeRedirOp *op = &ops[i];
-                if ((op->type == SHELL_REDIR_OP_OPEN || op->type == SHELL_REDIR_OP_HEREDOC) &&
+                if ((op->type == SHELL_REDIR_OP_OPEN || op->type == SHELL_REDIR_OP_HEREDOC ||
+                     op->type == SHELL_REDIR_OP_HERE_STRING) &&
                     op->source_fd >= 0 && op->source_fd != op->target_fd) {
                     close(op->source_fd);
                     op->source_fd = -1;
@@ -264,7 +289,7 @@ static int shellSpawnProcess(VM *vm,
                     close(op->source_fd);
                     op->source_fd = -1;
                 }
-            } else if (op->type == SHELL_REDIR_OP_HEREDOC) {
+            } else if (op->type == SHELL_REDIR_OP_HEREDOC || op->type == SHELL_REDIR_OP_HERE_STRING) {
                 if (op->source_fd >= 0) {
                     close(op->source_fd);
                     op->source_fd = -1;
@@ -272,6 +297,9 @@ static int shellSpawnProcess(VM *vm,
                 if (op->write_fd >= 0) {
                     const char *body = op->here_body ? op->here_body : "";
                     size_t remaining = op->here_length;
+                    if (remaining == 0 && body) {
+                        remaining = strlen(body);
+                    }
                     const char *cursor = body;
                     while (remaining > 0) {
                         ssize_t written = write(op->write_fd, cursor, remaining);
@@ -283,6 +311,19 @@ static int shellSpawnProcess(VM *vm,
                         }
                         cursor += written;
                         remaining -= (size_t)written;
+                    }
+                    if (op->append_newline) {
+                        const char newline = '\n';
+                        while (true) {
+                            ssize_t written = write(op->write_fd, &newline, 1);
+                            if (written < 0) {
+                                if (errno == EINTR) {
+                                    continue;
+                                }
+                                break;
+                            }
+                            break;
+                        }
                     }
                     close(op->write_fd);
                     op->write_fd = -1;
@@ -298,13 +339,15 @@ static int shellSpawnProcess(VM *vm,
 
 spawn_cleanup:
     for (size_t j = 0; j < op_count; ++j) {
-        if (ops[j].type == SHELL_REDIR_OP_OPEN || ops[j].type == SHELL_REDIR_OP_HEREDOC) {
+        if (ops[j].type == SHELL_REDIR_OP_OPEN || ops[j].type == SHELL_REDIR_OP_HEREDOC ||
+            ops[j].type == SHELL_REDIR_OP_HERE_STRING) {
             if (ops[j].source_fd >= 0) {
                 close(ops[j].source_fd);
                 ops[j].source_fd = -1;
             }
         }
-        if (ops[j].type == SHELL_REDIR_OP_HEREDOC && ops[j].write_fd >= 0) {
+        if ((ops[j].type == SHELL_REDIR_OP_HEREDOC || ops[j].type == SHELL_REDIR_OP_HERE_STRING) &&
+            ops[j].write_fd >= 0) {
             close(ops[j].write_fd);
             ops[j].write_fd = -1;
         }
@@ -728,6 +771,63 @@ static bool shellApplyExecRedirections(VM *vm, const ShellCommand *cmd,
                 if (dup2(pipefd[0], target_fd) < 0) {
                     int err = errno;
                     runtimeError(vm, "exec: failed to apply heredoc: %s", strerror(err));
+                    shellUpdateStatus(err ? err : 1);
+                    close(pipefd[0]);
+                    goto redir_error;
+                }
+                close(pipefd[0]);
+                break;
+            }
+            case SHELL_RUNTIME_REDIR_HERE_STRING: {
+                int pipefd[2];
+                if (pipe(pipefd) != 0) {
+                    int err = errno;
+                    runtimeError(vm, "exec: failed to create here-string pipe: %s", strerror(err));
+                    shellUpdateStatus(err ? err : 1);
+                    goto redir_error;
+                }
+                const char *body = redir->here_string ? redir->here_string
+                                                       : (redir->here_string_literal ? redir->here_string_literal : "");
+                size_t remaining = redir->here_string_length;
+                if (remaining == 0 && body) {
+                    remaining = strlen(body);
+                }
+                const char *cursor = body;
+                while (remaining > 0) {
+                    ssize_t written = write(pipefd[1], cursor, remaining);
+                    if (written < 0) {
+                        if (errno == EINTR) {
+                            continue;
+                        }
+                        int err = errno;
+                        runtimeError(vm, "exec: failed to write here-string: %s", strerror(err));
+                        shellUpdateStatus(err ? err : 1);
+                        close(pipefd[0]);
+                        close(pipefd[1]);
+                        goto redir_error;
+                    }
+                    cursor += written;
+                    remaining -= (size_t)written;
+                }
+                while (true) {
+                    ssize_t written = write(pipefd[1], "\n", 1);
+                    if (written < 0) {
+                        if (errno == EINTR) {
+                            continue;
+                        }
+                        int err = errno;
+                        runtimeError(vm, "exec: failed to terminate here-string: %s", strerror(err));
+                        shellUpdateStatus(err ? err : 1);
+                        close(pipefd[0]);
+                        close(pipefd[1]);
+                        goto redir_error;
+                    }
+                    break;
+                }
+                close(pipefd[1]);
+                if (dup2(pipefd[0], target_fd) < 0) {
+                    int err = errno;
+                    runtimeError(vm, "exec: failed to apply here-string: %s", strerror(err));
                     shellUpdateStatus(err ? err : 1);
                     close(pipefd[0]);
                     goto redir_error;

--- a/src/backend_ast/shell/shell_runtime_state.inc
+++ b/src/backend_ast/shell/shell_runtime_state.inc
@@ -601,7 +601,8 @@ static char *shellExpandPatternText(const char *pattern, size_t len) {
 typedef enum {
     SHELL_RUNTIME_REDIR_OPEN,
     SHELL_RUNTIME_REDIR_DUP,
-    SHELL_RUNTIME_REDIR_HEREDOC
+    SHELL_RUNTIME_REDIR_HEREDOC,
+    SHELL_RUNTIME_REDIR_HERE_STRING
 } ShellRuntimeRedirectionKind;
 
 typedef struct {
@@ -615,6 +616,9 @@ typedef struct {
     char *here_doc;
     size_t here_doc_length;
     bool here_doc_quoted;
+    char *here_string_literal;
+    char *here_string;
+    size_t here_string_length;
 } ShellRedirection;
 
 typedef struct {

--- a/src/backend_ast/shell/shell_word_expansion.inc
+++ b/src/backend_ast/shell/shell_word_expansion.inc
@@ -1507,6 +1507,8 @@ static void shellFreeRedirections(ShellCommand *cmd) {
     for (size_t i = 0; i < cmd->redir_count; ++i) {
         free(cmd->redirs[i].path);
         free(cmd->redirs[i].here_doc);
+        free(cmd->redirs[i].here_string_literal);
+        free(cmd->redirs[i].here_string);
     }
     free(cmd->redirs);
     cmd->redirs = NULL;
@@ -2954,6 +2956,7 @@ static bool shellAddRedirection(ShellCommand *cmd, const char *spec) {
     const char *type_text = "";
     const char *word_hex = "";
     const char *here_hex = "";
+    const char *here_string_hex = "";
     bool here_quoted = false;
 
     char *cursor = copy;
@@ -2979,6 +2982,8 @@ static bool shellAddRedirection(ShellCommand *cmd, const char *spec) {
             here_hex = value;
         } else if (strcmp(key, "hereq") == 0) {
             shellParseBool(value, &here_quoted);
+        } else if (strcmp(key, "hstr") == 0) {
+            here_string_hex = value;
         }
         if (!next) {
             break;
@@ -3106,27 +3111,22 @@ static bool shellAddRedirection(ShellCommand *cmd, const char *spec) {
         redir.here_doc_length = expanded ? strlen(expanded) : 0;
         redir.here_doc_quoted = here_quoted;
     } else if (strcmp(type_text, "<<<") == 0) {
-        redir.kind = SHELL_RUNTIME_REDIR_HEREDOC;
+        redir.kind = SHELL_RUNTIME_REDIR_HERE_STRING;
         if (!expanded_target) {
             free(word_encoded);
             free(copy);
             return false;
         }
-        size_t len = strlen(expanded_target);
-        char *body = (char *)malloc(len + 2);
-        if (!body) {
+        char *literal = decodeHexString(here_string_hex ? here_string_hex : "", NULL);
+        if (!literal) {
             free(expanded_target);
             free(word_encoded);
             free(copy);
             return false;
         }
-        memcpy(body, expanded_target, len);
-        body[len] = '\n';
-        body[len + 1] = '\0';
-        redir.here_doc = body;
-        redir.here_doc_length = len + 1;
-        redir.here_doc_quoted = false;
-        free(expanded_target);
+        redir.here_string_literal = literal;
+        redir.here_string = expanded_target;
+        redir.here_string_length = expanded_target ? strlen(expanded_target) : 0;
         expanded_target = NULL;
     } else {
         free(expanded_target);
@@ -3140,6 +3140,8 @@ static bool shellAddRedirection(ShellCommand *cmd, const char *spec) {
         free(expanded_target);
         free(redir.path);
         free(redir.here_doc);
+        free(redir.here_string_literal);
+        free(redir.here_string);
         free(word_encoded);
         free(copy);
         return false;

--- a/src/shell/ast.c
+++ b/src/shell/ast.c
@@ -259,6 +259,7 @@ ShellRedirection *shellCreateRedirection(ShellRedirectionType type, const char *
     redir->io_number = io_number ? strdup(io_number) : NULL;
     redir->target = target;
     redir->here_document = NULL;
+    redir->here_string_literal = NULL;
     redir->here_document_quoted = false;
     redir->dup_target = NULL;
     redir->line = line;
@@ -271,6 +272,7 @@ void shellFreeRedirection(ShellRedirection *redir) {
     free(redir->io_number);
     shellFreeWord(redir->target);
     free(redir->here_document);
+    free(redir->here_string_literal);
     free(redir->dup_target);
     free(redir);
 }
@@ -290,6 +292,18 @@ const char *shellRedirectionGetHereDocument(const ShellRedirection *redir) {
 
 bool shellRedirectionHereDocumentIsQuoted(const ShellRedirection *redir) {
     return redir ? redir->here_document_quoted : false;
+}
+
+void shellRedirectionSetHereStringLiteral(ShellRedirection *redir, const char *literal) {
+    if (!redir) {
+        return;
+    }
+    free(redir->here_string_literal);
+    redir->here_string_literal = literal ? strdup(literal) : NULL;
+}
+
+const char *shellRedirectionGetHereStringLiteral(const ShellRedirection *redir) {
+    return redir ? redir->here_string_literal : NULL;
 }
 
 void shellRedirectionSetDupTarget(ShellRedirection *redir, const char *target) {
@@ -977,6 +991,9 @@ static void shellDumpRedirectionJson(FILE *out, const ShellRedirection *redir, i
     shellPrintIndent(out, indent + 2);
     fprintf(out, "\"hereDocumentPayload\": \"%s\",\n",
             (redir && redir->here_document) ? redir->here_document : "");
+    shellPrintIndent(out, indent + 2);
+    fprintf(out, "\"hereStringLiteral\": \"%s\",\n",
+            (redir && redir->here_string_literal) ? redir->here_string_literal : "");
     shellPrintIndent(out, indent + 2);
     fprintf(out, "\"dupTarget\": \"%s\"\n", (redir && redir->dup_target) ? redir->dup_target : "");
     shellPrintIndent(out, indent);

--- a/src/shell/ast.h
+++ b/src/shell/ast.h
@@ -65,6 +65,7 @@ typedef struct {
     char *io_number;
     ShellWord *target;
     char *here_document;
+    char *here_string_literal;
     char *dup_target;
     bool here_document_quoted;
     int line;
@@ -223,6 +224,8 @@ void shellFreeRedirection(ShellRedirection *redir);
 void shellRedirectionSetHereDocument(ShellRedirection *redir, const char *payload, bool quoted);
 const char *shellRedirectionGetHereDocument(const ShellRedirection *redir);
 bool shellRedirectionHereDocumentIsQuoted(const ShellRedirection *redir);
+void shellRedirectionSetHereStringLiteral(ShellRedirection *redir, const char *literal);
+const char *shellRedirectionGetHereStringLiteral(const ShellRedirection *redir);
 void shellRedirectionSetDupTarget(ShellRedirection *redir, const char *target);
 const char *shellRedirectionGetDupTarget(const ShellRedirection *redir);
 ShellWord *shellRedirectionGetWordTarget(const ShellRedirection *redir);

--- a/src/shell/codegen.c
+++ b/src/shell/codegen.c
@@ -290,33 +290,46 @@ static char *buildRedirectionMetadata(const ShellRedirection *redir) {
         return NULL;
     }
 
-    size_t meta_len = (size_t)snprintf(NULL, 0,
-                                       "redir:fd=%s;type=%s;word=%s;dup=%s;here=%s;hereq=%d",
-                                       fd_text,
-                                       type_name ? type_name : "",
-                                       encoded_word,
-                                       dup_hex,
-                                       here_hex,
-                                       here_quoted ? 1 : 0);
-    char *meta = (char *)malloc(meta_len + 1);
-    if (!meta) {
+    const char *here_string_literal = shellRedirectionGetHereStringLiteral(redir);
+    char *here_string_hex = encodeHexString(here_string_literal ? here_string_literal : "");
+    if (!here_string_hex) {
         free(encoded_word);
         free(dup_hex);
         free(here_hex);
         return NULL;
     }
+
+    size_t meta_len = (size_t)snprintf(NULL, 0,
+                                       "redir:fd=%s;type=%s;word=%s;dup=%s;here=%s;hereq=%d;hstr=%s",
+                                       fd_text,
+                                       type_name ? type_name : "",
+                                       encoded_word,
+                                       dup_hex,
+                                       here_hex,
+                                       here_quoted ? 1 : 0,
+                                       here_string_hex);
+    char *meta = (char *)malloc(meta_len + 1);
+    if (!meta) {
+        free(encoded_word);
+        free(dup_hex);
+        free(here_hex);
+        free(here_string_hex);
+        return NULL;
+    }
     snprintf(meta, meta_len + 1,
-             "redir:fd=%s;type=%s;word=%s;dup=%s;here=%s;hereq=%d",
+             "redir:fd=%s;type=%s;word=%s;dup=%s;here=%s;hereq=%d;hstr=%s",
              fd_text,
              type_name ? type_name : "",
              encoded_word,
              dup_hex,
              here_hex,
-             here_quoted ? 1 : 0);
+             here_quoted ? 1 : 0,
+             here_string_hex);
 
     free(encoded_word);
     free(dup_hex);
     free(here_hex);
+    free(here_string_hex);
     return meta;
 }
 

--- a/src/shell/parser.c
+++ b/src/shell/parser.c
@@ -1677,6 +1677,11 @@ static ShellRedirection *parseRedirection(ShellParser *parser, bool *strip_tabs_
         }
         free(dup_copy);
     }
+    if (redir && type == SHELL_REDIRECT_HERE_STRING) {
+        char *literal = parserCopyWordWithoutMarkers(target);
+        shellRedirectionSetHereStringLiteral(redir, literal ? literal : "");
+        free(literal);
+    }
     return redir;
 }
 


### PR DESCRIPTION
## Summary
- capture here-string literals during parsing and encode them in the redirection metadata
- extend the runtime redirection structs and execution paths to materialise <<< input with a trailing newline
- cover the new behaviour by augmenting the here document regression script with a here-string case

## Testing
- python3 Tests/exsh/exsh_test_harness.py --only redirection_here_string *(fails: exsh executable not found at /workspace/pscal/build/bin/exsh)*

------
https://chatgpt.com/codex/tasks/task_b_68e854febb908329ba571681a5b7d419