### PR TITLE
Add ThreadStatsJson builtin for exsh stats

### DIFF
--- a/Examples/exsh/threading_showcase
+++ b/Examples/exsh/threading_showcase
@@ -192,11 +192,11 @@ while IFS='|' read -r tid label kind; do
         "$label" "$join_status" "$status_note" "$result_payload"
 done <"$THREAD_INFO_FILE"
 
-stats_output=$(builtin ThreadStats 2>/dev/null || printf '')
+stats_output=$(builtin ThreadStatsJson 2>/dev/null || printf '')
 if [ -n "$stats_output" ]; then
     printf 'threading_showcase:stats:%s\n' "$stats_output"
 else
-    printf 'threading_showcase:stats:<empty>\n'
+    printf 'threading_showcase:stats:[]\n'
 fi
 
 printf 'threading_showcase:end\n'

--- a/src/backend_ast/builtin.h
+++ b/src/backend_ast/builtin.h
@@ -118,6 +118,7 @@ Value vmBuiltinThreadPause(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinThreadResume(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinThreadCancel(struct VM_s* vm, int arg_count, Value* args);
 Value vmBuiltinThreadStats(struct VM_s* vm, int arg_count, Value* args);
+Value vmBuiltinThreadStatsJson(struct VM_s* vm, int arg_count, Value* args);
 
 /* Shell builtins */
 Value vmBuiltinShellExec(struct VM_s* vm, int arg_count, Value* args);


### PR DESCRIPTION
## Summary
- add JSON helper routines and a ThreadStatsJson builtin that emits worker pool summaries
- register the new builtin and expose it through the dispatcher and headers
- update the threading_showcase example to print the JSON stats instead of the raw array description

## Testing
- build/bin/exsh Examples/exsh/threading_showcase google.com yahoo.com


------
https://chatgpt.com/codex/tasks/task_b_68fb3131cb148329bbc1dbd5af0a9d01