### PR TITLE
Add automated tests for base example programs

### DIFF
--- a/Tests/examples/examples_manifest.json
+++ b/Tests/examples/examples_manifest.json
@@ -1,0 +1,461 @@
+[
+  {
+    "id": "pascal_hello",
+    "description": "Pascal hello world prints greeting",
+    "language": "pascal",
+    "path": "Examples/pascal/base/hello",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "Hello, World!"
+      }
+    ]
+  },
+  {
+    "id": "pascal_area_calculation",
+    "description": "Area calculation example reports computed areas",
+    "language": "pascal",
+    "path": "Examples/pascal/base/AreaCalculation",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "Area of Rectangle"
+      },
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "Area of Circle"
+      },
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "Area of Triangle"
+      }
+    ]
+  },
+  {
+    "id": "pascal_check_ext_builtin",
+    "description": "Check extended builtin availability reports PID",
+    "language": "pascal",
+    "path": "Examples/pascal/base/CheckExtBuiltin",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "GetPid available"
+      }
+    ]
+  },
+  {
+    "id": "pascal_find_primes",
+    "description": "Find primes example lists primes up to the provided limit",
+    "language": "pascal",
+    "path": "Examples/pascal/base/FindPrimes",
+    "stdin": "20\n",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "Prime numbers found up to 20"
+      },
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "Done."
+      }
+    ],
+    "input_delay": 0.2
+  },
+  {
+    "id": "pascal_quick_sort",
+    "description": "Quick sort demo prints sorted array banner",
+    "language": "pascal",
+    "path": "Examples/pascal/base/QuickSort",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "Sorted array:"
+      }
+    ]
+  },
+  {
+    "id": "pascal_threading_demo",
+    "description": "Threading demo spawns worker threads",
+    "language": "pascal",
+    "path": "Examples/pascal/base/ThreadingDemo",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "spawning threads"
+      },
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "all threads joined"
+      }
+    ]
+  },
+  {
+    "id": "pascal_threads_proc_ptr_demo",
+    "description": "Threads and procedure pointers demo reports thread result",
+    "language": "pascal",
+    "path": "Examples/pascal/base/ThreadsProcPtrDemo",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "thread result"
+      },
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "func ptr"
+      }
+    ]
+  },
+  {
+    "id": "pascal_show_extended_builtins",
+    "description": "Show extended builtins prints PID and swap result",
+    "language": "pascal",
+    "path": "Examples/pascal/base/ShowExtendedBuiltins",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "PID"
+      },
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "After Swap"
+      }
+    ]
+  },
+  {
+    "id": "pascal_vm_version_demo",
+    "description": "VM version demo prints VM and bytecode versions",
+    "language": "pascal",
+    "path": "Examples/pascal/base/VMVersionDemo",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "VM version"
+      },
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "Bytecode version"
+      }
+    ]
+  },
+  {
+    "id": "clike_hello",
+    "description": "CLike hello world prints greeting",
+    "language": "clike",
+    "path": "Examples/clike/base/hello",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "Hello World"
+      }
+    ]
+  },
+  {
+    "id": "clike_func_ptr_indirect_call",
+    "description": "Function pointer example prints computed value",
+    "language": "clike",
+    "path": "Examples/clike/base/FuncPtrIndirectCall",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "42"
+      }
+    ]
+  },
+  {
+    "id": "clike_http_async_demo",
+    "description": "HTTP async demo prints fetched body",
+    "language": "clike",
+    "path": "Examples/clike/base/HttpAsyncDemo",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "Body:"
+      },
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "HelloAsyncCL"
+      }
+    ]
+  },
+  {
+    "id": "clike_http_fetch_data_url",
+    "description": "HTTP data URL fetch prints payload",
+    "language": "clike",
+    "path": "Examples/clike/base/HttpFetchDataURL",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "hello world"
+      }
+    ]
+  },
+  {
+    "id": "clike_module_demo",
+    "description": "Module demo imports helper and prints squares",
+    "language": "clike",
+    "path": "Examples/clike/base/module_demo",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "5 squared"
+      },
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "5 cubed"
+      }
+    ]
+  },
+  {
+    "id": "clike_thread_demo",
+    "description": "Thread demo spawns worker and prints completion",
+    "language": "clike",
+    "path": "Examples/clike/base/thread_demo",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "child"
+      },
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "done"
+      }
+    ]
+  },
+  {
+    "id": "clike_vm_version_demo",
+    "description": "VM version demo prints runtime versions",
+    "language": "clike",
+    "path": "Examples/clike/base/vm_version_demo",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "VM version"
+      },
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "Bytecode version"
+      }
+    ]
+  },
+  {
+    "id": "clike_show_pid",
+    "description": "Show PID example prints process identifier",
+    "language": "clike",
+    "path": "Examples/clike/base/show_pid",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "PID"
+      }
+    ]
+  },
+  {
+    "id": "clike_fibonacci_native",
+    "description": "Native fibonacci implementation prints sequence",
+    "language": "clike",
+    "path": "Examples/clike/base/fibonacci_native",
+    "stdin": "10\n",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "Please enter an integer value"
+      },
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "10:55"
+      }
+    ],
+    "input_delay": 0.2
+  },
+  {
+    "id": "clike_factorial_native",
+    "description": "Native factorial implementation prints computed value",
+    "language": "clike",
+    "path": "Examples/clike/base/factorial_native",
+    "stdin": "5\n",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "Please enter an integer value"
+      },
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "factorial"
+      }
+    ],
+    "input_delay": 0.2
+  },
+  {
+    "id": "clike_chudnovsky_native",
+    "description": "Chudnovsky native implementation prints approximation",
+    "language": "clike",
+    "path": "Examples/clike/base/chudnovsky_native",
+    "stdin": "2\n",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "Please enter an integer value"
+      },
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "pi:"
+      }
+    ],
+    "input_delay": 0.2
+  },
+  {
+    "id": "rea_hello",
+    "description": "Rea hello world prints greeting",
+    "language": "rea",
+    "path": "Examples/rea/base/hello",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "Hello World"
+      }
+    ]
+  },
+  {
+    "id": "rea_base_syntax",
+    "description": "Base syntax example prints arithmetic and loop output",
+    "language": "rea",
+    "path": "Examples/rea/base/base_syntax",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "Initial values"
+      },
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "Counting up"
+      }
+    ]
+  },
+  {
+    "id": "rea_flow",
+    "description": "Flow example prints loop and switch sections",
+    "language": "rea",
+    "path": "Examples/rea/base/flow",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "For Loop Test"
+      },
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "Switch Statement"
+      }
+    ]
+  },
+  {
+    "id": "rea_inheritance",
+    "description": "Inheritance example constructs dog and prints speech",
+    "language": "rea",
+    "path": "Examples/rea/base/inheritance_and_constructor",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "An animal was created"
+      },
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "barks loudly"
+      }
+    ]
+  },
+  {
+    "id": "rea_myself",
+    "description": "myself keyword example prints point information",
+    "language": "rea",
+    "path": "Examples/rea/base/myself",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "New Point created"
+      },
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "sum of coordinates"
+      }
+    ]
+  },
+  {
+    "id": "rea_crt_demo",
+    "description": "CRT demo clears screen and prints messages",
+    "language": "rea",
+    "path": "Examples/rea/base/crt_demo",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "Hello from Rea"
+      },
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "Screen cleared"
+      }
+    ]
+  },
+  {
+    "id": "rea_method_demo",
+    "description": "Method call sugar example updates counters",
+    "language": "rea",
+    "path": "Examples/rea/base/method_demo",
+    "checks": [
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "c="
+      },
+      {
+        "type": "contains",
+        "stream": "stdout",
+        "value": "d="
+      }
+    ]
+  }
+]

--- a/Tests/examples/run_examples.py
+++ b/Tests/examples/run_examples.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import pty
+import re
+import selectors
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_TIMEOUT = 20.0
+STARTUP_TIMEOUT = 3.0
+ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-9;?]*[ -/]*[@-~]")
+ANSI_OSC_RE = re.compile(r"\x1B\][^\x07]*(?:\x07|\x1b\\)")
+
+INTERPRETERS = {
+    "pascal": {
+        "binary": REPO_ROOT / "build/bin/pascal",
+        "args": ["--no-cache"],
+    },
+    "clike": {
+        "binary": REPO_ROOT / "build/bin/clike",
+        "args": ["--no-cache"],
+    },
+    "rea": {
+        "binary": REPO_ROOT / "build/bin/rea",
+        "args": ["--no-cache"],
+    },
+}
+
+
+class Harness:
+    def __init__(self):
+        self.total = 0
+        self.failures = 0
+        self.skips = 0
+
+    def report(self, status: str, test_id: str, description: str, details=None):
+        self.total += 1
+        status = status.upper()
+        if status == "FAIL":
+            self.failures += 1
+        elif status == "SKIP":
+            self.skips += 1
+        print(f"[{status}] {test_id} – {description}")
+        if details:
+            for detail in details:
+                if not detail:
+                    continue
+                for line in detail.splitlines() or (detail,):
+                    print(f"    {line}")
+
+    def summary(self, label: str):
+        base = f"\nRan {self.total} {label} test(s); {self.failures} failure(s)"
+        if self.skips:
+            base += f"; {self.skips} skipped"
+        print(base)
+
+    def exit_code(self) -> int:
+        return 0 if self.failures == 0 else 1
+
+
+def strip_ansi(data: str) -> str:
+    data = ANSI_ESCAPE_RE.sub("", data)
+    data = ANSI_OSC_RE.sub("", data)
+    return data
+
+
+def normalise_output(raw: bytes) -> str:
+    text = raw.decode("utf-8", errors="replace")
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    return strip_ansi(text)
+
+
+def load_manifest(path: Path):
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def build_command(entry, script_path):
+    language = entry["language"]
+    interp = INTERPRETERS.get(language)
+    if not interp:
+        raise ValueError(f"Unsupported language: {language}")
+    binary = interp["binary"]
+    args = list(interp["args"])
+    cmd = [str(binary)] + args + [str(script_path)]
+    return binary, cmd
+
+
+def run_entry(entry, *, timeout: float, startup_only: bool):
+    stdin_data = entry.get("stdin", "")
+    input_delay = float(entry.get("input_delay", 0.0))
+    env_overrides = entry.get("env", {})
+    script_path = (REPO_ROOT / entry["path"]).resolve()
+    workdir = script_path.parent
+    env = os.environ.copy()
+    env.setdefault("TERM", "xterm-256color")
+    for key, value in env_overrides.items():
+        env[str(key)] = str(value)
+
+    if not script_path.exists():
+        return {
+            "status": "FAIL",
+            "details": [f"Example source not found at {script_path}"],
+            "stdout": b"",
+            "returncode": None,
+        }
+
+    binary, cmd = build_command(entry, script_path)
+    if not binary.exists():
+        return {
+            "status": "FAIL",
+            "details": [f"Interpreter not found at {binary}"],
+            "stdout": b"",
+            "returncode": None,
+        }
+
+    master_fd, slave_fd = pty.openpty()
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            cwd=workdir,
+            env=env,
+            close_fds=True,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        os.close(master_fd)
+        os.close(slave_fd)
+        return {
+            "status": "FAIL",
+            "details": [f"Failed to spawn process: {exc}"],
+            "stdout": b"",
+            "returncode": None,
+        }
+    finally:
+        os.close(slave_fd)
+
+    os.set_blocking(master_fd, False)
+    selector = selectors.DefaultSelector()
+    selector.register(master_fd, selectors.EVENT_READ)
+
+    stdout_chunks = []
+    start_time = time.monotonic()
+    deadline = start_time + timeout
+    stdin_sent = not stdin_data
+    timed_out = False
+    input_bytes = stdin_data.encode("utf-8") if stdin_data else b""
+
+    try:
+        while True:
+            now = time.monotonic()
+            if not stdin_sent and now - start_time >= input_delay:
+                try:
+                    os.write(master_fd, input_bytes)
+                except OSError:
+                    pass
+                stdin_sent = True
+
+            wait_timeout = max(0.0, min(0.1, deadline - now))
+            events = selector.select(wait_timeout)
+            for key, _ in events:
+                try:
+                    chunk = os.read(key.fd, 8192)
+                except OSError:
+                    chunk = b""
+                if chunk:
+                    stdout_chunks.append(chunk)
+                else:
+                    selector.unregister(key.fd)
+
+            if proc.poll() is not None:
+                break
+
+            if now >= deadline:
+                if startup_only:
+                    break
+                timed_out = True
+                break
+    finally:
+        selector.close()
+
+    if proc.poll() is None:
+        if startup_only:
+            proc.terminate()
+            try:
+                proc.wait(1.0)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+        else:
+            timed_out = True
+            proc.terminate()
+            try:
+                proc.wait(1.0)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+
+    # Drain remaining output
+    while True:
+        try:
+            chunk = os.read(master_fd, 8192)
+        except OSError:
+            break
+        if not chunk:
+            break
+        stdout_chunks.append(chunk)
+
+    os.close(master_fd)
+
+    stdout_data = b"".join(stdout_chunks)
+    return {
+        "status": "TIMEOUT" if timed_out else "OK",
+        "stdout": stdout_data,
+        "returncode": proc.returncode,
+        "details": [],
+    }
+
+
+def apply_checks(entry, stdout_text: str):
+    issues = []
+    checks = entry.get("checks", [])
+    for check in checks:
+        ctype = check.get("type", "contains")
+        stream = check.get("stream", "stdout")
+        if stream != "stdout":
+            issues.append(f"Unsupported stream '{stream}' for check")
+            continue
+        target = stdout_text
+        value = check.get("value", "")
+        if ctype == "contains":
+            if value not in target:
+                issues.append(f"stdout missing substring: {value}")
+        elif ctype == "equals":
+            if target.strip() != value.strip():
+                issues.append("stdout did not match expected text")
+        elif ctype == "startswith":
+            if not target.startswith(value):
+                issues.append(f"stdout does not start with: {value}")
+        elif ctype == "endswith":
+            if not target.rstrip().endswith(value):
+                issues.append(f"stdout does not end with: {value}")
+        elif ctype == "nonempty":
+            if not target.strip():
+                issues.append("stdout was empty")
+        else:
+            issues.append(f"Unknown check type: {ctype}")
+    return issues
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Run example program tests")
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=Path(__file__).with_name("examples_manifest.json"),
+        help="Path to examples manifest",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        manifest = load_manifest(args.manifest)
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"Failed to load manifest: {exc}", file=sys.stderr)
+        return 1
+
+    harness = Harness()
+
+    for entry in manifest:
+        test_id = entry.get("id", entry.get("path"))
+        description = entry.get("description", entry.get("path"))
+
+        skip_info = entry.get("skip")
+        if skip_info:
+            env_name = skip_info.get("env")
+            expected = skip_info.get("value")
+            if env_name and expected is not None:
+                if os.environ.get(env_name) != str(expected):
+                    reason = skip_info.get("reason", f"Requires {env_name}={expected}")
+                    harness.report("SKIP", test_id, description, [reason])
+                    continue
+
+        timeout = float(entry.get("timeout", DEFAULT_TIMEOUT))
+        startup_only = bool(entry.get("startup_only", False))
+        if startup_only:
+            timeout = float(entry.get("startup_timeout", STARTUP_TIMEOUT))
+
+        result = run_entry(entry, timeout=timeout, startup_only=startup_only)
+        stdout_text = normalise_output(result.get("stdout", b""))
+
+        details = []
+        details.extend(result.get("details", []))
+        if result.get("status") == "TIMEOUT":
+            details.append(f"Process timed out after {timeout:.1f}s")
+        issues = apply_checks(entry, stdout_text)
+
+        allowed_codes = entry.get("allow_exit_codes")
+        if allowed_codes is None:
+            allowed_codes = [0]
+        else:
+            allowed_codes = [int(code) for code in allowed_codes]
+
+        returncode = result.get("returncode")
+        exit_ok = startup_only or (returncode in allowed_codes)
+        if not exit_ok:
+            details.append(f"Unexpected exit code: {returncode}")
+
+        if issues:
+            details.extend(issues)
+        if details:
+            snippet = stdout_text.strip()
+            if snippet:
+                if len(snippet) > 500:
+                    snippet = snippet[:500] + "…"
+                details.append("Captured stdout:\n" + snippet)
+
+        if details:
+            harness.report("FAIL", test_id, description, details)
+        else:
+            harness.report("PASS", test_id, description)
+
+    harness.summary("Example")
+    return harness.exit_code()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Tests/run_all_tests
+++ b/Tests/run_all_tests
@@ -60,6 +60,10 @@ echo
 echo "Tiny Tests End"
 echo
 echo "====================================="
+echo "Running Example Program Tests"
+python3 ./examples/run_examples.py
+echo "Example Program Tests End"
+echo
 echo "Running JSON2BC Tests"
 bash ./run_json2bc_tests.sh
 echo "JSON2BC Tests End"


### PR DESCRIPTION
## Summary
- add a manifest describing Pascal, CLike, and Rea base example checks
- implement a pseudo-terminal aware Python runner to execute the examples and validate their output
- wire the new example suite into `Tests/run_all_tests` so it runs with the rest of the harness

## Testing
- python3 Tests/examples/run_examples.py

------
https://chatgpt.com/codex/tasks/task_b_68f7210352888329acf2826b6c31f02d