### PR TITLE
Fix Rea bytecode cache dependency resolution

### DIFF
--- a/src/rea/main.c
+++ b/src/rea/main.c
@@ -234,7 +234,13 @@ static void collectUsesClauses(AST* node, List* out) {
         collectUnitListPaths(node->unit_list, out);
     }
     if (node->type == AST_IMPORT && node->token && node->token->value) {
-        listAppend(out, node->token->value);
+        char *resolved = reaResolveImportPath(node->token->value);
+        if (resolved) {
+            listAppend(out, resolved);
+            free(resolved);
+        } else {
+            listAppend(out, node->token->value);
+        }
     }
     if (node->left) collectUsesClauses(node->left, out);
     if (node->right) collectUsesClauses(node->right, out);
@@ -396,6 +402,7 @@ int main(int argc, char **argv) {
     bool used_cache = 0;
     if (!no_cache) used_cache = loadBytecodeFromCache(path, kReaCompilerId, argv[0], dep_array, dep_count, &chunk);
     if (dep_array) free(dep_array);
+    freeList(dep_files);
     if (used_cache) {
 #if defined(__APPLE__)
 #define PSCAL_STAT_SEC(st) ((st).st_mtimespec.tv_sec)

--- a/src/rea/semantic.c
+++ b/src/rea/semantic.c
@@ -3753,3 +3753,16 @@ const char *reaGetModuleName(int index) {
     ReaModuleInfo *info = gLoadedModules[index];
     return info ? info->name : NULL;
 }
+
+char *reaResolveImportPath(const char *path) {
+    bool exists = false;
+    char *resolved = resolveModulePath(path, &exists);
+    if (!resolved) {
+        return NULL;
+    }
+    if (!exists) {
+        free(resolved);
+        return NULL;
+    }
+    return resolved;
+}

--- a/src/rea/semantic.h
+++ b/src/rea/semantic.h
@@ -13,5 +13,6 @@ int reaGetLoadedModuleCount(void);
 AST *reaGetModuleAST(int index);
 const char *reaGetModulePath(int index);
 const char *reaGetModuleName(int index);
+char *reaResolveImportPath(const char *path);
 
 #endif /* REA_SEMANTIC_H */


### PR DESCRIPTION
## Summary
- Resolve Rea module import paths before passing them to the bytecode cache so dependency mtimes are checked against real files
- Expose a semantic helper for resolving import paths and release the collected dependency list after cache probing

## Testing
- cmake -S . -B build
- cmake --build build --target rea

------
https://chatgpt.com/codex/tasks/task_b_68e994bd2c5083298985adfbc98d3b1d