### PR TITLE
Add bash-compatible -c option handling for exsh

### DIFF
--- a/Docs/exsh_overview.md
+++ b/Docs/exsh_overview.md
@@ -19,6 +19,10 @@ build/bin/exsh script.psh [arguments]
 ends:
 
 - `-v` prints the generated version string and latest git tag.
+- `-c <command> [name] [args...]` executes an inline command string. When
+  additional arguments follow the string, the first argument becomes `$0` for
+  diagnostics and the remainder populate the positional parameters so inline
+  runs match Bash semantics.
 - `--dump-ast-json` writes the parsed program to stdout in JSON form.
 - `--dump-bytecode` disassembles the compiled bytecode before execution.
 - `--dump-bytecode-only` disassembles and exits without running the VM.
@@ -30,6 +34,9 @@ ends:
 
 Example scripts live under `Examples/exsh/` and cover pipelines, conditionals,
 and environment-aware builtins.
+
+Omitting the command string after `-c` emits the diagnostic `exsh: -c: option
+requires an argument` and exits with status `2`, mirroring Bash's behaviour.
 
 ## Interactive mode
 

--- a/Tests/exsh/tests/dash_c_option.psh
+++ b/Tests/exsh/tests/dash_c_option.psh
@@ -1,0 +1,39 @@
+EXSH_BIN="./build/bin/exsh"
+
+if [ ! -x "$EXSH_BIN" ]; then
+  echo "command-output:missing-executable"
+  echo "missing-status:-1"
+  echo "missing-error:exsh binary not built"
+  exit 1
+fi
+
+command_output=$("$EXSH_BIN" -c 'printf "%s:%s:%s\n" "$0" "$1" "$2"' custom0 first second)
+"$EXSH_BIN" -c 1>/dev/null 2>__dash_c_err.txt
+missing_status=$?
+missing_error=$(tr -d '\n' < __dash_c_err.txt)
+rm -f __dash_c_err.txt
+
+if [ "$command_output" != "custom0:first:second" ]; then
+  echo "command-output:$command_output"
+  echo "missing-status:$missing_status"
+  echo "missing-error:$missing_error"
+  exit 1
+fi
+
+if [ "$missing_status" -ne 2 ]; then
+  echo "command-output:$command_output"
+  echo "missing-status:$missing_status"
+  echo "missing-error:$missing_error"
+  exit 1
+fi
+
+if [ "$missing_error" != "exsh: -c: option requires an argument" ]; then
+  echo "command-output:$command_output"
+  echo "missing-status:$missing_status"
+  echo "missing-error:$missing_error"
+  exit 1
+fi
+
+echo "command-output:$command_output"
+echo "missing-status:$missing_status"
+echo "missing-error:$missing_error"

--- a/Tests/exsh/tests/manifest.json
+++ b/Tests/exsh/tests/manifest.json
@@ -65,6 +65,15 @@
             "expected_stdout": "echo is a shell builtin\ntrue is a shell builtin\nfalse is a shell builtin\necho:plain:start\nalpha beta\necho:plain:end\necho:-e:start\nline1\nline2\necho:-e:end\necho:-E:start\nline1\\nline2\necho:-E:end\nno-newline:sentinel\nprefix:sentinel\ntrue-status:0\nfalse-status:1"
         },
         {
+            "id": "dash_c_option",
+            "name": "Dash-c executes inline commands",
+            "category": "cli",
+            "description": "Verify -c honours bash-compatible argument handling and diagnostics.",
+            "script": "Tests/exsh/tests/dash_c_option.psh",
+            "expect": "runtime_ok",
+            "expected_stdout": "command-output:custom0:first:second\nmissing-status:2\nmissing-error:exsh: -c: option requires an argument"
+        },
+        {
             "id": "builtin_functions",
             "name": "Builtins update environment and status",
             "category": "builtins",

--- a/src/shell/main.c
+++ b/src/shell/main.c
@@ -2756,8 +2756,15 @@ int main(int argc, char **argv) {
             options.verbose_errors = true;
         } else if (strcmp(argv[i], "-c") == 0) {
             if (i + 1 >= argc) {
-                fprintf(stderr, "-c requires an argument\n%s\n", SHELL_USAGE);
-                return EXIT_FAILURE;
+                const char *program = options.frontend_path ? options.frontend_path : "exsh";
+                const char *slash = strrchr(program, '/');
+                const char *backslash = strrchr(program, '\\');
+                if (backslash && (!slash || backslash > slash)) {
+                    slash = backslash;
+                }
+                const char *program_name = (slash && slash[1]) ? slash + 1 : program;
+                fprintf(stderr, "%s: -c: option requires an argument\n", program_name);
+                return vmExitWithCleanup(2);
             }
             command_string = argv[i + 1];
             if (i + 2 < argc) {


### PR DESCRIPTION
## Summary
- emit a bash-style diagnostic and exit code when `exsh -c` is missing its command string and keep argument handling compatible with bash
- document inline command usage and error behaviour for the `-c` option
- add a focused regression test to lock in `$0`/positional parameter handling and diagnostics for `-c`

## Testing
- cmake --build build
- python3 Tests/exsh/exsh_test_harness.py --manifest Tests/exsh/tests/manifest.json --only dash_c_option

------
https://chatgpt.com/codex/tasks/task_b_68f1290d958083299e6169ef97f4fdd6