### PR TITLE
Enhance Blackjack example with CRT scoreboard

### DIFF
--- a/Examples/pascal/base/BlackJack
+++ b/Examples/pascal/base/BlackJack
@@ -10,6 +10,7 @@ label
 
 type
   THand = array of Integer; // Stores card ranks (2-14: 11=Jack, 12=Queen, 13=King, 14=Ace)
+  TRoundOutcome = (roNone, roPlayerWin, roDealerWin, roPush);
 
 // Converts card rank (2-14) to user-friendly name
 function GetCardName(rank: Integer): String;
@@ -78,17 +79,91 @@ begin
   Result := Random(13) + 2; // 0-12 → 2-14
 end;
 
+procedure DrawFrame;
+begin
+  TextBackground(Black);
+  ClrScr;
+  TextColor(White);
+  GotoXY(1, 1);
+  Write('==================== BLACKJACK ====================');
+  TextColor(LightGray);
+  GotoXY(1, 2);
+  Write('Round:');
+  GotoXY(1, 3);
+  Write('Player Wins:');
+  GotoXY(1, 4);
+  Write('Dealer Wins:');
+  GotoXY(1, 5);
+  Write('Pushes:');
+  TextColor(Yellow);
+  GotoXY(1, 6);
+  Write('---------------------------------------------------');
+  TextColor(White);
+  GotoXY(1, 7);
+end;
+
+procedure UpdateScoreboard(roundNumber, playerWins, dealerWins, pushes: Integer);
+begin
+  TextColor(LightCyan);
+  GotoXY(9, 2);
+  ClrEol;
+  Write(' ', roundNumber:3);
+  TextColor(LightGreen);
+  GotoXY(14, 3);
+  ClrEol;
+  Write(' ', playerWins:3);
+  TextColor(LightRed);
+  GotoXY(14, 4);
+  ClrEol;
+  Write(' ', dealerWins:3);
+  TextColor(Yellow);
+  GotoXY(10, 5);
+  ClrEol;
+  Write(' ', pushes:3);
+  TextColor(White);
+  GotoXY(1, 7);
+end;
+
+procedure PauseForEffect;
+begin
+  Delay(250);
+end;
+
+procedure ClearMainArea;
+var
+  row: Integer;
+begin
+  for row := 7 to 25 do
+  begin
+    GotoXY(1, row);
+    ClrEol;
+  end;
+  GotoXY(1, 7);
+end;
+
 var
   humanHand, dealerHand: THand;
   input: String; // Fixed: Use String for input (avoids buffer leaks)
   playAgain: String;
   humanVal, dealerVal: Integer;
   hasBlackjack: Boolean;
+  playerWins, dealerWins, pushes: Integer;
+  roundNumber: Integer;
+  roundOutcome: TRoundOutcome;
 
 begin
   Randomize; // Seed random number generator (critical for fairness)
+  playerWins := 0;
+  dealerWins := 0;
+  pushes := 0;
+  roundNumber := 0;
 
   repeat
+    DrawFrame;
+    Inc(roundNumber);
+    roundOutcome := roNone;
+    UpdateScoreboard(roundNumber, playerWins, dealerWins, pushes);
+    ClearMainArea;
     // Reset hands for new game by reinitialising to two cards immediately.
     SetLength(humanHand, 2);
     humanHand[0] := DealCard;
@@ -105,23 +180,39 @@ begin
 
     if hasBlackjack then
     begin
+      GotoXY(1, WhereY);
       DisplayHand(humanHand, False, True);
       DisplayHand(dealerHand, True, True);
 
       if (humanVal = 21) and (dealerVal = 21) then
-        Writeln('Push! Both have Blackjack.')
+      begin
+        TextColor(Yellow);
+        Writeln('Push! Both have Blackjack.');
+        TextColor(White);
+        roundOutcome := roPush;
+      end
       else if humanVal = 21 then
-        Writeln('YOU WIN with Blackjack!')
+      begin
+        TextColor(LightGreen);
+        Writeln('YOU WIN with Blackjack!');
+        TextColor(White);
+        roundOutcome := roPlayerWin;
+      end
       else
+      begin
+        TextColor(LightRed);
         Writeln('Dealer wins with Blackjack.');
+        TextColor(White);
+        roundOutcome := roDealerWin;
+      end;
 
       goto EndGame; // Skip to play-again prompt
     end;
 
     // ===== NORMAL GAME FLOW =====
-      ClrScr;
-      Writeln;
-      Writeln('===== Initial Deal =====');
+    GotoXY(1, 7);
+    ClrEol;
+    Writeln('===== Initial Deal =====');
     DisplayHand(humanHand, False, True); // Show your full hand
     DisplayHand(dealerHand, True, False); // Show dealer's up card only
 
@@ -145,14 +236,20 @@ begin
           humanHand[High(humanHand)] := DealCard;
 
           // Show new hand and check for bust
-            Writeln;
-            Writeln('You hit:');
+          Writeln;
+          TextColor(LightCyan);
+          Writeln('You hit:');
+          TextColor(White);
+          PauseForEffect;
           DisplayHand(humanHand, False, True);
           humanVal := CalculateHandValue(humanHand);
 
           if humanVal > 21 then
           begin
+            TextColor(LightRed);
             Writeln('YOU BUST! Dealer wins.');
+            TextColor(White);
+            roundOutcome := roDealerWin;
             goto EndGame;
           end;
         end;
@@ -164,19 +261,25 @@ begin
 
     // ===== DEALER'S TURN: Play by rules (hit until ≥17) =====
     Writeln;
+    TextColor(LightMagenta);
     Writeln('===== Dealer is Playing =====');
+    TextColor(White);
     while CalculateHandValue(dealerHand) < 17 do
     begin
       // Deal another card to dealer
       SetLength(dealerHand, Length(dealerHand) + 1);
       dealerHand[High(dealerHand)] := DealCard;
+      PauseForEffect;
       DisplayHand(dealerHand, True, True); // Show hand after each hit
     end;
 
     dealerVal := CalculateHandValue(dealerHand);
     if dealerVal > 21 then
     begin
+      TextColor(LightGreen);
       Writeln('Dealer busts! YOU WIN.');
+      TextColor(White);
+      roundOutcome := roPlayerWin;
       goto EndGame;
     end;
 
@@ -187,13 +290,35 @@ begin
     DisplayHand(dealerHand, True, True);
 
     if humanVal > dealerVal then
-      Writeln('YOU WIN!')
+    begin
+      TextColor(LightGreen);
+      Writeln('YOU WIN!');
+      TextColor(White);
+      roundOutcome := roPlayerWin;
+    end
     else if humanVal < dealerVal then
-      Writeln('Dealer wins.')
+    begin
+      TextColor(LightRed);
+      Writeln('Dealer wins.');
+      TextColor(White);
+      roundOutcome := roDealerWin;
+    end
     else
+    begin
+      TextColor(Yellow);
       Writeln('Push! It''s a tie.');
+      TextColor(White);
+      roundOutcome := roPush;
+    end;
 
 EndGame:
+    case roundOutcome of
+      roPlayerWin: Inc(playerWins);
+      roDealerWin: Inc(dealerWins);
+      roPush:      Inc(pushes);
+    end;
+    UpdateScoreboard(roundNumber, playerWins, dealerWins, pushes);
+
     // Ask to play again (fixed: no buffer leaks now)
     Writeln;
     Write('Play again? (y/n): ');


### PR DESCRIPTION
## Summary
- add a CRT-driven frame and scoreboard to the Blackjack example with persistent round tracking
- use color, cursor positioning, and delays to provide clearer feedback during player and dealer turns
- highlight round outcomes and blackjack/bust conditions while updating cumulative player, dealer, and push totals

## Testing
- not run (example code)


------
https://chatgpt.com/codex/tasks/task_b_68eff4ceb35c8329b982116745a8cf22