### PR TITLE
Add comprehensive exsh threading showcase example

### DIFF
--- a/Docs/threading.md
+++ b/Docs/threading.md
@@ -78,6 +78,10 @@ bench run:
 - Run `build/bin/exsh Examples/exsh/threading_demo` to confirm thread names,
   status handling, and cooperative cancellation behave as expected for the
   builtins allowed on worker threads.【F:Examples/exsh/threading_demo†L1-L30】
+- Run `build/bin/exsh Examples/exsh/threading_showcase` to exercise
+  `ThreadSpawnBuiltin`, `ThreadPoolSubmit`, naming/lookup helpers, result
+  collection, and the `ThreadStats` snapshot in a single transcript before
+  landing worker-pool changes.【F:Examples/exsh/threading_showcase†L1-L135】
 - Execute `build/bin/pascal Examples/pascal/base/docs_examples/threading_config`
   after exporting `PSCAL_THREAD_POOL_SIZE=<n>` to verify Pascal observes the
   configured limit and reports worker usage through `ThreadStatsCount`.

--- a/Examples/exsh/README.md
+++ b/Examples/exsh/README.md
@@ -109,6 +109,26 @@ worker's return value and success bit. The sample script spawns a DNS lookup and
 an asynchronous delay, waits for both handles, and prints the resolved IP and
 status flag.
 
+## `threading_showcase`
+
+```sh
+#!/usr/bin/env exsh
+tid=$(builtin ThreadSpawnBuiltin str:dnslookup "str:$host")
+builtin ThreadSetName "$tid" "str:dns:$host"
+WaitForThread "$tid"
+result=$(builtin ThreadGetResult "$tid" bool:true)
+stats=$(builtin ThreadStats)
+```
+
+`threading_showcase` expands on the basic demo by exercising every worker-pool
+builtin in one run. It spawns multiple DNS lookups, queues a delay via
+`ThreadPoolSubmit`, assigns human-readable names with `ThreadSetName`, and uses
+`ThreadLookup` to show how the names map back to thread handles. After the
+workers finish, the script demonstrates both result-collection styles (`get`
+followed by `status` and the one-shot `get(..., true)`) before dumping the pool
+snapshot provided by `ThreadStats`. Set
+`THREAD_SHOWCASE_DELAY_MS=<millis>` to adjust the queued delay.
+
 ## `sierpinski_threads`
 
 ```sh

--- a/Examples/exsh/threading_showcase
+++ b/Examples/exsh/threading_showcase
@@ -1,0 +1,136 @@
+#!/usr/bin/env exsh
+# Comprehensive thread helper demonstration for exsh.
+#
+# Usage:
+#   build/bin/exsh Examples/exsh/threading_showcase [host ...]
+#
+# When no hostnames are provided the script resolves three defaults
+# (localhost, example.com, and the intentionally failing invalid.invalid).
+# The optional THREAD_SHOWCASE_DELAY_MS environment variable controls the
+# delay submitted via the worker queue (defaults to 750 milliseconds).
+#
+# The demo exercises the following helpers:
+#   * ThreadSpawnBuiltin – launch DNS lookups on background workers.
+#   * ThreadPoolSubmit  – queue a delay without blocking the caller.
+#   * ThreadSetName     – assign friendly names for easier diagnostics.
+#   * ThreadLookup      – map thread names back to handles.
+#   * WaitForThread     – join workers while checking their status codes.
+#   * ThreadGetResult   – retrieve stored builtin results.
+#   * ThreadGetStatus   – drop cached results/status flags so slots can reuse.
+#   * ThreadStats       – emit a snapshot of the worker pool state at the end.
+#
+# Each log line is prefixed with "threading_showcase:" so automated tooling can
+# scrape the transcript easily.
+
+set -e
+set -o pipefail
+
+if [ "$#" -gt 0 ]; then
+    : # Hosts supplied by the caller.
+else
+    set -- localhost example.com invalid.invalid
+fi
+
+DELAY_MS=${THREAD_SHOWCASE_DELAY_MS:-750}
+
+# Accumulate thread metadata as "id|label|kind" tuples (newline separated).
+THREAD_INFO=""
+
+printf 'threading_showcase:start hosts=%s delay_ms=%s\n' "$*" "$DELAY_MS"
+
+for host in "$@"; do
+    tid=$(builtin ThreadSpawnBuiltin str:dnslookup "str:$host")
+    label="dns:$host"
+    # Naming threads keeps ThreadStats/ThreadLookup output legible.
+    if builtin ThreadSetName "$tid" "str:$label" >/dev/null 2>&1; then
+        printf 'threading_showcase:spawn:%s:%s\n' "$label" "$tid"
+    else
+        printf 'threading_showcase:spawn:%s:%s (name-pending)\n' "$label" "$tid"
+    fi
+    THREAD_INFO="${THREAD_INFO}${tid}|${label}|dns"$'\n'
+done
+
+# Try to queue the delay via ThreadPoolSubmit; fall back to ThreadSpawnBuiltin
+# if the helper is unavailable in the current build.
+if delay_tid=$(builtin ThreadPoolSubmit str:delay "int:$DELAY_MS" 2>/dev/null); then
+    delay_kind=delay_queue
+    printf 'threading_showcase:submit:delay:%sms:%s\n' "$DELAY_MS" "$delay_tid"
+else
+    delay_tid=$(builtin ThreadSpawnBuiltin str:delay "int:$DELAY_MS")
+    delay_kind=delay_spawn
+    printf 'threading_showcase:spawn:delay:%sms:%s\n' "$DELAY_MS" "$delay_tid"
+fi
+
+delay_label="delay:${DELAY_MS}ms"
+builtin ThreadSetName "$delay_tid" "str:$delay_label" >/dev/null 2>&1 || true
+THREAD_INFO="${THREAD_INFO}${delay_tid}|${delay_label}|${delay_kind}"$'\n'
+
+# Demonstrate ThreadLookup for every recorded label.
+while IFS='|' read -r tid label kind; do
+    [ -z "$tid" ] && continue
+    lookup=$(builtin ThreadLookup "str:$label" 2>/dev/null || printf '')
+    if [ -n "$lookup" ]; then
+        printf 'threading_showcase:lookup:%s:%s\n' "$label" "$lookup"
+    else
+        printf 'threading_showcase:lookup:%s:<not-found>\n' "$label"
+    fi
+done <<'INFO'
+$THREAD_INFO
+INFO
+
+dns_counter=0
+while IFS='|' read -r tid label kind; do
+    [ -z "$tid" ] && continue
+    if WaitForThread "$tid"; then
+        join_status=$EXSH_LAST_STATUS
+    else
+        join_status=$EXSH_LAST_STATUS
+    fi
+
+    result_payload=""
+    status_note=""
+
+    case "$kind" in
+        dns)
+            dns_counter=$((dns_counter + 1))
+            if [ "$dns_counter" -eq 1 ]; then
+                # Two-step collection: read the value, then drop the cached state.
+                result_payload=$(builtin ThreadGetResult "$tid")
+                status_flag=$(builtin ThreadGetStatus "$tid" bool:true)
+                status_note="status=$status_flag"
+            else
+                # Consume the status flag at the same time as the result.
+                result_payload=$(builtin ThreadGetResult "$tid" bool:true)
+                status_note="status via WaitForThread=$join_status"
+            fi
+            ;;
+        delay_queue|delay_spawn)
+            status_flag=$(builtin ThreadGetStatus "$tid" bool:true)
+            status_note="status=$status_flag"
+            result_payload="<void>"
+            ;;
+        *)
+            status_flag=$(builtin ThreadGetStatus "$tid" bool:true)
+            status_note="status=$status_flag"
+            ;;
+    esac
+
+    if [ -z "$result_payload" ]; then
+        result_payload="<empty>"
+    fi
+
+    printf 'threading_showcase:result:%s:join=%s %s value=%s\n' \
+        "$label" "$join_status" "$status_note" "$result_payload"
+done <<'INFO'
+$THREAD_INFO
+INFO
+
+stats_output=$(builtin ThreadStats 2>/dev/null || printf '')
+if [ -n "$stats_output" ]; then
+    printf 'threading_showcase:stats:%s\n' "$stats_output"
+else
+    printf 'threading_showcase:stats:<empty>\n'
+fi
+
+printf 'threading_showcase:end\n'
+

--- a/README.md
+++ b/README.md
@@ -104,7 +104,11 @@ The exsh front end now includes `Examples/exsh/threading_demo`, which shows how
 to launch allow-listed VM builtins on worker threads with
 `ThreadSpawnBuiltin`/`WaitForThread`/`ThreadGetResult`. The script resolves
 `localhost` on a background worker, joins both the DNS lookup and a timer, and
-prints the stored result via the new helpers.
+prints the stored result via the new helpers. For a fuller tour, run
+`Examples/exsh/threading_showcase` to see `ThreadPoolSubmit`,
+`ThreadSetName`/`ThreadLookup`, the alternate `ThreadGetResult(..., true)`
+path, and a `ThreadStats` snapshot; set `THREAD_SHOWCASE_DELAY_MS` to tweak the
+queued delay.
 
 ## Tiny language front end (Written in Python)
 


### PR DESCRIPTION
## Summary
- add `Examples/exsh/threading_showcase`, a detailed exsh script that walks through thread spawning, naming, lookup, result collection, and pool stats
- document the new showcase in the exsh examples README, threading guide, and main README alongside the existing `threading_demo`

## Testing
- not run (exsh demo script)


------
https://chatgpt.com/codex/tasks/task_b_68fa812af7fc832986bbb0760c4d6356