### PR TITLE
Fix macOS weak imports for shell runtime symbols

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -28,9 +28,12 @@
 #include <stdio.h>   // For printf, fprintf
 #include <pthread.h>
 
-#if defined(__GNUC__)
-__attribute__((weak)) void shellRuntimeSetLastStatus(int status);
-__attribute__((weak)) void shellRuntimeSetLastStatusSticky(int status);
+#if defined(__APPLE__)
+extern void shellRuntimeSetLastStatus(int status) __attribute__((weak_import));
+extern void shellRuntimeSetLastStatusSticky(int status) __attribute__((weak_import));
+#elif defined(__GNUC__)
+extern void shellRuntimeSetLastStatus(int status) __attribute__((weak));
+extern void shellRuntimeSetLastStatusSticky(int status) __attribute__((weak));
 #else
 void shellRuntimeSetLastStatus(int status);
 void shellRuntimeSetLastStatusSticky(int status);


### PR DESCRIPTION
## Summary
- ensure shell runtime helpers use weak_import on macOS so optional shell symbols link correctly
- keep weak symbol declarations for other toolchains

## Testing
- cmake --build build --target pscaljson2bc -j4

------
https://chatgpt.com/codex/tasks/task_b_68f9f1fda0648329aa2bcdb3fef1471f