### PR TITLE
Fix exsh builtins to match shellbench expectations

### DIFF
--- a/src/backend_ast/shell/shell_builtins.inc
+++ b/src/backend_ast/shell/shell_builtins.inc
@@ -1008,7 +1008,7 @@ Value vmBuiltinShellCase(VM *vm, int arg_count, Value *args) {
         goto cleanup;
     }
     free(expanded_subject);
-    shellUpdateStatus(1);
+    shellUpdateStatus(0);
 
 cleanup:
     shellRestoreCurrentVm(previous_vm);
@@ -1018,6 +1018,7 @@ cleanup:
 Value vmBuiltinShellCaseClause(VM *vm, int arg_count, Value *args) {
     VM *previous_vm = shellSwapCurrentVm(vm);
     Value result = makeVoid();
+    shellRuntimeEnterCondition();
     if (arg_count < 1 || args[0].type != TYPE_STRING) {
         runtimeError(vm, "shell case clause: expected metadata");
         shellUpdateStatus(1);
@@ -1083,6 +1084,7 @@ Value vmBuiltinShellCaseClause(VM *vm, int arg_count, Value *args) {
     }
 
 cleanup:
+    shellRuntimeLeaveCondition();
     shellRestoreCurrentVm(previous_vm);
     return result;
 }
@@ -1101,7 +1103,7 @@ Value vmBuiltinShellCaseEnd(VM *vm, int arg_count, Value *args) {
     bool matched = ctx->matched;
     shellCaseStackPop();
     if (!matched) {
-        shellUpdateStatus(1);
+        shellUpdateStatus(0);
     }
     shellRestoreCurrentVm(previous_vm);
     return makeVoid();

--- a/src/backend_ast/shell/shell_word_expansion.inc
+++ b/src/backend_ast/shell/shell_word_expansion.inc
@@ -2268,7 +2268,8 @@ static bool shellIsRuntimeBuiltin(const char *name) {
         "umask",   "command","hash",  "trap",   "local",  "let",    "break",   "continue","alias",
         "bind",    "shopt",  "history","jobs",   "disown", "fg",      "finger",  "bg",
         "wait",    "builtin","source", "read",   "printf", "shift",   "return",  "help",
-        "type",    ":",      "unalias","getopts","mapfile","__shell_double_bracket", "__shell_arithmetic", "times"
+        "type",    "test",   "[",      ":",      "unalias","getopts","mapfile","__shell_double_bracket",
+        "__shell_arithmetic", "times"
     };
 
     size_t count = sizeof(kBuiltins) / sizeof(kBuiltins[0]);


### PR DESCRIPTION
## Summary
- ensure `test`/`[` are treated as runtime builtins so shellbench bracket checks run through the exsh implementation
- update the case builtins to evaluate clauses under a condition guard and report success when no clause matches, aligning with bash

## Testing
- SHELLBENCH_BENCHMARK_TIME=1 SHELLBENCH_WARMUP_TIME=0 ./shellbench -s exsh,bash sample/cmp.sh > /tmp/sb_out.txt
- cat /tmp/sb_out.txt

------
https://chatgpt.com/codex/tasks/task_b_68e86b6a28d083299f68f518d6934746