### PR TITLE
Hook WaitForThread into exsh front-end

### DIFF
--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -107,6 +107,7 @@ Value vmBuiltinQuitrequested(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinReal(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinVMVersion(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinBytecodeVersion(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinWaitForThread(struct VM_s* vm, int arg_count, Value* args);
 
 /* Shell builtins */
 Value vmBuiltinShellExec(struct VM_s* vm, int arg_count, Value* args);
@@ -169,6 +170,7 @@ Value vmBuiltinShellKill(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellFg(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellBg(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellWait(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinShellWaitForThread(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellBuiltin(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellColon(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinShellEcho(struct VM_s* vm, int arg_count, Value* args);

--- a/src/backend_ast/shell/shell_builtins.inc
+++ b/src/backend_ast/shell/shell_builtins.inc
@@ -8392,6 +8392,71 @@ Value vmBuiltinShellWait(VM *vm, int arg_count, Value *args) {
     return makeVoid();
 }
 
+Value vmBuiltinShellWaitForThread(VM *vm, int arg_count, Value *args) {
+    if (arg_count != 1) {
+        runtimeError(vm, "WaitForThread: expected thread id");
+        shellUpdateStatus(1);
+        return makeVoid();
+    }
+
+    Value thread_value = args[0];
+    Value converted = makeVoid();
+    bool converted_valid = false;
+
+    if (thread_value.type == TYPE_STRING && thread_value.s_val && thread_value.s_val[0] != '\0') {
+        const char *raw = thread_value.s_val;
+        const char *id_text = raw;
+        const char *colon = strchr(raw, ':');
+        if (colon && colon[1] != '\0') {
+            id_text = colon + 1;
+        }
+
+        long long parsed = 0;
+        if (!shellParseSignedLongLong(id_text, &parsed)) {
+            runtimeError(vm, "WaitForThread: %s: invalid thread id", raw);
+            shellUpdateStatus(1);
+            return makeVoid();
+        }
+        converted = makeInt(parsed);
+        thread_value = converted;
+        converted_valid = true;
+    }
+
+    if (!(thread_value.type == TYPE_THREAD || IS_INTLIKE(thread_value))) {
+        runtimeError(vm, "WaitForThread: expected thread id");
+        if (converted_valid) {
+            freeValue(&converted);
+        }
+        shellUpdateStatus(1);
+        return makeVoid();
+    }
+
+    long long thread_id = asI64(thread_value);
+    if (thread_id <= 0 || thread_id > INT_MAX) {
+        runtimeError(vm, "WaitForThread: %lld: invalid thread id", thread_id);
+        if (converted_valid) {
+            freeValue(&converted);
+        }
+        shellUpdateStatus(1);
+        return makeVoid();
+    }
+
+    if (!vmJoinThreadById(vm, (int)thread_id)) {
+        runtimeError(vm, "WaitForThread: %lld: invalid thread id", thread_id);
+        if (converted_valid) {
+            freeValue(&converted);
+        }
+        shellUpdateStatus(1);
+        return makeVoid();
+    }
+
+    if (converted_valid) {
+        freeValue(&converted);
+    }
+    shellUpdateStatus(0);
+    return makeVoid();
+}
+
 Value vmBuiltinShellBuiltin(VM *vm, int arg_count, Value *args) {
     if (arg_count < 1 || args[0].type != TYPE_STRING || !args[0].s_val || args[0].s_val[0] == '\0') {
         runtimeError(vm, "builtin: expected VM builtin name");

--- a/src/backend_ast/shell/shell_word_expansion.inc
+++ b/src/backend_ast/shell/shell_word_expansion.inc
@@ -2286,7 +2286,7 @@ static bool shellIsRuntimeBuiltin(const char *name) {
         "shift",  "return", "help",   "type",   "which", "test",   "[",      ":",      "unalias",
         "getopts",
         "mapfile","__shell_double_bracket",
-        "__shell_arithmetic", "times",  "echo",   "true",   "false"
+        "__shell_arithmetic", "times",  "echo",   "true",   "false", "WaitForThread"
     };
 
     size_t count = sizeof(kBuiltins) / sizeof(kBuiltins[0]);

--- a/src/ext_builtins/shell_frontend.c
+++ b/src/ext_builtins/shell_frontend.c
@@ -78,6 +78,7 @@ void registerShellFrontendBuiltins(void) {
     registerShellBuiltin(category, command_group, "fg", vmBuiltinShellFg);
     registerShellBuiltin(category, command_group, "bg", vmBuiltinShellBg);
     registerShellBuiltin(category, command_group, "wait", vmBuiltinShellWait);
+    registerShellBuiltin(category, command_group, "WaitForThread", vmBuiltinShellWaitForThread);
     registerShellBuiltin(category, command_group, "hash", vmBuiltinShellHash);
     registerShellBuiltin(category, command_group, "enable", vmBuiltinShellEnable);
     registerShellBuiltin(category, command_group, "help", vmBuiltinShellHelp);

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -45,6 +45,7 @@ static const ShellBuiltinEntry kShellBuiltins[] = {
     {"fg", "fg", 18},
     {"bg", "bg", 19},
     {"wait", "wait", 20},
+    {"WaitForThread", "waitforthread", 1056},
     {"builtin", "builtin", 21},
     {"source", "source", 21},
     {".", "source", 21},

--- a/src/vm/vm.h
+++ b/src/vm/vm.h
@@ -139,6 +139,7 @@ void vmResetExecutionState(VM* vm); // Reset stack/frames so a VM can be reused
 InterpretResult interpretBytecode(VM* vm, BytecodeChunk* chunk, HashTable* globals, HashTable* const_globals, HashTable* procedures, uint16_t entry);
 void vmNullifyAliases(VM* vm, uintptr_t disposedAddrValue);
 int vmSpawnCallbackThread(VM* vm, VMThreadCallback callback, void* user_data, VMThreadCleanup cleanup);
+bool vmJoinThreadById(struct VM_s* vm, int id);
 
 // Register and lookup class methods in the VM's procedure table
 void vmRegisterClassMethod(VM* vm, const char* className, uint16_t methodIndex, Symbol* methodSymbol);


### PR DESCRIPTION
## Summary
- add a shell-facing WaitForThread wrapper that accepts both string and typed thread identifiers before delegating to the VM join helper
- register the new builtin with the exsh runtime tables so the shell treats WaitForThread as a first-class builtin command
- expose the handler in the public builtin header so other front-ends can reference it

## Testing
- build/bin/exsh -c 'WaitForThread 1'
- build/bin/exsh -c 'builtin WaitForThread "int:1"'
- build/bin/exsh -c 'type WaitForThread'


------
https://chatgpt.com/codex/tasks/task_b_68f89a1160388329b9d65c9313609a1c