### PR TITLE
Ensure EXSH_LAST_STATUS remains exported

### DIFF
--- a/src/backend_ast/shell/shell_command_utils.inc
+++ b/src/backend_ast/shell/shell_command_utils.inc
@@ -3053,6 +3053,12 @@ static bool shellSetTrackedVariable(const char *name, const char *value, bool is
             } else {
                 shellArrayRegistryRemove(name);
             }
+            if (strcmp(name, "EXSH_LAST_STATUS") == 0) {
+                const char *text = value ? value : "";
+                if (setenv(name, text, 1) != 0) {
+                    return false;
+                }
+            }
             return true;
         }
         errno = ENOMEM;


### PR DESCRIPTION
## Summary
- synchronize EXSH_LAST_STATUS updates to the process environment even when a pipeline local scope intercepts the assignment

## Testing
- PATH="$(pwd)/build/bin:$PATH" Examples/exsh/functions

------
https://chatgpt.com/codex/tasks/task_b_68f86149aff08329a5875a0cb5f19186