### PR TITLE
Configure example resource paths using install prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -801,6 +801,40 @@ endif()
 # ---- Examples ----
 add_subdirectory(Examples)
 
+set(PSCAL_CONFIGURED_EXAMPLES
+    Examples/pascal/base/hangman
+    Examples/pascal/base/hangman2
+    Examples/pascal/base/hangman3
+    Examples/pascal/base/hangman4
+    Examples/pascal/base/hangman5
+    Examples/pascal/base/weather
+    Examples/pascal/base/weather_json
+    Examples/pascal/sdl/mando
+    Examples/pascal/sdl/mando_Linux
+    Examples/pascal/sdl/SoundSimplePong
+    Examples/pascal/sdl/FireWorks
+    Examples/clike/base/hangman5
+    Examples/clike/base/simple_web_server
+    Examples/clike/sdl/mandelbrot_interactive
+    Examples/clike/sdl/spacegame
+    Examples/rea/base/hangman5
+    Examples/rea/base/openweather_forecast
+    Examples/rea/sdl/planets
+    Examples/rea/sdl/planets_inner
+    Examples/rea/sdl/planets_earth
+    Examples/rea/sdl/block_game
+    Examples/rea/sdl/mandelbrot_interactive
+    Examples/rea/sdl/mandelbrot_interactive_ext)
+list(REMOVE_DUPLICATES PSCAL_CONFIGURED_EXAMPLES)
+set(PSCAL_CONFIGURED_EXAMPLES_DIR "${CMAKE_BINARY_DIR}/configured_examples")
+foreach(example IN LISTS PSCAL_CONFIGURED_EXAMPLES)
+    set(src "${CMAKE_SOURCE_DIR}/${example}")
+    set(dst "${PSCAL_CONFIGURED_EXAMPLES_DIR}/${example}")
+    get_filename_component(dst_dir "${dst}" DIRECTORY)
+    file(MAKE_DIRECTORY "${dst_dir}")
+    configure_file("${src}" "${dst}" @ONLY)
+endforeach()
+
 # ---- optional install ----
 include(GNUInstallDirs)
 set(_pscal_runtime_root "${PSCAL_INSTALL_ROOT_DESTINATION}")
@@ -845,6 +879,14 @@ install(DIRECTORY etc/
 install(DIRECTORY Examples/
         DESTINATION "${_pscal_runtime_root}/Examples"
         USE_SOURCE_PERMISSIONS)
+foreach(example IN LISTS PSCAL_CONFIGURED_EXAMPLES)
+    get_filename_component(example_dir "${example}" DIRECTORY)
+    install(FILES "${PSCAL_CONFIGURED_EXAMPLES_DIR}/${example}"
+            DESTINATION "${_pscal_runtime_root}/Examples/${example_dir}"
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                       GROUP_READ GROUP_EXECUTE
+                       WORLD_READ WORLD_EXECUTE)
+endforeach()
 install(DIRECTORY Docs/
         DESTINATION "${_pscal_runtime_root}/docs")
 install(DIRECTORY Tests/libs/

--- a/Examples/clike/base/hangman5
+++ b/Examples/clike/base/hangman5
@@ -21,6 +21,7 @@ int centerCol, hangmanStartCol, effectiveWidth;
 
 int wins = 0;
 int losses = 0;
+str configuredInstallRoot = "@PSCAL_INSTALL_ROOT_RESOLVED@";
 
 str trimTrailingSlashes(str path) {
     int len = length(path);
@@ -122,6 +123,15 @@ str resolveInstallRoot(str resourceRel) {
     if (strlen(override) > 0) {
         if (strlen(resourceRel) == 0 || pathExists(pathJoin(override, resourceRel))) {
             return override;
+        }
+    }
+
+    if (length(configuredInstallRoot) > 0 && copy(configuredInstallRoot, 1, 1) != "@") {
+        str configured = normalizePath(configuredInstallRoot);
+        if (strlen(configured) > 0) {
+            if (strlen(resourceRel) == 0 || pathExists(pathJoin(configured, resourceRel))) {
+                return configured;
+            }
         }
     }
 

--- a/Examples/clike/base/simple_web_server
+++ b/Examples/clike/base/simple_web_server
@@ -12,6 +12,7 @@ str RootDir;
 str IndexPath;
 str Body;
 text GFile;
+str ConfiguredInstallRoot = "@PSCAL_INSTALL_ROOT_RESOLVED@";
 
 // Worker pool + simple ring queue for accepted connections
 int MaxThreads = 8;                   // configurable via CLI
@@ -462,6 +463,15 @@ str resolveInstallRoot(str resourceRel) {
   if (strlen(override) > 0) {
     if (strlen(resourceRel) == 0 || fsPathExists(fsPathJoin(override, resourceRel))) {
       return override;
+    }
+  }
+
+  if (length(ConfiguredInstallRoot) > 0 && copy(ConfiguredInstallRoot, 1, 1) != "@") {
+    str configured = fsNormalizePath(ConfiguredInstallRoot);
+    if (strlen(configured) > 0) {
+      if (strlen(resourceRel) == 0 || fsPathExists(fsPathJoin(configured, resourceRel))) {
+        return configured;
+      }
     }
   }
 

--- a/Examples/clike/sdl/mandelbrot_interactive
+++ b/Examples/clike/sdl/mandelbrot_interactive
@@ -19,6 +19,9 @@ const int KEY_RIGHT = 1073741903;
 const int KEY_UP = 1073741906;
 const int KEY_DOWN = 1073741905;
 
+str ConfiguredInstallRoot = "@PSCAL_INSTALL_ROOT_RESOLVED@";
+str ConfiguredFontPath = "@PSCAL_INSTALL_ROOT_RESOLVED@/fonts/Roboto/static/Roboto-Regular.ttf";
+
 byte pixelData[Width * Height * BytesPerPixel];
 int rowDone[Height];
 int threadStart[ThreadCount];
@@ -141,6 +144,15 @@ str resolveInstallRoot(str resourceRel) {
     if (strlen(override) > 0) {
         if (strlen(resourceRel) == 0 || pathExists(pathJoin(override, resourceRel))) {
             return override;
+        }
+    }
+
+    if (length(ConfiguredInstallRoot) > 0 && copy(ConfiguredInstallRoot, 1, 1) != "@") {
+        str configured = normalizePath(ConfiguredInstallRoot);
+        if (strlen(configured) > 0) {
+            if (strlen(resourceRel) == 0 || pathExists(pathJoin(configured, resourceRel))) {
+                return configured;
+            }
         }
     }
 
@@ -311,6 +323,9 @@ int main() {
     if (!textReady) textReady = tryInitFont(envFontPath, fontSize);
     str installRoot;
     installRoot = resolveInstallRoot("/fonts/Roboto/static/Roboto-Regular.ttf");
+    if (!textReady && length(ConfiguredFontPath) > 0 && copy(ConfiguredFontPath, 1, 1) != "@") {
+        textReady = tryInitFont(ConfiguredFontPath, fontSize);
+    }
     if (!textReady) textReady = tryInitFont(pathJoin(installRoot, "/fonts/Roboto/static/Roboto-Regular.ttf"), fontSize);
     if (!textReady) textReady = tryInitFont("/opt/pscal/fonts/Roboto/static/Roboto-Regular.ttf", fontSize);
     if (!textReady) textReady = tryInitFont("/usr/local/pscal/fonts/Roboto/static/Roboto-Regular.ttf", fontSize);

--- a/Examples/clike/sdl/spacegame
+++ b/Examples/clike/sdl/spacegame
@@ -85,6 +85,8 @@ int pathExists(str path) {
     return 0;
 }
 
+str ConfiguredInstallRoot = "@PSCAL_INSTALL_ROOT_RESOLVED@";
+
 str defaultInstallRoot() {
     str scriptPath = normalizePath(paramstr(0));
     if (strlen(scriptPath) == 0) return "";
@@ -103,6 +105,15 @@ str resolveInstallRoot(str resourceRel) {
     if (strlen(override) > 0) {
         if (strlen(resourceRel) == 0 || pathExists(pathJoin(override, resourceRel))) {
             return override;
+        }
+    }
+
+    if (length(ConfiguredInstallRoot) > 0 && copy(ConfiguredInstallRoot, 1, 1) != "@") {
+        str configured = normalizePath(ConfiguredInstallRoot);
+        if (strlen(configured) > 0) {
+            if (strlen(resourceRel) == 0 || pathExists(pathJoin(configured, resourceRel))) {
+                return configured;
+            }
         }
     }
 

--- a/Examples/pascal/base/hangman
+++ b/Examples/pascal/base/hangman
@@ -1,12 +1,55 @@
 #!/usr/bin/env pascal
 program HangmanGame;
 
-uses CRT;
+uses CRT, SysUtils;
 
 const
   MAX_WRONG = 8;  { maximum number of wrong guesses }
   MIN_LENGTH = 4; { minimum length of word }
   MAX_LENGTH = 7; { maximum length of word }
+  CONFIGURED_WORDS_PATH = '@PSCAL_INSTALL_ROOT_RESOLVED@/etc/words';
+  DEFAULT_WORDS_PATH = '/etc/words';
+  REPO_WORDS_FALLBACKS: array[0..2] of string = (
+    '../../etc/words',
+    '../etc/words',
+    'etc/words'
+  );
+
+function ResolveWordsPath: string;
+var
+  baseDir, candidate: string;
+  i: integer;
+begin
+  if Pos('PSCAL_INSTALL_ROOT', CONFIGURED_WORDS_PATH) = 0 then
+  begin
+    if FileExists(CONFIGURED_WORDS_PATH) then
+    begin
+      ResolveWordsPath := CONFIGURED_WORDS_PATH;
+      exit;
+    end;
+  end;
+
+  baseDir := ExtractFilePath(ExpandFileName(ParamStr(0)));
+  if baseDir = '' then
+    baseDir := IncludeTrailingPathDelimiter(GetCurrentDir)
+  else
+    baseDir := IncludeTrailingPathDelimiter(ExcludeTrailingPathDelimiter(baseDir));
+
+  for i := Low(REPO_WORDS_FALLBACKS) to High(REPO_WORDS_FALLBACKS) do
+  begin
+    candidate := ExpandFileName(baseDir + REPO_WORDS_FALLBACKS[i]);
+    if FileExists(candidate) then
+    begin
+      ResolveWordsPath := candidate;
+      exit;
+    end;
+  end;
+
+  if FileExists(DEFAULT_WORDS_PATH) then
+    ResolveWordsPath := DEFAULT_WORDS_PATH
+  else
+    ResolveWordsPath := CONFIGURED_WORDS_PATH;
+end;
 
 var
   chosen: string;
@@ -50,7 +93,7 @@ var
   filename: string;
   validCount, target: integer;
 begin
-  filename := '/usr/local/Pscal/etc/words';  { Adjust path as needed }
+  filename := ResolveWordsPath;  { Prefer installed prefix; fall back to repo/system locations }
   ChooseRandomWord := '';  
   assign(f, filename);
   {$I-}

--- a/Examples/pascal/base/hangman2
+++ b/Examples/pascal/base/hangman2
@@ -1,12 +1,19 @@
 #!/usr/bin/env pascal
 program HangmanGame;
 
-uses CRT;
+uses CRT, SysUtils;
 
 const
   MAX_WRONG = 8;  { maximum number of wrong guesses }
   MIN_LENGTH = 4;
   MAX_LENGTH = 7;
+  CONFIGURED_WORDS_PATH = '@PSCAL_INSTALL_ROOT_RESOLVED@/etc/words';
+  DEFAULT_WORDS_PATH = '/etc/words';
+  REPO_WORDS_FALLBACKS: array[0..2] of string = (
+    '../../etc/words',
+    '../etc/words',
+    'etc/words'
+  );
   // Constants for screen layout
   HEADER_ROW = 1;
   SUBTITLE_ROW = 2;
@@ -55,6 +62,42 @@ begin
       end;
 end;
 
+function ResolveWordsPath: string;
+var
+  baseDir, candidate: string;
+  i: integer;
+begin
+  if Pos('PSCAL_INSTALL_ROOT', CONFIGURED_WORDS_PATH) = 0 then
+  begin
+    if FileExists(CONFIGURED_WORDS_PATH) then
+    begin
+      ResolveWordsPath := CONFIGURED_WORDS_PATH;
+      exit;
+    end;
+  end;
+
+  baseDir := ExtractFilePath(ExpandFileName(ParamStr(0)));
+  if baseDir = '' then
+    baseDir := IncludeTrailingPathDelimiter(GetCurrentDir)
+  else
+    baseDir := IncludeTrailingPathDelimiter(ExcludeTrailingPathDelimiter(baseDir));
+
+  for i := Low(REPO_WORDS_FALLBACKS) to High(REPO_WORDS_FALLBACKS) do
+  begin
+    candidate := ExpandFileName(baseDir + REPO_WORDS_FALLBACKS[i]);
+    if FileExists(candidate) then
+    begin
+      ResolveWordsPath := candidate;
+      exit;
+    end;
+  end;
+
+  if FileExists(DEFAULT_WORDS_PATH) then
+    ResolveWordsPath := DEFAULT_WORDS_PATH
+  else
+    ResolveWordsPath := CONFIGURED_WORDS_PATH;
+end;
+
 function ChooseRandomWord: string;
 var
   f: Text;
@@ -63,7 +106,7 @@ var
   validCount, target: integer;
 begin
   // *** IMPORTANT: Update this path to your actual 'words' file location ***
-  filename := '/usr/local/Pscal/etc/words';  { Adjust path as needed }
+  filename := ResolveWordsPath;  { Prefer installed prefix; fall back to repo/system locations }
   ChooseRandomWord := '';
   assign(f, filename);
   {$I-} reset(f); {$I+} // Disable IO checking for reset

--- a/Examples/pascal/base/hangman3
+++ b/Examples/pascal/base/hangman3
@@ -1,12 +1,19 @@
 #!/usr/bin/env pascal
 program HangmanGame;
 
-uses CRT;
+uses CRT, SysUtils;
 
 const
   MAX_WRONG = 8;  { maximum number of wrong guesses }
   MIN_LENGTH = 4;
   MAX_LENGTH = 7;
+  CONFIGURED_WORDS_PATH = '@PSCAL_INSTALL_ROOT_RESOLVED@/etc/words';
+  DEFAULT_WORDS_PATH = '/etc/words';
+  REPO_WORDS_FALLBACKS: array[0..2] of string = (
+    '../../etc/words',
+    '../etc/words',
+    'etc/words'
+  );
   // Constants for RELATIVE screen layout (vertical offsets from topMargin)
   HEADER_ROW = 1;
   SUBTITLE_ROW = 2;
@@ -70,6 +77,42 @@ begin
       end;
 end;
 
+function ResolveWordsPath: string;
+var
+  baseDir, candidate: string;
+  i: integer;
+begin
+  if Pos('PSCAL_INSTALL_ROOT', CONFIGURED_WORDS_PATH) = 0 then
+  begin
+    if FileExists(CONFIGURED_WORDS_PATH) then
+    begin
+      ResolveWordsPath := CONFIGURED_WORDS_PATH;
+      exit;
+    end;
+  end;
+
+  baseDir := ExtractFilePath(ExpandFileName(ParamStr(0)));
+  if baseDir = '' then
+    baseDir := IncludeTrailingPathDelimiter(GetCurrentDir)
+  else
+    baseDir := IncludeTrailingPathDelimiter(ExcludeTrailingPathDelimiter(baseDir));
+
+  for i := Low(REPO_WORDS_FALLBACKS) to High(REPO_WORDS_FALLBACKS) do
+  begin
+    candidate := ExpandFileName(baseDir + REPO_WORDS_FALLBACKS[i]);
+    if FileExists(candidate) then
+    begin
+      ResolveWordsPath := candidate;
+      exit;
+    end;
+  end;
+
+  if FileExists(DEFAULT_WORDS_PATH) then
+    ResolveWordsPath := DEFAULT_WORDS_PATH
+  else
+    ResolveWordsPath := CONFIGURED_WORDS_PATH;
+end;
+
 function ChooseRandomWord: string;
 var
   f: Text;
@@ -78,7 +121,7 @@ var
   validCount, target: integer;
 begin
   // *** IMPORTANT: Update this path to your actual 'words' file location ***
-  filename := '/usr/local/Pscal/etc/words';  { Adjust path as needed }
+  filename := ResolveWordsPath;  { Prefer installed prefix; fall back to repo/system locations }
   ChooseRandomWord := '';
   assign(f, filename);
   {$I-} reset(f); {$I+} // Disable IO checking for reset

--- a/Examples/pascal/base/hangman4
+++ b/Examples/pascal/base/hangman4
@@ -1,7 +1,7 @@
 #!/usr/bin/env pascal
 program HangmanGame;
 
-uses CRT;
+uses CRT, SysUtils;
 
 const
   MAX_WRONG = 8;  { maximum number of wrong guesses }
@@ -26,6 +26,13 @@ const
   // For DrawBorder()
   CornerTL = '╔'; CornerTR = '╗'; CornerBL = '╚'; CornerBR = '╝';
   LineH = '═'; LineV = '║';
+  CONFIGURED_WORDS_PATH = '@PSCAL_INSTALL_ROOT_RESOLVED@/etc/words';
+  DEFAULT_WORDS_PATH = '/etc/words';
+  REPO_WORDS_FALLBACKS: array[0..2] of string = (
+    '../../etc/words',
+    '../etc/words',
+    'etc/words'
+  );
 
 var
   chosen: string;
@@ -79,6 +86,42 @@ begin
       end;
 end;
 
+function ResolveWordsPath: string;
+var
+  baseDir, candidate: string;
+  i: integer;
+begin
+  if Pos('PSCAL_INSTALL_ROOT', CONFIGURED_WORDS_PATH) = 0 then
+  begin
+    if FileExists(CONFIGURED_WORDS_PATH) then
+    begin
+      ResolveWordsPath := CONFIGURED_WORDS_PATH;
+      exit;
+    end;
+  end;
+
+  baseDir := ExtractFilePath(ExpandFileName(ParamStr(0)));
+  if baseDir = '' then
+    baseDir := IncludeTrailingPathDelimiter(GetCurrentDir)
+  else
+    baseDir := IncludeTrailingPathDelimiter(ExcludeTrailingPathDelimiter(baseDir));
+
+  for i := Low(REPO_WORDS_FALLBACKS) to High(REPO_WORDS_FALLBACKS) do
+  begin
+    candidate := ExpandFileName(baseDir + REPO_WORDS_FALLBACKS[i]);
+    if FileExists(candidate) then
+    begin
+      ResolveWordsPath := candidate;
+      exit;
+    end;
+  end;
+
+  if FileExists(DEFAULT_WORDS_PATH) then
+    ResolveWordsPath := DEFAULT_WORDS_PATH
+  else
+    ResolveWordsPath := CONFIGURED_WORDS_PATH;
+end;
+
 function ChooseRandomWord: string;
 var
   f: Text;
@@ -86,7 +129,7 @@ var
   filename: string;
   validCount, target: integer;
 begin
-  filename := '/usr/local/Pscal/etc/words';  { Adjust path as needed }
+  filename := ResolveWordsPath;  { Prefer installed prefix; fall back to repo/system locations }
   ChooseRandomWord := '';
   assign(f, filename);
   {$I-} reset(f); {$I+}

--- a/Examples/pascal/base/hangman5
+++ b/Examples/pascal/base/hangman5
@@ -26,7 +26,9 @@ const
   // For DrawBorder()
   CornerTL = '╔'; CornerTR = '╗'; CornerBL = '╚'; CornerBR = '╝';
   LineH = '═'; LineV = '║';
+  CONFIGURED_INSTALL_ROOT = '@PSCAL_INSTALL_ROOT_RESOLVED@';
   INSTALL_FALLBACKS: array[0..1] of string = ('/opt/pscal', '/usr/local/pscal');
+  INSTALL_FALLBACKS_COUNT = 2;
 
 type
   PWordNode = ^TWordNode;
@@ -128,13 +130,21 @@ end;
 
 function ResolveInstallRoot: string;
 var
-  override, candidate: string;
+  override, candidate, configured: string;
   i: Integer;
 begin
   override := NormalizePath(GetEnv('PSCAL_INSTALL_ROOT'));
   if (override <> '') and DirectoryExists(override) then
   begin
     ResolveInstallRoot := override;
+    exit;
+  end;
+
+  configured := NormalizePath(CONFIGURED_INSTALL_ROOT);
+  if (configured <> '') and (Pos('PSCAL_INSTALL_ROOT', CONFIGURED_INSTALL_ROOT) = 0) and
+     DirectoryExists(configured) then
+  begin
+    ResolveInstallRoot := configured;
     exit;
   end;
 
@@ -145,7 +155,7 @@ begin
     exit;
   end;
 
-  for i := Low(INSTALL_FALLBACKS) to High(INSTALL_FALLBACKS) do
+  for i := 0 to INSTALL_FALLBACKS_COUNT - 1 do
     if DirectoryExists(INSTALL_FALLBACKS[i]) then
     begin
       ResolveInstallRoot := INSTALL_FALLBACKS[i];
@@ -180,7 +190,7 @@ begin
     exit;
   end;
 
-  for i := Low(INSTALL_FALLBACKS) to High(INSTALL_FALLBACKS) do
+  for i := 0 to INSTALL_FALLBACKS_COUNT - 1 do
   begin
     candidate := JoinPaths(INSTALL_FALLBACKS[i], relativePath);
     if FileExists(candidate) or DirectoryExists(candidate) then

--- a/Examples/pascal/base/weather
+++ b/Examples/pascal/base/weather
@@ -6,6 +6,8 @@ uses CRT, SysUtils; // Assuming CRT for file ops, SysUtils for ParamStr etc.
 const
   MAX_SUBSTR_LEN = 1024;                         // Max length for copy/pos substrings
   INSTALL_FALLBACKS: array[0..1] of string = ('/opt/pscal', '/usr/local/pscal');
+  INSTALL_FALLBACKS_COUNT = 2;
+  CONFIGURED_INSTALL_ROOT = '@PSCAL_INSTALL_ROOT_RESOLVED@';
 
 type
   // mstream type assumed to be available implicitly or via SysUtils/other unit
@@ -86,13 +88,21 @@ end;
 
 function ResolveInstallRoot: string;
 var
-  override, candidate: string;
+  override, candidate, configured: string;
   i: Integer;
 begin
   override := NormalizePath(GetEnv('PSCAL_INSTALL_ROOT'));
   if (override <> '') and DirectoryExists(override) then
   begin
     ResolveInstallRoot := override;
+    exit;
+  end;
+
+  configured := NormalizePath(CONFIGURED_INSTALL_ROOT);
+  if (configured <> '') and (Pos('PSCAL_INSTALL_ROOT', CONFIGURED_INSTALL_ROOT) = 0) and
+     DirectoryExists(configured) then
+  begin
+    ResolveInstallRoot := configured;
     exit;
   end;
 
@@ -103,7 +113,7 @@ begin
     exit;
   end;
 
-  for i := Low(INSTALL_FALLBACKS) to High(INSTALL_FALLBACKS) do
+  for i := 0 to INSTALL_FALLBACKS_COUNT - 1 do
     if DirectoryExists(INSTALL_FALLBACKS[i]) then
     begin
       ResolveInstallRoot := INSTALL_FALLBACKS[i];
@@ -138,7 +148,7 @@ begin
     exit;
   end;
 
-  for i := Low(INSTALL_FALLBACKS) to High(INSTALL_FALLBACKS) do
+  for i := 0 to INSTALL_FALLBACKS_COUNT - 1 do
   begin
     candidate := JoinPaths(INSTALL_FALLBACKS[i], relativePath);
     if FileExists(candidate) or DirectoryExists(candidate) then

--- a/Examples/pascal/base/weather_json
+++ b/Examples/pascal/base/weather_json
@@ -6,6 +6,8 @@ uses CRT, SysUtils;
 const
   TEMPERATURE_DECIMAL_PLACES = 1;
   INSTALL_FALLBACKS: array[0..1] of string = ('/opt/pscal', '/usr/local/pscal');
+  INSTALL_FALLBACKS_COUNT = 2;
+  CONFIGURED_INSTALL_ROOT = '@PSCAL_INSTALL_ROOT_RESOLVED@';
 
 function NormalizePath(const path: string): string;
 var
@@ -71,13 +73,21 @@ end;
 
 function ResolveInstallRoot: string;
 var
-  override, candidate: string;
+  override, candidate, configured: string;
   i: Integer;
 begin
   override := NormalizePath(GetEnv('PSCAL_INSTALL_ROOT'));
   if (override <> '') and DirectoryExists(override) then
   begin
     ResolveInstallRoot := override;
+    exit;
+  end;
+
+  configured := NormalizePath(CONFIGURED_INSTALL_ROOT);
+  if (configured <> '') and (Pos('PSCAL_INSTALL_ROOT', CONFIGURED_INSTALL_ROOT) = 0) and
+     DirectoryExists(configured) then
+  begin
+    ResolveInstallRoot := configured;
     exit;
   end;
 
@@ -88,7 +98,7 @@ begin
     exit;
   end;
 
-  for i := Low(INSTALL_FALLBACKS) to High(INSTALL_FALLBACKS) do
+  for i := 0 to INSTALL_FALLBACKS_COUNT - 1 do
     if DirectoryExists(INSTALL_FALLBACKS[i]) then
     begin
       ResolveInstallRoot := INSTALL_FALLBACKS[i];
@@ -123,7 +133,7 @@ begin
     exit;
   end;
 
-  for i := Low(INSTALL_FALLBACKS) to High(INSTALL_FALLBACKS) do
+  for i := 0 to INSTALL_FALLBACKS_COUNT - 1 do
   begin
     candidate := JoinPaths(INSTALL_FALLBACKS[i], relativePath);
     if FileExists(candidate) or DirectoryExists(candidate) then

--- a/Examples/pascal/sdl/FireWorks
+++ b/Examples/pascal/sdl/FireWorks
@@ -1,10 +1,19 @@
 #!/usr/bin/env pascal
 program FireworksDemo;
 
+uses SysUtils;
+
 const
   MAX_PARTICLES = 400;
   GRAV = 0.15;
   PI = 3.14159;
+  ConfiguredFontPath = '@PSCAL_INSTALL_ROOT_RESOLVED@/fonts/Roboto/static/Roboto-Regular.ttf';
+  LegacyFontPath = '/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf';
+  RepoFontFallbacks: array[0..2] of string = (
+    'fonts/Roboto/static/Roboto-Regular.ttf',
+    '../fonts/Roboto/static/Roboto-Regular.ttf',
+    '../../fonts/Roboto/static/Roboto-Regular.ttf'
+  );
 
 type
   Particle = record
@@ -13,6 +22,45 @@ type
     life   : Integer;
     r, g, b: Integer;
   end;
+
+function ResolveFontPath: string;
+var
+  baseDir, candidate: string;
+  i: Integer;
+begin
+  if Pos('PSCAL_INSTALL_ROOT', ConfiguredFontPath) = 0 then
+  begin
+    if FileExists(ConfiguredFontPath) then
+    begin
+      ResolveFontPath := ConfiguredFontPath;
+      exit;
+    end;
+  end;
+
+  if FileExists(LegacyFontPath) then
+  begin
+    ResolveFontPath := LegacyFontPath;
+    exit;
+  end;
+
+  baseDir := ExtractFilePath(ExpandFileName(ParamStr(0)));
+  if baseDir = '' then
+    baseDir := IncludeTrailingPathDelimiter(GetCurrentDir)
+  else
+    baseDir := IncludeTrailingPathDelimiter(ExcludeTrailingPathDelimiter(baseDir));
+
+  for i := Low(RepoFontFallbacks) to High(RepoFontFallbacks) do
+  begin
+    candidate := ExpandFileName(baseDir + RepoFontFallbacks[i]);
+    if FileExists(candidate) then
+    begin
+      ResolveFontPath := candidate;
+      exit;
+    end;
+  end;
+
+  ResolveFontPath := ConfiguredFontPath;
+end;
 
 var
   Particles: array[0..MAX_PARTICLES-1] of Particle;
@@ -45,7 +93,7 @@ begin
   InitGraph(800, 600, 'Fireworks!');
   InitSoundSystem();
   boom := LoadSound('explosion.wav');
-  FontFileName := '/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf'; // The default font
+  FontFileName := ResolveFontPath; // Prefer installed prefix; fall back to repo/system locations
   FontSize := 24;
   InitTextSystem(FontFileName, FontSize);
 

--- a/Examples/pascal/sdl/SoundSimplePong
+++ b/Examples/pascal/sdl/SoundSimplePong
@@ -1,6 +1,8 @@
 #!/usr/bin/env pascal
 program SimplePong;
 
+uses SysUtils;
+
 { This program demonstrates basic SDL graphics,
   input handling, paddle collision, score keeping, and a score limit.
   The computer AI is now limited by a maximum paddle speed and has imperfect targeting.
@@ -13,6 +15,54 @@ program SimplePong;
 // are globally available or imported via a unit.
 // Assuming a global boolean flag (e.g., break_requested) is set by GraphLoop
 // when the window is closed or 'q' is pressed.
+
+const
+  ConfiguredFontPath = '@PSCAL_INSTALL_ROOT_RESOLVED@/fonts/Roboto/static/Roboto-Regular.ttf';
+  LegacyFontPath = '/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf';
+  RepoFontFallbacks: array[0..2] of string = (
+    'fonts/Roboto/static/Roboto-Regular.ttf',
+    '../fonts/Roboto/static/Roboto-Regular.ttf',
+    '../../fonts/Roboto/static/Roboto-Regular.ttf'
+  );
+
+function ResolveFontPath: string;
+var
+  baseDir, candidate: string;
+  i: Integer;
+begin
+  if Pos('PSCAL_INSTALL_ROOT', ConfiguredFontPath) = 0 then
+  begin
+    if FileExists(ConfiguredFontPath) then
+    begin
+      ResolveFontPath := ConfiguredFontPath;
+      exit;
+    end;
+  end;
+
+  if FileExists(LegacyFontPath) then
+  begin
+    ResolveFontPath := LegacyFontPath;
+    exit;
+  end;
+
+  baseDir := ExtractFilePath(ExpandFileName(ParamStr(0)));
+  if baseDir = '' then
+    baseDir := IncludeTrailingPathDelimiter(GetCurrentDir)
+  else
+    baseDir := IncludeTrailingPathDelimiter(ExcludeTrailingPathDelimiter(baseDir));
+
+  for i := Low(RepoFontFallbacks) to High(RepoFontFallbacks) do
+  begin
+    candidate := ExpandFileName(baseDir + RepoFontFallbacks[i]);
+    if FileExists(candidate) then
+    begin
+      ResolveFontPath := candidate;
+      exit;
+    end;
+  end;
+
+  ResolveFontPath := ConfiguredFontPath;
+end;
 
 var
   WindowWidth, WindowHeight : Integer;
@@ -82,7 +132,7 @@ begin
 
   // --- Text System Initialization ---
   // NOTE: Adjust the font file path if needed for your system
-  FontFileName := '/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf'; // The default font
+  FontFileName := ResolveFontPath; // Prefer installed prefix; fall back to repo/system locations
   FontSize := 24;
   InitTextSystem(FontFileName, FontSize);
 

--- a/Examples/pascal/sdl/mando
+++ b/Examples/pascal/sdl/mando
@@ -13,7 +13,8 @@ CONST
   ScreenUpdateInterval = 4;  // Refresh SDL window periodically to reduce event overhead
   MandelBytesPerPixel = 4;
   RepoFontPath    = 'fonts/Roboto/static/Roboto-Regular.ttf';
-  SystemFontPath  = '/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf';
+  LegacyFontPath  = '/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf';
+  ConfiguredFontPath = '@PSCAL_INSTALL_ROOT_RESOLVED@/fonts/Roboto/static/Roboto-Regular.ttf';
   DefaultFontSize = 18;
 
 TYPE
@@ -72,8 +73,10 @@ BEGIN
 
   InitGraph(WindowWidth, WindowHeight, WindowTitle);
 
-  IF FileExists(SystemFontPath) THEN
-    SelectedFontPath := SystemFontPath
+  IF (Pos('PSCAL_INSTALL_ROOT', ConfiguredFontPath) = 0) AND FileExists(ConfiguredFontPath) THEN
+    SelectedFontPath := ConfiguredFontPath
+  ELSE IF FileExists(LegacyFontPath) THEN
+    SelectedFontPath := LegacyFontPath
   ELSE IF FileExists(RepoFontPath) THEN
     SelectedFontPath := RepoFontPath;
 

--- a/Examples/pascal/sdl/mando_Linux
+++ b/Examples/pascal/sdl/mando_Linux
@@ -12,7 +12,8 @@ CONST
   MandelBytesPerPixel = 4;
 
   RepoFontPath    = 'fonts/Roboto/static/Roboto-Regular.ttf';
-  SystemFontPath  = '/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf';
+  LegacyFontPath  = '/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf';
+  ConfiguredFontPath = '@PSCAL_INSTALL_ROOT_RESOLVED@/fonts/Roboto/static/Roboto-Regular.ttf';
   DefaultFontSize = 18;
 
   // Console layout for status messages
@@ -75,8 +76,10 @@ BEGIN
   // --- Initialize SDL Graphics ---
   InitGraph(WindowWidth, WindowHeight, WindowTitle);
 
-  IF FileExists(SystemFontPath) THEN
-    SelectedFontPath := SystemFontPath
+  IF (Pos('PSCAL_INSTALL_ROOT', ConfiguredFontPath) = 0) AND FileExists(ConfiguredFontPath) THEN
+    SelectedFontPath := ConfiguredFontPath
+  ELSE IF FileExists(LegacyFontPath) THEN
+    SelectedFontPath := LegacyFontPath
   ELSE IF FileExists(RepoFontPath) THEN
     SelectedFontPath := RepoFontPath;
 

--- a/Examples/rea/base/hangman5
+++ b/Examples/rea/base/hangman5
@@ -28,6 +28,8 @@ const char CornerBR = '╝';
 const char LineH = '═';
 const char LineV = '║';
 
+str ConfiguredInstallRoot = "@PSCAL_INSTALL_ROOT_RESOLVED@";
+
 bool contains(str s, char c) {
   int i = 1;
   while (i <= length(s)) {
@@ -148,6 +150,15 @@ str resolveInstallRoot(str resourcePath) {
   if (length(override) > 0) {
     if (length(resourcePath) == 0 || pathExists(pathJoin(override, resourcePath))) {
       return override;
+    }
+  }
+
+  if (length(ConfiguredInstallRoot) > 0 && copy(ConfiguredInstallRoot, 1, 1) != '@') {
+    str configured = normalizePath(ConfiguredInstallRoot);
+    if (length(configured) > 0) {
+      if (length(resourcePath) == 0 || pathExists(pathJoin(configured, resourcePath))) {
+        return configured;
+      }
     }
   }
 

--- a/Examples/rea/base/openweather_forecast
+++ b/Examples/rea/base/openweather_forecast
@@ -205,6 +205,8 @@ bool pathExists(str path) {
   return false;
 }
 
+str ConfiguredInstallRoot = "@PSCAL_INSTALL_ROOT_RESOLVED@";
+
 str defaultInstallRoot() {
   str scriptPath = normalizePath(paramstr(0));
   if (length(scriptPath) == 0) return "";
@@ -223,6 +225,15 @@ str resolveInstallRoot(str resourceRel) {
   if (length(override) > 0) {
     if (length(resourceRel) == 0 || pathExists(pathJoin(override, resourceRel))) {
       return override;
+    }
+  }
+
+  if (length(ConfiguredInstallRoot) > 0 && copy(ConfiguredInstallRoot, 1, 1) != '@') {
+    str configured = normalizePath(ConfiguredInstallRoot);
+    if (length(configured) > 0) {
+      if (length(resourceRel) == 0 || pathExists(pathJoin(configured, resourceRel))) {
+        return configured;
+      }
     }
   }
 

--- a/Examples/rea/sdl/block_game
+++ b/Examples/rea/sdl/block_game
@@ -15,6 +15,8 @@ int FBlockColorG[FBlockCount];
 int FBlockColorB[FBlockCount];
 bool FBlockDataInitialized = false;
 
+str ConfiguredFontPath = "@PSCAL_INSTALL_ROOT_RESOLVED@/fonts/Roboto/static/Roboto-Regular.ttf";
+
 void initializeFBlockData() {
     if (FBlockDataInitialized) {
         return;
@@ -511,11 +513,13 @@ class Game {
     
     void run() {
         initgraph(WindowWidth, WindowHeight, "Rea Block Game");
-        str systemFontPath = "/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf";
+        str legacyFontPath = "/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf";
         str repoFontPath1 = "fonts/Roboto/static/Roboto-Regular.ttf";
         str repoFontPath2 = "../../fonts/Roboto/static/Roboto-Regular.ttf";
-        if (fileexists(systemFontPath)) {
-            inittextsystem(systemFontPath, 18);
+        if (length(ConfiguredFontPath) > 0 && ConfiguredFontPath[1] != '@' && fileexists(ConfiguredFontPath)) {
+            inittextsystem(ConfiguredFontPath, 18);
+        } else if (fileexists(legacyFontPath)) {
+            inittextsystem(legacyFontPath, 18);
         } else if (fileexists(repoFontPath1)) {
             inittextsystem(repoFontPath1, 18);
         } else {

--- a/Examples/rea/sdl/mandelbrot_interactive
+++ b/Examples/rea/sdl/mandelbrot_interactive
@@ -50,11 +50,14 @@ class MandelbrotApp {
     double aspect = double(myself.Height) / double(myself.Width);
     myself.maxIm = myself.minIm + widthSpan * aspect;
     initgraph(myself.Width, myself.Height, "Rea Mandelbrot");
-    string systemFontPath = "/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf";
+    string configuredFontPath = "@PSCAL_INSTALL_ROOT_RESOLVED@/fonts/Roboto/static/Roboto-Regular.ttf";
+    string legacyFontPath = "/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf";
     string repoFontPath1 = "fonts/Roboto/static/Roboto-Regular.ttf";
     string repoFontPath2 = "../../fonts/Roboto/static/Roboto-Regular.ttf";
-    if (fileexists(systemFontPath)) {
-      inittextsystem(systemFontPath, 18);
+    if (length(configuredFontPath) > 0 && configuredFontPath[1] != '@' && fileexists(configuredFontPath)) {
+      inittextsystem(configuredFontPath, 18);
+    } else if (fileexists(legacyFontPath)) {
+      inittextsystem(legacyFontPath, 18);
     } else if (fileexists(repoFontPath1)) {
       inittextsystem(repoFontPath1, 18);
     } else {

--- a/Examples/rea/sdl/mandelbrot_interactive_ext
+++ b/Examples/rea/sdl/mandelbrot_interactive_ext
@@ -48,11 +48,14 @@ class MandelbrotApp {
     double aspect = double(myself.Height) / double(myself.Width);
     myself.maxIm = myself.minIm + widthSpan * aspect;
     initgraph(myself.Width, myself.Height, "Rea Mandelbrot (ext)");
-    string systemFontPath = "/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf";
+    string configuredFontPath = "@PSCAL_INSTALL_ROOT_RESOLVED@/fonts/Roboto/static/Roboto-Regular.ttf";
+    string legacyFontPath = "/usr/local/Pscal/fonts/Roboto/static/Roboto-Regular.ttf";
     string repoFontPath1 = "fonts/Roboto/static/Roboto-Regular.ttf";
     string repoFontPath2 = "../../fonts/Roboto/static/Roboto-Regular.ttf";
-    if (fileexists(systemFontPath)) {
-      inittextsystem(systemFontPath, 18);
+    if (length(configuredFontPath) > 0 && configuredFontPath[1] != '@' && fileexists(configuredFontPath)) {
+      inittextsystem(configuredFontPath, 18);
+    } else if (fileexists(legacyFontPath)) {
+      inittextsystem(legacyFontPath, 18);
     } else if (fileexists(repoFontPath1)) {
       inittextsystem(repoFontPath1, 18);
     } else {

--- a/Examples/rea/sdl/planets
+++ b/Examples/rea/sdl/planets
@@ -9,6 +9,8 @@ bool quit = false;
 int posMutex = mutex();
 float earthMonths = 0.0;
 
+str ConfiguredInstallRoot = "@PSCAL_INSTALL_ROOT_RESOLVED@";
+
 str trimTrailingSlashes(str path) {
   int len = length(path);
   while (len > 1 && path[len] == '/') {
@@ -103,6 +105,15 @@ str resolveInstallRoot(str resourceRel) {
   if (length(override) > 0) {
     if (length(resourceRel) == 0 || pathExists(pathJoin(override, resourceRel))) {
       return override;
+    }
+  }
+
+  if (length(ConfiguredInstallRoot) > 0 && copy(ConfiguredInstallRoot, 1, 1) != '@') {
+    str configured = normalizePath(ConfiguredInstallRoot);
+    if (length(configured) > 0) {
+      if (length(resourceRel) == 0 || pathExists(pathJoin(configured, resourceRel))) {
+        return configured;
+      }
     }
   }
 

--- a/Examples/rea/sdl/planets_earth
+++ b/Examples/rea/sdl/planets_earth
@@ -10,6 +10,8 @@ bool quit = false;
 int posMutex = mutex();
 float earthMonths = 0.0;
 
+str ConfiguredInstallRoot = "@PSCAL_INSTALL_ROOT_RESOLVED@";
+
 str trimTrailingSlashes(str path) {
   int len = length(path);
   while (len > 1 && path[len] == '/') {
@@ -104,6 +106,15 @@ str resolveInstallRoot(str resourceRel) {
   if (length(override) > 0) {
     if (length(resourceRel) == 0 || pathExists(pathJoin(override, resourceRel))) {
       return override;
+    }
+  }
+
+  if (length(ConfiguredInstallRoot) > 0 && copy(ConfiguredInstallRoot, 1, 1) != '@') {
+    str configured = normalizePath(ConfiguredInstallRoot);
+    if (length(configured) > 0) {
+      if (length(resourceRel) == 0 || pathExists(pathJoin(configured, resourceRel))) {
+        return configured;
+      }
     }
   }
 

--- a/Examples/rea/sdl/planets_inner
+++ b/Examples/rea/sdl/planets_inner
@@ -10,6 +10,8 @@ bool quit = false;
 int posMutex = mutex();
 float earthMonths = 0.0;
 
+str ConfiguredInstallRoot = "@PSCAL_INSTALL_ROOT_RESOLVED@";
+
 str trimTrailingSlashes(str path) {
   int len = length(path);
   while (len > 1 && path[len] == '/') {
@@ -104,6 +106,15 @@ str resolveInstallRoot(str resourceRel) {
   if (length(override) > 0) {
     if (length(resourceRel) == 0 || pathExists(pathJoin(override, resourceRel))) {
       return override;
+    }
+  }
+
+  if (length(ConfiguredInstallRoot) > 0 && copy(ConfiguredInstallRoot, 1, 1) != '@') {
+    str configured = normalizePath(ConfiguredInstallRoot);
+    if (length(configured) > 0) {
+      if (length(resourceRel) == 0 || pathExists(pathJoin(configured, resourceRel))) {
+        return configured;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- generate install-time copies of examples that require bundled assets so they embed the resolved CMake install prefix
- update Pascal, CLike, and Rea examples to prefer the configured install root for dictionary and font lookups while retaining repository fallbacks
- extend SDL examples with helper routines that locate installed fonts before falling back to legacy or relative paths

## Testing
- not run (environment lacks the Pascal/SDL runtimes for these demos)


------
https://chatgpt.com/codex/tasks/task_b_68e9de5383f08329b93399b449cf0b13