### PR TITLE
Fix configured example install destinations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -880,7 +880,8 @@ install(DIRECTORY Examples/
         DESTINATION "${_pscal_runtime_root}/Examples"
         USE_SOURCE_PERMISSIONS)
 foreach(example IN LISTS PSCAL_CONFIGURED_EXAMPLES)
-    get_filename_component(example_dir "${example}" DIRECTORY)
+    string(REGEX REPLACE "^Examples/" "" example_relative "${example}")
+    get_filename_component(example_dir "${example_relative}" DIRECTORY)
     install(FILES "${PSCAL_CONFIGURED_EXAMPLES_DIR}/${example}"
             DESTINATION "${_pscal_runtime_root}/Examples/${example_dir}"
             PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE


### PR DESCRIPTION
## Summary
- ensure configured example files install into the correct Examples directory
- avoid creating nested Examples/Examples paths so substituted assets overwrite originals

## Testing
- cmake -S . -B build

------
https://chatgpt.com/codex/tasks/task_b_68ea47a6a3b4832997016694f6efdef4