### PR TITLE
Allow configuring PSCAL install root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ Developer experience
 - Build: macOS SDK auto‑detect; opt‑in `-DPSCAL_USE_BREW_CURL=ON` to prefer Homebrew curl; clean `-Wall` builds.
 
 Fixed
-- Installer: ensure `/usr/local/pscal/misc` exists before copying misc assets.
+- Installer: ensure `${PSCAL_INSTALL_ROOT}/misc` exists before copying misc assets.
 
 All notable changes to this project will be documented in this file.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,20 @@ add_compile_definitions(
     PSCAL_GIT_TAG="${PSCAL_GIT_TAG}"
 )
 
-set(PSCAL_INSTALL_ROOT "/usr/local/pscal" CACHE PATH "Default PSCAL runtime asset directory")
+# Derive the default install root from the selected CMake install prefix so a
+# customised `-DCMAKE_INSTALL_PREFIX` keeps runtime assets colocated with the
+# binaries unless users explicitly override `-DPSCAL_INSTALL_ROOT`.
+set(_pscal_install_prefix "${CMAKE_INSTALL_PREFIX}")
+if(NOT _pscal_install_prefix)
+    set(_pscal_install_prefix "/usr/local")
+endif()
+string(REGEX REPLACE "/$" "" _pscal_install_prefix "${_pscal_install_prefix}")
+if(_pscal_install_prefix MATCHES "/pscal$")
+    set(_pscal_install_root_default "${_pscal_install_prefix}")
+else()
+    set(_pscal_install_root_default "${_pscal_install_prefix}/pscal")
+endif()
+set(PSCAL_INSTALL_ROOT "${_pscal_install_root_default}" CACHE PATH "Default PSCAL runtime asset directory")
 string(REGEX REPLACE "/$" "" PSCAL_INSTALL_ROOT "${PSCAL_INSTALL_ROOT}")
 file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/generated")
 configure_file(src/core/pscal_paths.h.in "${CMAKE_BINARY_DIR}/generated/pscal_paths.h" @ONLY)

--- a/Docs/simple_web_server.md
+++ b/Docs/simple_web_server.md
@@ -2,7 +2,7 @@
 
 ## Overview
 - Purpose: Minimal HTTP 1.1 server implemented in CLike for demos and local testing.
-- Default root: Populates `/tmp/htdocs.<PID>` by copying `${PSCAL_INSTALL_ROOT}/misc/htdocs` (default `/usr/local/pscal/misc/htdocs`); falls back to a minimal `index.html` if the copy fails.
+- Default root: Populates `/tmp/htdocs.<PID>` by copying `${PSCAL_INSTALL_ROOT}/misc/htdocs` (defaults to `${CMAKE_INSTALL_PREFIX}/pscal/misc/htdocs` unless overridden); falls back to a minimal `index.html` if the copy fails.
 - Design: Single listener socket, multi-threaded worker pool, bounded in-memory queue, simple static file serving.
 
 ## Features

--- a/Examples/clike/base/README.md
+++ b/Examples/clike/base/README.md
@@ -38,5 +38,6 @@ build/bin/clike Examples/Clike/<program>
 
 The clike front end resolves imports by first checking the directory in the
 `CLIKE_LIB_DIR` environment variable and falling back to
-`${PSCAL_INSTALL_ROOT}/clike/lib` (defaulting to
-`/usr/local/pscal/clike/lib`).
+`${PSCAL_INSTALL_ROOT}/clike/lib` (which defaults to
+`${CMAKE_INSTALL_PREFIX}/pscal/clike/lib` unless overridden at configure
+time).

--- a/README.md
+++ b/README.md
@@ -321,11 +321,12 @@ The front ends need access to various sounds and libraries.  To install them run
 sudo ./install.sh
 ```
 
-To relocate the runtime assets, configure the build with
-`-DPSCAL_INSTALL_ROOT=/path/to/pscal` and pass the same location to the
-installer, e.g. `./install.sh --prefix /usr/local --pscal-dir /path/to/pscal`.
-When a build directory is provided, `install.sh` will automatically read the
-compiled default from `build/pscal_install_root.txt`.
+The runtime install root defaults to `${CMAKE_INSTALL_PREFIX}/pscal`. To relocate
+the assets, configure the build with `-DPSCAL_INSTALL_ROOT=/path/to/pscal` (or
+adjust `-DCMAKE_INSTALL_PREFIX`) and re-run CMake. The installer automatically
+reads both the prefix and the compiled default root from the build tree
+(`CMakeCache.txt` and `pscal_install_root.txt`), but you can still override them
+explicitly via `--prefix`/`--pscal-dir`.
 
 ## Extending built-ins
 

--- a/RELEASE_NOTES_v2.2.md
+++ b/RELEASE_NOTES_v2.2.md
@@ -44,7 +44,7 @@ Date: 2025-09-18
   - Updated README and guides for procedure/function pointers, thread APIs, AST JSON pipeline, and HTTP security.
 - Build
   - macOS: SDK auto-detection; opt-in `-DPSCAL_USE_BREW_CURL=ON` to prefer Homebrew curl.
-  - Installer: misc library copy fixed (ensures `/usr/local/pscal/misc` exists).
+  - Installer: misc library copy fixed (ensures `${PSCAL_INSTALL_ROOT}/misc` exists).
 
 ## Fixed
 - Pointer metadata propagation for locals/globals enabling reliable `new(p)` and `p^` dereference behavior.

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,8 @@ usage() {
 Usage: install.sh [--prefix DIR] [--pscal-dir DIR] [--build-dir DIR]
 
 Options:
-  --prefix DIR      Installation prefix (default: /usr/local)
+  --prefix DIR      Installation prefix (default: value from the build cache
+                    or /usr/local)
   --pscal-dir DIR   Destination for PSCAL libraries and assets.
                     Defaults to the compiled-in install root when available
                     (unless --prefix is provided), otherwise
@@ -80,6 +81,16 @@ case $BUILD_DIR in
 esac
 
 BUILD_ROOT=$(dirname "$BIN_SRC")
+
+if [ "$PREFIX_SET" -eq 0 ]; then
+    CACHE_FILE=$BUILD_ROOT/CMakeCache.txt
+    if [ -f "$CACHE_FILE" ]; then
+        CACHE_PREFIX=$(sed -n 's/^CMAKE_INSTALL_PREFIX:PATH=//p' "$CACHE_FILE" | tail -n 1)
+        if [ -n "$CACHE_PREFIX" ]; then
+            PREFIX=$CACHE_PREFIX
+        fi
+    fi
+fi
 
 resolve_pscal_dir() {
     candidate=$1


### PR DESCRIPTION
## Summary
- derive the default PSCAL asset root from the selected CMake install prefix so binaries compile with the correct path
- update install.sh to reuse the configured prefix and document the new defaults across the README and guides
- refresh historical notes to reference the generic PSCAL install root instead of a hard-coded /usr/local path

## Testing
- cmake -S . -B build
- ./install.sh --help

------
https://chatgpt.com/codex/tasks/task_b_68e9aafedbf08329ad3c282a978b2ab4