### PR TITLE
Reduce exsh exit polling overhead

### DIFF
--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -221,6 +221,7 @@ void shellRuntimePopScript(void);
 bool shellRuntimeIsOutermostScript(void);
 bool shellRuntimeShouldDeferExit(struct VM_s* vm);
 bool shellRuntimeMaybeRequestPendingExit(struct VM_s* vm);
+const volatile bool *shellRuntimePendingExitFlag(void);
 void shellRuntimeSetInteractive(bool interactive);
 bool shellRuntimeIsInteractive(void);
 void shellRuntimeSetExitOnSignal(bool enabled);

--- a/src/backend_ast/shell/shell_runtime_state.inc
+++ b/src/backend_ast/shell/shell_runtime_state.inc
@@ -1743,6 +1743,10 @@ bool shellRuntimeMaybeRequestPendingExit(VM *vm) {
     return true;
 }
 
+const volatile bool *shellRuntimePendingExitFlag(void) {
+    return &gShellRuntime.errexit_pending;
+}
+
 ShellTrapAction shellRuntimeGetSignalTrapAction(int signo) {
     if (signo <= 0 || signo >= NSIG) {
         return SHELL_TRAP_ACTION_DEFAULT;


### PR DESCRIPTION
## Summary
- cache the shell runtime's pending exit flag in the VM interpreter loop so we only invoke the exit handler when needed
- expose a shellRuntimePendingExitFlag helper and weak stub so non-shell front ends keep building

## Testing
- Tests/run_exsh_tests.sh *(fails: exsh executable not built in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68f7a20946e48329b90e8907f1aa06bc