### PR TITLE
Preserve declare values when no assignment is provided

### DIFF
--- a/src/backend_ast/shell/shell_builtins.inc
+++ b/src/backend_ast/shell/shell_builtins.inc
@@ -4220,6 +4220,32 @@ Value vmBuiltinShellDeclare(VM *vm, int arg_count, Value *args) {
                     // Without an assignment, bash preserves the current value of global
                     // variables when applying attributes. Leave the value untouched so
                     // constructs like `typeset -i var` do not reset an existing binding.
+                    if (shellReadonlyContains(spec)) {
+                        runtimeError(vm, "declare: %s: readonly variable", spec);
+                        ok = false;
+                    } else {
+                        const ShellArrayVariable *array_var = shellArrayRegistryFindConst(spec);
+                        bool exists = (array_var != NULL);
+                        if (!exists) {
+                            const char *existing = getenv(spec);
+                            exists = (existing != NULL);
+                        }
+                        if (!exists) {
+                            const char *initial = integer_attribute ? "0" : "";
+                            errno = 0;
+                            if (!shellSetTrackedVariable(spec, initial, false)) {
+                                if (errno != 0) {
+                                    runtimeError(vm,
+                                                "declare: unable to set '%s': %s",
+                                                spec,
+                                                strerror(errno));
+                                } else {
+                                    runtimeError(vm, "declare: unable to set '%s'", spec);
+                                }
+                                ok = false;
+                            }
+                        }
+                    }
                 }
             }
             if (ok && mark_readonly) {


### PR DESCRIPTION
## Summary
- avoid clobbering existing variables when declare/typeset is invoked without an assignment
- document the behaviour to keep integer attributes from zeroing out previous values

## Testing
- ./shellbench -s exsh,bash sample/count.sh

------
https://chatgpt.com/codex/tasks/task_b_68e8cc8d805083299455a69c6eb972d9