### PR TITLE
Recognize eval builtin invocation in exsh

### DIFF
--- a/Tests/exsh/tests/eval_scope_retention.psh
+++ b/Tests/exsh/tests/eval_scope_retention.psh
@@ -1,7 +1,7 @@
 echo "eval-retain:start"
 greeting="outer"
 greet() { echo "greet:$greeting"; }
-builtin eval 'echo "eval-first:$greeting"; greet; greeting="inner"; newvar="from-eval"; echo "eval-second:$greeting"; greet'
+eval 'echo "eval-first:$greeting"; greet; greeting="inner"; newvar="from-eval"; echo "eval-second:$greeting"; greet'
 greet
 echo "after-greeting:$greeting"
 echo "newvar:$newvar"

--- a/src/backend_ast/shell/shell_word_expansion.inc
+++ b/src/backend_ast/shell/shell_word_expansion.inc
@@ -2264,11 +2264,12 @@ static bool shellIsRuntimeBuiltin(const char *name) {
     }
     static const char *kBuiltins[] = {
         "cd",      "pwd",    "dirs",   "pushd",  "popd",   "exit",    "logout",  "exec",
-        "export",  "unset",  "setenv", "unsetenv","set",    "declare", "typeset", "readonly",
-        "umask",   "command","hash",  "trap",   "local",  "let",    "break",   "continue","alias",
-        "bind",    "shopt",  "history","jobs",   "disown", "fg",      "finger",  "bg",
-        "wait",    "builtin","source", "read",   "printf", "shift",   "return",  "help",
-        "type",    "test",   "[",      ":",      "unalias","getopts","mapfile","__shell_double_bracket",
+        "eval",    "export", "unset",  "setenv", "unsetenv","set",    "declare", "typeset",
+        "readonly","umask",  "command","hash",   "trap",   "local",   "let",     "break",
+        "continue","alias", "bind",   "shopt",  "history","jobs",   "disown",  "fg",
+        "finger", "bg",     "wait",   "builtin","source", "read",   "printf",  "shift",
+        "return", "help",   "type",   "test",   "[",      ":",      "unalias","getopts",
+        "mapfile","__shell_double_bracket",
         "__shell_arithmetic", "times"
     };
 


### PR DESCRIPTION
## Summary
- include `eval` in the runtime builtin whitelist so bare `eval` commands resolve to the builtin handler
- adjust the eval scope retention regression script to cover calling `eval` without the `builtin` prefix

## Testing
- Tests/run_exsh_tests.sh --only eval_scope_retention

------
https://chatgpt.com/codex/tasks/task_b_68e8fae820c88329afc05167f14faccf