### PR TITLE
Fix macOS link failure for pscaljson2bc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -966,6 +966,7 @@ set(JSON2BC_SOURCES
     src/core/utils.c src/core/types.c src/core/list.c src/core/version.c src/core/cache.c
     src/compiler/bytecode.c src/compiler/compiler.c
     src/backend_ast/builtin.c src/backend_ast/builtin_network_api.c
+    src/backend_ast/shell_runtime_stub.c
     src/backend_ast/sdl.c src/backend_ast/sdl3d.c src/backend_ast/gl.c src/backend_ast/audio.c
     src/symbol/symbol.c
     src/vm/vm.c


### PR DESCRIPTION
## Summary
- include the shell runtime stub in the JSON-to-bytecode tool target so the optional shell status helpers resolve during linking

## Testing
- cmake --build build --target pscaljson2bc

------
https://chatgpt.com/codex/tasks/task_b_68fa02406cdc8329a04bb28c923a76f6