### PR TITLE
Fix redirection backup collisions in exsh

### DIFF
--- a/Docs/exsh_debug_log.md
+++ b/Docs/exsh_debug_log.md
@@ -1,0 +1,27 @@
+# exsh Debug Log
+
+This document records troubleshooting steps and findings while investigating the shellbench regressions for the exsh front end.
+
+## Session 2025-10-16
+- Initialized log document for ongoing troubleshooting.
+- Plan: configure and build exsh via CMake to enable manual reproduction of shellbench scenarios.
+- Ran `cmake -S . -B build` (SDL auto-disabled) to generate build system.
+- Built `exsh` via `cmake --build build --target exsh`.
+- Reviewed shellbench `sample/assign.sh` via GitHub to understand `@begin/@end` instrumentation macros.
+- Downloaded the `shellbench` harness script locally to inspect macro expansion (`generate_*_begin_helper`).
+- Plan: reproduce `assign.sh` benchmark using local harness and exsh binary to capture runtime errors.
+- Ran `/tmp/shellbench` with `SHELLBENCH_SHELLS=./build/bin/exsh` against `sample/assign.sh`; confirmed '?' results for multiple cases while others succeed (e.g., `local var`).
+- Plan: source shellbench helpers to capture expanded benchmark code for failing case (`positional params`).
+- Attempted to rerun benchmark with `-e` flag for error output; initial run hung (interrupted) — need to retry with reduced timing.
+- Retried with `SHELLBENCH_BENCHMARK_TIME=1`, `SHELLBENCH_WARMUP_TIME=0`, and `-e`; still saw '?' for `variable`/`local var` tests without additional error output.
+- Used `__SOURCED__=1 . /tmp/shellbench` trick to dump translated code for `positional params`; observed wait-loop with `kill -HUP "$MAIN_PID"` handshake.
+- Attempted to background-run extracted benchmark script manually to capture FD3 output; shell session dropped (need to retry carefully).
+- Created helper harnesses (`run_variable_bench.sh`, etc.) to orchestrate HUP/TERM signals; confirmed `__finished` handler fires and writes counts when FD3 targets a file.
+- Instrumented benchmark code with debug logs showing handshake progression and large iteration counts (~28k) during manual runs.
+- Observed worker processes exiting with status 1 under manual control, matching shellbench's reliance on the EXIT trap output rather than process status.
+- Built debugging variant of `shellbench` to redirect FD3 to temporary files; saw stable counts for some tests while others still produced '?' (e.g., `local var`).
+- Wrapped exsh with a tee on FD3 to capture raw counts during stock shellbench runs; captured four `1` outputs despite shellbench reporting '?', suggesting the harness receives minimal iteration counts.
+- Multiple attempts to call `bench` directly from a sourced shellbench environment caused the interactive shell session to hang, indicating extra care needed when debugging inside the harness.
+- Noticed `echo hi >&3` continued to print to stdout when FD 3 was closed; traced this to `shellEnsureExecRedirBackup` reusing the same descriptor as the redirection source.
+- Updated redirection backup logic to duplicate into a descriptor past the avoid range, preventing collisions with the source FD and restoring expected `>&` semantics.
+- Rebuilt exsh and confirmed direct tests (`echo hi >&3` with closed FD) now error out; reran `assign.sh` benchmarks to verify `variable`/`positional params` counts recover (remaining anomalies isolated to `local`/`typeset` cases pending follow-up).

--- a/src/backend_ast/shell/shell_command_utils.inc
+++ b/src/backend_ast/shell/shell_command_utils.inc
@@ -31,6 +31,7 @@ static bool shellApplyExecRedirections(VM *vm, const ShellCommand *cmd,
                                        ShellExecRedirBackup **out_backups,
                                        size_t *out_count);
 static bool shellEnsureExecRedirBackup(int target_fd,
+                                       int avoid_fd,
                                        ShellExecRedirBackup **backups,
                                        size_t *count,
                                        size_t *capacity);

--- a/src/backend_ast/shell/shell_execution.inc
+++ b/src/backend_ast/shell/shell_execution.inc
@@ -617,6 +617,7 @@ static bool shellCommandIsExecBuiltin(const ShellCommand *cmd) {
 }
 
 static bool shellEnsureExecRedirBackup(int target_fd,
+                                       int avoid_fd,
                                        ShellExecRedirBackup **backups,
                                        size_t *count,
                                        size_t *capacity) {
@@ -633,11 +634,60 @@ static bool shellEnsureExecRedirBackup(int target_fd,
     backup.saved_fd = -1;
     backup.saved_valid = false;
     backup.was_closed = false;
-    int dup_fd = dup(target_fd);
+    int min_fd = target_fd + 1;
+    if (avoid_fd >= 0 && avoid_fd >= min_fd) {
+        min_fd = avoid_fd + 1;
+    }
+    int dup_fd = -1;
+#ifdef F_DUPFD_CLOEXEC
+    dup_fd = fcntl(target_fd, F_DUPFD_CLOEXEC, min_fd);
+    if (dup_fd < 0 && errno == EINVAL) {
+        dup_fd = -1;
+    }
+#endif
+    if (dup_fd < 0) {
+        dup_fd = fcntl(target_fd, F_DUPFD, min_fd);
+        if (dup_fd >= 0) {
+            fcntl(dup_fd, F_SETFD, FD_CLOEXEC);
+        }
+    }
+    if (dup_fd < 0) {
+        dup_fd = dup(target_fd);
+        if (dup_fd >= 0) {
+            fcntl(dup_fd, F_SETFD, FD_CLOEXEC);
+        }
+    }
+    if (dup_fd >= 0 && avoid_fd >= 0 && dup_fd == avoid_fd) {
+#ifdef F_DUPFD_CLOEXEC
+        int alt_fd = fcntl(target_fd, F_DUPFD_CLOEXEC, avoid_fd + 1);
+        if (alt_fd >= 0) {
+            close(dup_fd);
+            dup_fd = alt_fd;
+        } else if (errno == EINVAL) {
+            alt_fd = -1;
+        }
+#else
+        int alt_fd = -1;
+#endif
+        if (dup_fd >= 0 && dup_fd == avoid_fd) {
+            if (alt_fd < 0) {
+                alt_fd = fcntl(target_fd, F_DUPFD, avoid_fd + 1);
+                if (alt_fd >= 0) {
+                    fcntl(alt_fd, F_SETFD, FD_CLOEXEC);
+                }
+            }
+            if (alt_fd >= 0) {
+                close(dup_fd);
+                dup_fd = alt_fd;
+            } else {
+                close(dup_fd);
+                dup_fd = -1;
+            }
+        }
+    }
     if (dup_fd >= 0) {
         backup.saved_fd = dup_fd;
         backup.saved_valid = true;
-        fcntl(dup_fd, F_SETFD, FD_CLOEXEC);
     } else if (errno == EBADF) {
         backup.was_closed = true;
     } else {
@@ -709,7 +759,11 @@ static bool shellApplyExecRedirections(VM *vm, const ShellCommand *cmd,
     for (size_t i = 0; i < cmd->redir_count; ++i) {
         const ShellRedirection *redir = &cmd->redirs[i];
         int target_fd = redir->fd;
-        if (!shellEnsureExecRedirBackup(target_fd, &backups, &backup_count, &backup_capacity)) {
+        int avoid_fd = -1;
+        if (redir->kind == SHELL_RUNTIME_REDIR_DUP && !redir->close_target) {
+            avoid_fd = redir->dup_target_fd;
+        }
+        if (!shellEnsureExecRedirBackup(target_fd, avoid_fd, &backups, &backup_count, &backup_capacity)) {
             int err = errno;
             if (err == 0) {
                 err = ENOMEM;


### PR DESCRIPTION
## Summary
- document ongoing shellbench debugging steps in Docs/exsh_debug_log.md for future investigators
- prevent shellEnsureExecRedirBackup from reusing the same descriptor as the redirection source, avoiding clobbered >& dupes for builtins
- update forward declaration to match the new helper signature

## Testing
- cmake --build build --target exsh

------
https://chatgpt.com/codex/tasks/task_b_68f078c425708329bdd43abebaaec620