### PR TITLE
Fix duplicate registration of VM builtins

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -663,6 +663,13 @@ void registerVmBuiltin(const char *name, VmBuiltinFn handler,
             return;
         }
     }
+    for (size_t i = 0; i < num_extra_vm_builtins; ++i) {
+        if (strcasecmp(name, extra_vm_builtins[i].name) == 0) {
+            extra_vm_builtins[i].handler = handler;
+            pthread_mutex_unlock(&builtin_registry_mutex);
+            return;
+        }
+    }
 
     VmBuiltinMapping *new_table = realloc(extra_vm_builtins,
         sizeof(VmBuiltinMapping) * (num_extra_vm_builtins + 1));


### PR DESCRIPTION
## Summary
- avoid appending duplicate entries when registering VM builtins, so repeated registration updates the existing handler instead of shifting builtin ids

## Testing
- build/bin/exsh -c '__count=0; while __count=$((__count+1)); do eval "var=1"; if [ "$__count" -ge 120 ]; then break; fi; done'
- SHELLBENCH_WARMUP_TIME=0 SHELLBENCH_BENCHMARK_TIME=1 ./shellbench -s ../pscal/build/bin/exsh --error sample/eval.sh


------
https://chatgpt.com/codex/tasks/task_b_68e906a3ea748329be27db060a957092