### PR TITLE
Fix exsh path resolution for Sierpinski threads demo

### DIFF
--- a/Examples/exsh/sierpinski_threads
+++ b/Examples/exsh/sierpinski_threads
@@ -209,9 +209,24 @@ resolve_exsh_binary() {
         return 0
     fi
 
-    local script_dir repo_root
-    script_dir=${0%/*}
-    if [ -z "$script_dir" ] || [ "$script_dir" = "$0" ]; then
+    local script_path script_dir repo_root
+
+    script_path="$0"
+    case "$script_path" in
+        */*)
+            script_dir=${script_path%/*}
+            ;;
+        *)
+            script_path=$(find_in_path "$script_path" 2>/dev/null || printf '')
+            if [ -n "$script_path" ]; then
+                script_dir=${script_path%/*}
+            else
+                script_dir='.'
+            fi
+            ;;
+    esac
+
+    if [ -z "$script_dir" ]; then
         script_dir='.'
     fi
 


### PR DESCRIPTION
## Summary
- make the Sierpinski threads demo resolve its script directory even when invoked without a slash
- fall back to PATH lookup before deriving the repo root so worker processes can find the exsh binary

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68f871eee5288329afcdaf063afed4e8