### PR TITLE
Reduce builtin flushing overhead

### DIFF
--- a/src/backend_ast/shell/shell_command_utils.inc
+++ b/src/backend_ast/shell/shell_command_utils.inc
@@ -382,7 +382,7 @@ static char *shellRunCommandSubstitution(const char *command) {
     gShellRuntime.local_scope_active = previous_local_scope_flag;
     gShellRuntime.pipeline_subshell_active = previous_pipeline_flag;
 
-    fflush(NULL);
+    shellFlushStandardStreams();
 
     if (stdout_redirected) {
         dup2(saved_stdout, STDOUT_FILENO);

--- a/src/backend_ast/shell/shell_execution.inc
+++ b/src/backend_ast/shell/shell_execution.inc
@@ -273,7 +273,7 @@ static int shellSpawnProcess(VM *vm,
             bool builtin_ran = shellInvokeBuiltin(vm ? vm : gShellCurrentVm, (ShellCommand *)cmd);
             if (builtin_ran) {
                 int status = gShellRuntime.last_status;
-                fflush(NULL);
+                shellFlushStandardStreams();
                 _exit(status);
             }
 

--- a/src/backend_ast/shell/shell_runtime_state.inc
+++ b/src/backend_ast/shell/shell_runtime_state.inc
@@ -37,6 +37,11 @@
 #include <pthread.h>
 #include <time.h>
 
+static void shellFlushStandardStreams(void) {
+    fflush(stdout);
+    fflush(stderr);
+}
+
 #if defined(__GLIBC__) || defined(__ANDROID__)
 #define SHELL_HAVE_SECURE_GETENV 1
 extern char *secure_getenv(const char *name);

--- a/src/backend_ast/shell/shell_word_expansion.inc
+++ b/src/backend_ast/shell/shell_word_expansion.inc
@@ -2459,7 +2459,7 @@ static bool shellInvokeBuiltin(VM *vm, ShellCommand *cmd) {
     shellRuntimeSetCurrentCommandLocation(cmd->line, cmd->column);
     ShellExecRedirBackup *redir_backups = NULL;
     size_t redir_backup_count = 0;
-    fflush(NULL);
+    shellFlushStandardStreams();
     if (!shellApplyExecRedirections(vm, cmd, &redir_backups, &redir_backup_count)) {
         if (args) {
             for (int i = 0; i < arg_count; ++i) {
@@ -2518,7 +2518,7 @@ static bool shellInvokeBuiltin(VM *vm, ShellCommand *cmd) {
                 runtimeError(vm, "shell builtin '%s': out of memory", name);
                 shellUpdateStatus(1);
                 shellRuntimeSetCurrentCommandName(previous_name);
-                fflush(NULL);
+                shellFlushStandardStreams();
                 shellRestoreExecRedirections(redir_backups, redir_backup_count);
                 shellFreeExecRedirBackups(redir_backups, redir_backup_count);
                 shellRuntimeSetCurrentCommandLocation(previous_line, previous_column);
@@ -2531,7 +2531,7 @@ static bool shellInvokeBuiltin(VM *vm, ShellCommand *cmd) {
         handler(vm, arg_count, args);
     }
     shellRuntimeSetCurrentCommandName(previous_name);
-    fflush(NULL);
+    shellFlushStandardStreams();
     shellRestoreExecRedirections(redir_backups, redir_backup_count);
     shellFreeExecRedirBackups(redir_backups, redir_backup_count);
     if (args) {


### PR DESCRIPTION
## Summary
- add a shared helper that only flushes stdout and stderr for builtin execution
- replace the previous fflush(NULL) calls in builtin, command substitution, and child pipeline paths with the targeted helper to avoid global stream flushing

## Testing
- ./shellbench -s 'exsh,bash' sample/assign.sh sample/cmp.sh sample/count.sh sample/eval.sh sample/func.sh sample/null.sh sample/subshell.sh sample/stringop1.sh

------
https://chatgpt.com/codex/tasks/task_b_68f7a7cdfeb4832984a3e4beee4bc5b1