### PR TITLE
Fix exsh Sierpinski demo rendering

### DIFF
--- a/Examples/exsh/sierpinski_threads
+++ b/Examples/exsh/sierpinski_threads
@@ -317,8 +317,15 @@ is_positive_integer() {
 draw_point() {
     local x="$1"
     local y="$2"
-    run_exsh_builtin GotoXY "int:$x" "int:$y"
-    run_exsh_builtin Write "int:0" "str:$CHAR_TO_DRAW"
+    if [ "$HEADLESS_MODE" = "1" ]; then
+        return 0
+    fi
+
+    if ! run_exsh_builtin GotoXY "int:$x" "int:$y"; then
+        printf '\033[%d;%dH' "$y" "$x"
+    fi
+
+    printf '%s' "$CHAR_TO_DRAW"
 }
 
 draw_sierpinski() {

--- a/src/ext_builtins/user/sierpinski_threads.c
+++ b/src/ext_builtins/user/sierpinski_threads.c
@@ -1,6 +1,7 @@
 #include "backend_ast/builtin.h"
 #include "core/utils.h"
 #include "vm/vm.h"
+#include "Pascal/globals.h"
 
 #include <pthread.h>
 #include <stdio.h>
@@ -24,14 +25,21 @@ static void sierpinskiDrawPoint(VM *vm, int x, int y, char drawChar) {
         return;
     }
 
-    Value coords[2];
-    coords[0] = makeInt(x);
-    coords[1] = makeInt(y);
-
     pthread_mutex_lock(&gSierpinskiMutex);
-    vmBuiltinGotoxy(vm, 2, coords);
-    putchar(drawChar);
+
+    int absX = gWindowLeft + x - 1;
+    int absY = gWindowTop + y - 1;
+
+    if (absX < 1) {
+        absX = 1;
+    }
+    if (absY < 1) {
+        absY = 1;
+    }
+
+    fprintf(stdout, "\x1B[%d;%dH%c", absY, absX, drawChar);
     fflush(stdout);
+
     pthread_mutex_unlock(&gSierpinskiMutex);
 }
 


### PR DESCRIPTION
## Summary
- update the exsh demo fallback drawing helper to emit characters via ANSI escape sequences instead of the Write builtin
- render worker thread output with explicit cursor-positioning escape sequences so the fractal appears reliably

## Testing
- not run (exsh build not available in this environment)


------
https://chatgpt.com/codex/tasks/task_b_68f8ce731490832996bf224803f45ac2