### PR TITLE
Fix builtin redirection buffering for exsh builtins

### DIFF
--- a/src/backend_ast/shell/shell_word_expansion.inc
+++ b/src/backend_ast/shell/shell_word_expansion.inc
@@ -2440,6 +2440,7 @@ static bool shellInvokeBuiltin(VM *vm, ShellCommand *cmd) {
     }
     ShellExecRedirBackup *redir_backups = NULL;
     size_t redir_backup_count = 0;
+    fflush(NULL);
     if (!shellApplyExecRedirections(vm, cmd, &redir_backups, &redir_backup_count)) {
         if (args) {
             for (int i = 0; i < arg_count; ++i) {
@@ -2455,6 +2456,7 @@ static bool shellInvokeBuiltin(VM *vm, ShellCommand *cmd) {
     shellRuntimeSetCurrentCommandName(name);
     handler(vm, arg_count, args);
     shellRuntimeSetCurrentCommandName(previous_name);
+    fflush(NULL);
     shellRestoreExecRedirections(redir_backups, redir_backup_count);
     shellFreeExecRedirBackups(redir_backups, redir_backup_count);
     if (args) {


### PR DESCRIPTION
## Summary
- flush stdio buffers before applying and after executing builtin redirections so redirected output stays suppressed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e99db0a80483298909519ddcb0903a