### PR TITLE
Add Bash-compatible caller builtin and call stack tracking

### DIFF
--- a/Docs/exsh_bash_builtin_coverage.txt
+++ b/Docs/exsh_bash_builtin_coverage.txt
@@ -7,11 +7,11 @@ Bash builtins reported by `help`
 
 Builtins currently implemented in exsh
 --------------------------------------
-cd pwd dirs pushd popd echo exit exec true false set unset export read printf test [ shift alias unalias history setenv unsetenv declare jobs disown kill fg bg wait builtin source . trap local let break continue : eval return logout finger help bind shopt command type getopts mapfile readarray
+cd pwd dirs pushd popd echo exit exec true false set unset export read printf test [ shift alias unalias history setenv unsetenv declare jobs disown kill fg bg wait builtin source . trap local let break continue : eval return logout finger help bind shopt command caller type getopts mapfile readarray
 
 Bash builtins missing from exsh
 -------------------------------
-caller compgen complete compopt enable fc hash suspend ulimit
+compgen complete compopt enable fc hash suspend ulimit
 
 Plans to address missing builtins
 ---------------------------------
@@ -47,10 +47,10 @@ Plans to address missing builtins
    - Implement vmBuiltinShellFc beside vmBuiltinShellHistory, re running edited commands and updating history and status accordingly.
    - Register fc in the builtin tables and create parity tests that edit commands and verify output with Bash.
 
-7) caller builtin:
-   - Track function invocations by pushing frames that contain name and source location when shellInvokeFunction runs and pop them afterwards.
-   - Implement vmBuiltinShellCaller to read the stack, honour optional depth arguments, and print frames in Bash compatible format.
-   - Register the builtin, document it, and add regression scripts that call caller within nested functions for parity with Bash.
+7) caller builtin: Completed.
+   - Tracks function invocations by pushing frames that contain the name and source location when shellInvokeFunction runs and pops them afterwards.
+   - Implements vmBuiltinShellCaller to read the stack, honour optional depth arguments, and print frames in a Bash compatible format.
+   - Registered the builtin, documented it, and added regression parity coverage that exercises caller within nested functions alongside Bash.
 
 8) let arithmetic builtin: Completed.
    - Added vmBuiltinShellLet which evaluates each argument with shellEvaluateArithmetic, applying assignments via shellSetTrackedVariable and compound operators for +=, -=, *=, /=, and %= while tracking arithmetic errors.

--- a/Tests/exsh/tests/bash_parity_caller.psh
+++ b/Tests/exsh/tests/bash_parity_caller.psh
@@ -1,0 +1,20 @@
+#!/usr/bin/env exsh
+
+foo() {
+    caller
+    caller 1
+    caller 2
+    caller 3
+    printf 'caller_depth3_status:%s\n' "$?"
+}
+
+bar() {
+    foo
+}
+
+baz() {
+    bar
+}
+
+baz
+printf 'caller_status:%s\n' "$?"

--- a/Tests/exsh/tests/manifest.json
+++ b/Tests/exsh/tests/manifest.json
@@ -487,6 +487,14 @@
             "expected_stdout": "count:3\nvalues:alpha,beta,gamma\nafter-shift:2\nremaining:beta,gamma\n"
         },
         {
+            "id": "bash_parity_caller",
+            "name": "caller mirrors Bash call stack output",
+            "category": "builtins",
+            "description": "caller reports call frames with optional depth in parity with Bash.",
+            "script": "Tests/exsh/tests/bash_parity_caller.psh",
+            "expect": "match_bash"
+        },
+        {
             "id": "bash_parity_export_pipeline",
             "name": "export works in pipelines",
             "category": "parity",

--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -155,6 +155,7 @@ Value vmBuiltinShellBreak(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellContinue(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellAlias(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellUnalias(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinShellCaller(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellHistory(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellJobs(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellDisown(struct VM_s* vm, int arg_count, Value* args);

--- a/src/backend_ast/shell/shell_builtins.inc
+++ b/src/backend_ast/shell/shell_builtins.inc
@@ -6480,6 +6480,16 @@ static const ShellHelpTopic kShellHelpTopics[] = {
         0
     },
     {
+        "caller",
+        "Report information about active call frames.",
+        "caller [depth]",
+        "Prints the line number and caller context for the current function by "
+        "default. Providing DEPTH selects a deeper stack frame, mirroring Bash's "
+        "caller builtin output.",
+        NULL,
+        0
+    },
+    {
         "history",
         "Print the interactive history list.",
         "history",
@@ -6925,6 +6935,69 @@ Value vmBuiltinShellUnalias(VM *vm, int arg_count, Value *args) {
     }
 
     shellUpdateStatus(ok ? 0 : 1);
+    return makeVoid();
+}
+
+Value vmBuiltinShellCaller(VM *vm, int arg_count, Value *args) {
+    long depth = 0;
+    if (arg_count > 1) {
+        runtimeError(vm, "caller: too many arguments");
+        shellUpdateStatus(2);
+        return makeVoid();
+    }
+    if (arg_count == 1) {
+        if (args[0].type != TYPE_STRING || !args[0].s_val) {
+            runtimeError(vm, "caller: expected numeric depth");
+            shellUpdateStatus(2);
+            return makeVoid();
+        }
+        char *end = NULL;
+        depth = strtol(args[0].s_val, &end, 10);
+        if (!end || *end != '\0') {
+            runtimeError(vm, "caller: %s: numeric argument required", args[0].s_val);
+            shellUpdateStatus(2);
+            return makeVoid();
+        }
+        if (depth < 0) {
+            runtimeError(vm, "caller: negative depth not allowed");
+            shellUpdateStatus(2);
+            return makeVoid();
+        }
+    }
+
+    size_t stack_depth = shellRuntimeCallStackDepth();
+    if (stack_depth == 0 || (size_t)depth >= stack_depth) {
+        shellUpdateStatus(1);
+        return makeVoid();
+    }
+
+    const ShellCallFrame *frame = shellRuntimeCallFrameAtDepth((size_t)depth);
+    if (!frame) {
+        shellUpdateStatus(1);
+        return makeVoid();
+    }
+
+    int line = frame->line >= 0 ? frame->line : 0;
+    const char *function = (frame->caller_function && *frame->caller_function)
+                               ? frame->caller_function
+                               : "NULL";
+    const char *source = (frame->source && *frame->source) ? frame->source : NULL;
+
+    if (depth == 0) {
+        if (source) {
+            printf("%d %s\n", line, source);
+        } else {
+            printf("%d %s\n", line, function);
+        }
+    } else {
+        if (source) {
+            printf("%d %s %s\n", line, function, source);
+        } else {
+            printf("%d %s\n", line, function);
+        }
+    }
+
+    shellUpdateStatus(0);
     return makeVoid();
 }
 

--- a/src/backend_ast/shell/shell_runtime_state.inc
+++ b/src/backend_ast/shell/shell_runtime_state.inc
@@ -95,6 +95,40 @@ typedef struct {
     char *detail;
 } ShellCommandResult;
 
+typedef struct {
+    char **entries;
+    size_t count;
+    size_t capacity;
+} ShellHistory;
+
+static ShellHistory gShellHistory = {NULL, 0, 0};
+static char *gShellArg0 = NULL;
+
+typedef struct {
+    char *function;
+    char *caller_function;
+    char *source;
+    int line;
+    int column;
+} ShellCallFrame;
+
+static ShellCallFrame *gShellCallStack = NULL;
+static size_t gShellCallStackCount = 0;
+static size_t gShellCallStackCapacity = 0;
+
+static char **gShellSourceStack = NULL;
+static size_t gShellSourceDepth = 0;
+static size_t gShellSourceCapacity = 0;
+
+typedef struct {
+    char *name;
+    char *parameter_metadata;
+    ShellCompiledFunction *compiled;
+} ShellFunctionEntry;
+
+static ShellFunctionEntry *gShellFunctions = NULL;
+static size_t gShellFunctionCount = 0;
+
 static int shellParseEnvBool(const char *value) {
     if (!value) {
         return -1;
@@ -114,6 +148,186 @@ static int shellParseEnvBool(const char *value) {
         return 0;
     }
     return -1;
+}
+
+static void shellRuntimeFreeCallFrame(ShellCallFrame *frame) {
+    if (!frame) {
+        return;
+    }
+    free(frame->function);
+    free(frame->caller_function);
+    free(frame->source);
+    frame->function = NULL;
+    frame->caller_function = NULL;
+    frame->source = NULL;
+    frame->line = 0;
+    frame->column = 0;
+}
+
+static bool shellRuntimeEnsureCallStackCapacity(size_t needed) {
+    if (gShellCallStackCapacity >= needed) {
+        return true;
+    }
+    size_t new_capacity = gShellCallStackCapacity ? (gShellCallStackCapacity * 2) : 4;
+    while (new_capacity < needed) {
+        new_capacity *= 2;
+    }
+    ShellCallFrame *resized = (ShellCallFrame *)realloc(gShellCallStack,
+                                                        new_capacity * sizeof(ShellCallFrame));
+    if (!resized) {
+        return false;
+    }
+    for (size_t i = gShellCallStackCapacity; i < new_capacity; ++i) {
+        resized[i].function = NULL;
+        resized[i].caller_function = NULL;
+        resized[i].source = NULL;
+        resized[i].line = 0;
+        resized[i].column = 0;
+    }
+    gShellCallStack = resized;
+    gShellCallStackCapacity = new_capacity;
+    return true;
+}
+
+static bool shellRuntimeEnsureSourceCapacity(size_t needed) {
+    if (gShellSourceCapacity >= needed) {
+        return true;
+    }
+    size_t new_capacity = gShellSourceCapacity ? (gShellSourceCapacity * 2) : 4;
+    while (new_capacity < needed) {
+        new_capacity *= 2;
+    }
+    char **resized = (char **)realloc(gShellSourceStack, new_capacity * sizeof(char *));
+    if (!resized) {
+        return false;
+    }
+    for (size_t i = gShellSourceCapacity; i < new_capacity; ++i) {
+        resized[i] = NULL;
+    }
+    gShellSourceStack = resized;
+    gShellSourceCapacity = new_capacity;
+    return true;
+}
+
+static bool shellRuntimePushSourcePath(const char *path) {
+    const char *label = (path && *path) ? path : "";
+    if (!shellRuntimeEnsureSourceCapacity(gShellSourceDepth + 1)) {
+        return false;
+    }
+    char *copy = strdup(label);
+    if (!copy) {
+        return false;
+    }
+    gShellSourceStack[gShellSourceDepth++] = copy;
+    return true;
+}
+
+static void shellRuntimePopSourcePath(void) {
+    if (gShellSourceDepth == 0) {
+        return;
+    }
+    size_t index = gShellSourceDepth - 1;
+    free(gShellSourceStack[index]);
+    gShellSourceStack[index] = NULL;
+    gShellSourceDepth--;
+    if (gShellSourceDepth == 0 && gShellSourceStack) {
+        free(gShellSourceStack);
+        gShellSourceStack = NULL;
+        gShellSourceCapacity = 0;
+    }
+}
+
+static const char *shellRuntimeCurrentSourcePath(void) {
+    if (gShellSourceDepth == 0) {
+        return NULL;
+    }
+    return gShellSourceStack[gShellSourceDepth - 1];
+}
+
+bool shellRuntimeTrackSourcePush(const char *path) {
+    return shellRuntimePushSourcePath(path);
+}
+
+void shellRuntimeTrackSourcePop(void) {
+    shellRuntimePopSourcePath();
+}
+
+static bool shellRuntimePushCallFrame(const char *function_name,
+                                      int call_line,
+                                      int call_column) {
+    if (!shellRuntimeEnsureCallStackCapacity(gShellCallStackCount + 1)) {
+        return false;
+    }
+    ShellCallFrame *frame = &gShellCallStack[gShellCallStackCount];
+    frame->function = NULL;
+    frame->caller_function = NULL;
+    frame->source = NULL;
+    frame->line = (call_line >= 0) ? call_line : 0;
+    frame->column = (call_column >= 0) ? call_column : 0;
+
+    if (function_name && *function_name) {
+        frame->function = strdup(function_name);
+        if (!frame->function) {
+            return false;
+        }
+    }
+
+    const ShellCallFrame *previous =
+        (gShellCallStackCount > 0) ? &gShellCallStack[gShellCallStackCount - 1] : NULL;
+    const char *caller_name = NULL;
+    if (previous && previous->function && *previous->function) {
+        caller_name = previous->function;
+    } else if (!previous) {
+        caller_name = "main";
+    }
+    if (caller_name) {
+        frame->caller_function = strdup(caller_name);
+        if (!frame->caller_function) {
+            free(frame->function);
+            frame->function = NULL;
+            return false;
+        }
+    }
+
+    const char *source = shellRuntimeCurrentSourcePath();
+    if (source && *source) {
+        frame->source = strdup(source);
+        if (!frame->source) {
+            free(frame->function);
+            free(frame->caller_function);
+            frame->function = NULL;
+            frame->caller_function = NULL;
+            return false;
+        }
+    }
+
+    gShellCallStackCount++;
+    return true;
+}
+
+static void shellRuntimePopCallFrame(void) {
+    if (gShellCallStackCount == 0) {
+        return;
+    }
+    ShellCallFrame *frame = &gShellCallStack[gShellCallStackCount - 1];
+    shellRuntimeFreeCallFrame(frame);
+    gShellCallStackCount--;
+    if (gShellCallStackCount == 0 && gShellCallStack) {
+        free(gShellCallStack);
+        gShellCallStack = NULL;
+        gShellCallStackCapacity = 0;
+    }
+}
+
+static size_t shellRuntimeCallStackDepth(void) {
+    return gShellCallStackCount;
+}
+
+static const ShellCallFrame *shellRuntimeCallFrameAtDepth(size_t depth) {
+    if (depth >= gShellCallStackCount) {
+        return NULL;
+    }
+    return &gShellCallStack[gShellCallStackCount - 1 - depth];
 }
 
 static const char *shellResolveBashPath(void) {
@@ -2889,24 +3103,6 @@ typedef struct {
 
 static ShellJob *gShellJobs = NULL;
 static size_t gShellJobCount = 0;
-
-typedef struct {
-    char **entries;
-    size_t count;
-    size_t capacity;
-} ShellHistory;
-
-static ShellHistory gShellHistory = {NULL, 0, 0};
-static char *gShellArg0 = NULL;
-
-typedef struct {
-    char *name;
-    char *parameter_metadata;
-    ShellCompiledFunction *compiled;
-} ShellFunctionEntry;
-
-static ShellFunctionEntry *gShellFunctions = NULL;
-static size_t gShellFunctionCount = 0;
 
 typedef enum {
     SHELL_META_SUBSTITUTION_DOLLAR,

--- a/src/backend_ast/shell/shell_word_expansion.inc
+++ b/src/backend_ast/shell/shell_word_expansion.inc
@@ -2266,7 +2266,7 @@ static bool shellIsRuntimeBuiltin(const char *name) {
         "cd",      "pwd",    "dirs",   "pushd",  "popd",   "exit",    "logout",  "exec",
         "eval",    "export", "unset",  "setenv", "unsetenv","set",    "declare", "typeset",
         "readonly","umask",  "command","hash",   "trap",   "local",   "let",     "break",
-        "continue","alias", "bind",   "shopt",  "history","jobs",   "disown",  "kill",
+        "continue","alias", "caller", "bind",   "shopt",  "history","jobs",   "disown",  "kill",
         "fg",     "finger", "bg",     "wait",   "builtin","source", "read",   "printf",
         "shift",  "return", "help",   "type",   "test",   "[",      ":",      "unalias",
         "getopts",
@@ -2353,6 +2353,8 @@ static bool shellInvokeFunction(VM *vm, ShellCommand *cmd) {
     VM *invoke_vm = NULL;
     VM nested_vm;
     bool using_cached_vm = false;
+    bool nested_vm_initialized = false;
+    bool frame_pushed = false;
     if (!function_vm_in_use) {
         if (!function_vm_initialized) {
             initVM(&function_vm);
@@ -2366,7 +2368,15 @@ static bool shellInvokeFunction(VM *vm, ShellCommand *cmd) {
     } else {
         initVM(&nested_vm);
         invoke_vm = &nested_vm;
+        nested_vm_initialized = true;
     }
+
+    if (!shellRuntimePushCallFrame(name, cmd->line, cmd->column)) {
+        runtimeError(vm, "%s: out of memory", name);
+        shellUpdateStatus(1);
+        goto invoke_cleanup;
+    }
+    frame_pushed = true;
 
     InterpretResult result = interpretBytecode(invoke_vm, &entry->compiled->chunk,
                                                globalSymbols, constGlobalSymbols, procedure_table, 0);
@@ -2375,11 +2385,16 @@ static bool shellInvokeFunction(VM *vm, ShellCommand *cmd) {
     } else {
         shellUpdateStatus(shellRuntimeLastStatus());
     }
+
+invoke_cleanup:
     if (using_cached_vm) {
         vmResetExecutionState(&function_vm);
         function_vm_in_use = false;
-    } else {
+    } else if (nested_vm_initialized) {
         freeVM(&nested_vm);
+    }
+    if (frame_pushed) {
+        shellRuntimePopCallFrame();
     }
     if (scope_pushed) {
         shellLocalScopePop();

--- a/src/ext_builtins/shell_frontend.c
+++ b/src/ext_builtins/shell_frontend.c
@@ -68,6 +68,7 @@ void registerShellFrontendBuiltins(void) {
     registerShellBuiltin(category, command_group, "continue", vmBuiltinShellContinue);
     registerShellBuiltin(category, command_group, "alias", vmBuiltinShellAlias);
     registerShellBuiltin(category, command_group, "unalias", vmBuiltinShellUnalias);
+    registerShellBuiltin(category, command_group, "caller", vmBuiltinShellCaller);
     registerShellBuiltin(category, command_group, "history", vmBuiltinShellHistory);
     registerShellBuiltin(category, command_group, "jobs", vmBuiltinShellJobs);
     registerShellBuiltin(category, command_group, "disown", vmBuiltinShellDisown);

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -28,6 +28,7 @@ static const ShellBuiltinEntry kShellBuiltins[] = {
     {"shift", "shift", 12},
     {"alias", "alias", 13},
     {"unalias", "unalias", 38},
+    {"caller", "caller", 52},
     {"history", "history", 14},
     {"setenv", "setenv", 15},
     {"unsetenv", "unsetenv", 16},

--- a/src/shell/runner.h
+++ b/src/shell/runner.h
@@ -38,6 +38,9 @@ bool shellSymbolTableScopePush(ShellSymbolTableScope *scope);
 void shellSymbolTableScopePop(ShellSymbolTableScope *scope);
 bool shellSymbolTableScopeIsActive(void);
 
+bool shellRuntimeTrackSourcePush(const char *path);
+void shellRuntimeTrackSourcePop(void);
+
 char *shellLoadFile(const char *path);
 int shellRunSource(const char *source,
                    const char *path,


### PR DESCRIPTION
## Summary
- track shell script source paths and call frames so runtime state can report caller context
- implement the Bash-compatible `caller` builtin, register it across the frontend/runtime, and document coverage
- add a Bash parity test that exercises nested caller invocations

## Testing
- `cmake --build build --target exsh`
- `Tests/run_exsh_tests.sh`


------
https://chatgpt.com/codex/tasks/task_b_68ea6d8a712883299816ee9cb4f4ff5d