### PR TITLE
Add cache-friendly shellbench variant without -c

### DIFF
--- a/Tool/shellbench_cacheable/.shellspec
+++ b/Tool/shellbench_cacheable/.shellspec
@@ -1,0 +1,13 @@
+--require spec_helper
+--kcov-options "--include-pattern=shellbench/shellbench"
+
+## Default kcov (coverage) options
+# --kcov-options "--include-path=. --path-strip-level=1"
+# --kcov-options "--include-pattern=.sh"
+# --kcov-options "--exclude-pattern=/.shellspec,/spec/,/coverage/,/report/"
+
+## Example: Include script "myprog" with no extension
+# --kcov-options "--include-pattern=.sh,myprog"
+
+## Example: Only specified files/directories
+# --kcov-options "--include-pattern=myprog,/lib/"

--- a/Tool/shellbench_cacheable/LICENSE
+++ b/Tool/shellbench_cacheable/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 ShellSpec
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Tool/shellbench_cacheable/README.md
+++ b/Tool/shellbench_cacheable/README.md
@@ -1,0 +1,183 @@
+# ShellBench
+
+A benchmark utility for POSIX shell comparison
+
+## Usage
+
+```console
+Usage: shellbench [options] files...
+
+  -s, --shell SHELL[,SHELL...]  The shell(s) to run the benchmark. [default: sh]
+  -t, --time SECONDS            Benchmark execution time. (SECONDS > 0) [default: 3]
+  -w, --warmup SECONDS          Benchmark preparation time. (SECONDS > 0) [default: 1]
+  -c, --correct                 Enable correction mode to eliminate loop overhead.
+  -e, --error                   Display error details.
+  -h, --help                    You're looking at it.
+```
+
+## Sample
+
+```console
+$ ./shellbench -s sh,bash,ksh,mksh,posh,zsh sample/count.sh sample/output.sh
+------------------------------------------------------------------------------------------------
+name                                   sh       bash        ksh       mksh       posh        zsh
+------------------------------------------------------------------------------------------------
+count.sh: posix                 1,034,369    248,929    282,537    364,627    411,116    577,090
+count.sh: typeset -i                error    237,421    288,133    341,660      error    593,124
+count.sh: increment                 error    272,415    443,765    350,265      error    835,077
+output.sh: echo                   279,335    121,104    375,175    179,903    201,718     59,138
+output.sh: printf                 277,989    118,461    209,123        180        179     63,644
+output.sh: print                    error      error    281,775    182,388      error     63,006
+------------------------------------------------------------------------------------------------
+* count: number of executions per second
+```
+
+file: **sample/count.sh**
+
+```sh
+#!/bin/sh
+
+setup() { i=1; }
+cleanup() { :; }
+
+#bench "posix"
+@begin
+i=$((i+1))
+@end
+
+#bench "typeset -i"
+typeset -i i
+@begin
+i=$((i+1))
+@end
+
+#bench "increment"
+typeset -i i
+@begin
+((i++))
+@end
+```
+
+file: **sample/output.sh**
+
+```sh
+#!/bin/sh
+
+#bench "echo"
+@begin
+echo "test"
+@end
+
+#bench "printf"
+@begin
+printf "test\n"
+@end
+
+#bench "print"
+@begin
+print "test"
+@end
+```
+
+## Directives
+
+### `#bench`
+
+Define new benchmark
+
+```sh
+#bench NAME
+```
+
+### @begin & @end
+
+Repeatedly execute between `@begin` to `@end`, and count the number of executions.
+
+```sh
+@begin
+echo "test"
+@end
+```
+
+## Hooks
+
+### `setup`
+
+Invoked before each benchmark.
+
+### `cleanup`
+
+Invoked after each benchmark.
+
+## Environment variables
+
+| name                      | description                       | default |
+| ------------------------- | --------------------------------- | ------- |
+| SHELLBENCH_SHELLS         | The shell(s) to run the benchmark | sh      |
+| SHELLBENCH_BENCHMARK_TIME | Benchmark execution time          | 3       |
+| SHELLBENCH_WARMUP_TIME    | Benchmark preparation time        | 1       |
+| SHELLBENCH_NAME_WIDTH     | Display width of benchmark name   | 30      |
+| SHELLBENCH_COUNT_WIDTH    | Display width of benchamrk count  | 10      |
+| SHELLBENCH_NULLLOOP_COUNT | null loop measurement             |         |
+
+## How it works
+
+ShellBench translates `@begin` and `@end` to loop as follows:
+
+```sh
+# From
+@begin
+echo "test"
+@end
+
+# Translate to
+while __count=$(($__count+1)); do
+echo "test"
+done
+```
+
+That is, during the benchmark time, not only `echo` but `while`, `__ count=$(($__count+1))`, count the number of times it is executed.
+
+This loop will be killed by another process after benchmark time. Therefore, after `@end` is not executed.
+
+### Correction mode
+
+Calculate the benchmark measurement results more strictly.
+This mode is suitable when the cost impact of the loop cannot be ignored.
+
+Difference between default and modification mode
+
+- Default mode: Measure `while`, `__count=$(($__count+1))` and target code.
+- Correction mode: Measure only target code
+
+Correction mode first measures the null loop and then eliminates
+the null loop measurement from the benchmark measurement.
+
+```sh
+# Null loop
+while __count=$(($__count+1)); do
+__CORRECTION_MODE=
+done
+```
+
+And translates `@begin` and `@end` in correction mode as follows:
+
+```sh
+# From
+@begin
+echo "test"
+@end
+
+# Translate to
+while __count=$(($__count+1)); do
+__CORRECTION_MODE=
+echo "test"
+done
+```
+
+Compute a corrected value from the null loop execution count and the benchmark count.
+
+Corrected count: `B / ( 1.0 - ( B * ( 1.0 / A ) ) )`
+
+- A: null loop executed count
+- B: benchmark count

--- a/Tool/shellbench_cacheable/sample/assign.sh
+++ b/Tool/shellbench_cacheable/sample/assign.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+#bench "positional params"
+func() {
+  @begin
+  set -- "1"
+  @end
+}
+func
+
+#bench "variable"
+func() {
+  @begin
+  var=1
+  @end
+}
+func
+
+#bench "local var"
+func() {
+  local var
+  @begin
+  var=1
+  @end
+}
+func
+
+#bench "local var (typeset)"
+function func {
+  typeset var
+  @begin
+  var=1
+  @end
+}
+func

--- a/Tool/shellbench_cacheable/sample/cmp.sh
+++ b/Tool/shellbench_cacheable/sample/cmp.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+setup() { string=""; }
+
+#bench "[ ]"
+@begin
+if [ "$string" = "string" ]; then
+  :
+fi
+@end
+
+#bench "[[ ]]"
+@begin
+if [[ $string == "string" ]]; then
+  :
+fi
+@end
+
+#bench "case"
+@begin
+case $string in (string)
+  :
+esac
+@end

--- a/Tool/shellbench_cacheable/sample/count.sh
+++ b/Tool/shellbench_cacheable/sample/count.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+setup() { i=1; }
+cleanup() { :; }
+
+#bench "posix"
+@begin
+i=$((i+1))
+@end
+
+#bench "typeset -i"
+typeset -i i
+@begin
+i=$((i+1))
+@end
+
+#bench "increment"
+typeset -i i
+@begin
+((i++))
+@end

--- a/Tool/shellbench_cacheable/sample/eval.sh
+++ b/Tool/shellbench_cacheable/sample/eval.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+#bench "direct assign"
+@begin
+func() {
+  var=1
+}
+func
+@end
+
+#bench "eval assign"
+@begin
+func() {
+  eval "var=1"
+}
+func
+@end
+
+#bench "command subs"
+@begin
+func() {
+  echo 1
+}
+var=$(func)
+@end

--- a/Tool/shellbench_cacheable/sample/func.sh
+++ b/Tool/shellbench_cacheable/sample/func.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+#bench "no func"
+@begin
+:
+@end
+
+#bench "func"
+func() {
+  :
+}
+@begin
+func
+@end

--- a/Tool/shellbench_cacheable/sample/null.sh
+++ b/Tool/shellbench_cacheable/sample/null.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+#bench "blank"
+@begin
+@end
+
+#bench "assign variable"
+@begin
+var=
+@end
+
+#bench "define function"
+@begin
+foo() { :; }
+@end
+
+#bench "undefined variable"
+unset no_such_variable
+@begin
+${no_such_variable:-}
+@end
+
+#bench ": command"
+@begin
+:
+@end

--- a/Tool/shellbench_cacheable/sample/output.sh
+++ b/Tool/shellbench_cacheable/sample/output.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+#bench "echo"
+@begin
+echo "test"
+@end
+
+#bench "printf"
+@begin
+printf "test\n"
+@end
+
+#bench "print"
+@begin
+print "test"
+@end

--- a/Tool/shellbench_cacheable/sample/stringop1.sh
+++ b/Tool/shellbench_cacheable/sample/stringop1.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+setup() { string='string'; }
+
+#bench "string length"
+@begin
+var=${#string}
+@end

--- a/Tool/shellbench_cacheable/sample/stringop2.sh
+++ b/Tool/shellbench_cacheable/sample/stringop2.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+setup() { string='string'; }
+
+#bench "substr 1 builtin"
+@begin
+var=${string:2}
+@end
+
+#bench "substr 1 echo | cut"
+@begin
+var=$(echo "$string" | cut -c3-)
+@end
+
+#bench "substr 1 cut here doc"
+@begin
+var=$(cut -c3- << EOF
+$string
+EOF
+)
+@end
+
+#bench "substr 1 cut here str"
+@begin
+var=$(cut -c3- <<< "$string")
+@end
+
+#bench "substr 2 builtin"
+@begin
+var=${string:2:3}
+@end
+
+#bench "substr 2 echo | cut"
+@begin
+var=$(echo "$string" | cut -c3-5)
+@end
+
+#bench "substr 2 cut here doc"
+@begin
+var=$(cut -c3-5 << EOF
+$string
+EOF
+)
+@end
+
+#bench "substr 2 cut here str"
+@begin
+var=$(cut -c3-5 <<< "$string")
+@end
+
+#bench "substr 2 expr"
+@begin
+var=$(expr substr $string 3 3)
+@end

--- a/Tool/shellbench_cacheable/sample/stringop3.sh
+++ b/Tool/shellbench_cacheable/sample/stringop3.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+
+setup() { string='abc:def:ghi'; }
+
+#bench "str remove ^ shortest builtin"
+@begin
+var=${string#*:}
+@end
+
+#bench "str remove ^ shortest echo | cut"
+@begin
+var=$(echo "$string" | cut '-d:' -f2-)
+@end
+
+#bench "str remove ^ shortest cut here doc"
+@begin
+var=$(cut '-d:' -f2- << EOF
+$string
+EOF
+)
+@end
+
+#bench "str remove ^ shortest cut here str"
+@begin
+var=$(cut '-d:' -f2- <<< "$string")
+@end
+
+#bench "str remove ^ longest builtin"
+@begin
+var=${string##*:}
+@end
+
+#bench "str remove ^ longest echo | cut"
+@begin
+var=$(echo "$string" | cut '-d:' -f3)
+@end
+
+#bench "str remove ^ longest cut here doc"
+@begin
+var=$(cut '-d:' -f3 << EOF
+$string
+EOF
+)
+@end
+
+#bench "str remove ^ longest cut here str"
+@begin
+var=$(cut '-d:' -f3 <<< "$string")
+@end
+
+#bench "str remove $ shortest builtin"
+@begin
+var=${string%:*}
+@end
+
+#bench "str remove $ shortest echo | cut"
+@begin
+var=$(echo "$string" | cut '-d:' -f-2)
+@end
+
+#bench "str remove $ shortest cut here doc"
+@begin
+var=$(cut '-d:' -f-2 << EOF
+$string
+EOF
+)
+@end
+
+#bench "str remove $ shortest cut here str"
+@begin
+var=$(cut '-d:' -f-2 <<< "$string")
+@end
+
+#bench "str remove $ longest builtin"
+@begin
+var=${string%%:*}
+@end
+
+#bench "str remove $ longest echo | cut"
+@begin
+var=$(echo "$string" | cut '-d:' -f1)
+@end
+
+#bench "str remove $ longest cut here doc"
+@begin
+var=$(cut '-d:' -f1 << EOF
+$string
+EOF
+)
+@end
+
+#bench "str remove $ longest cut here str"
+@begin
+var=$(cut '-d:' -f1 <<< "$string")
+@end

--- a/Tool/shellbench_cacheable/sample/stringop4.sh
+++ b/Tool/shellbench_cacheable/sample/stringop4.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+
+setup() { string='abc:def:ghi'; }
+
+#bench "str subst one builtin"
+@begin
+var=${string/:/|}
+@end
+
+#bench "str subst one echo | sed"
+@begin
+var=$(echo "$string" | sed -e 's/:/|/')
+@end
+
+#bench "str subst one sed here doc"
+@begin
+var=$(sed -e 's/:/|/' << EOF
+$string
+EOF
+)
+@end
+
+#bench "str subst one sed here str"
+@begin
+var=$(sed -e 's/:/|/' <<< "$string")
+@end
+
+#bench "str subst all builtin"
+@begin
+var=${string//:/|}
+@end
+
+#bench "str subst all echo | sed"
+@begin
+var=$(echo "$string" | sed -e 's/:/|/g')
+@end
+
+#bench "str subst all sed here doc"
+@begin
+var=$(sed -e 's/:/|/g' << EOF
+$string
+EOF
+)
+@end
+
+#bench "str subst all sed here str"
+@begin
+var=$(sed -e 's/:/|/g' <<< "$string")
+@end
+
+#bench "str subst front builtin"
+@begin
+var=${string/#abc:/cba:}
+@end
+
+#bench "str subst front echo | sed"
+@begin
+var=$(echo "$string" | sed -e 's/^abc:/cba:/')
+@end
+
+#bench "str subst front here doc"
+@begin
+var=$(sed -e 's/^abc:/cba:/' << EOF
+$string
+EOF
+)
+@end
+
+#bench "str subst front sed here str"
+@begin
+var=$(sed -e 's/^abc:/cba:/' <<< "$string")
+@end
+
+#bench "str subst back builtin"
+@begin
+var=${string/%:ghi/:ihg}
+@end
+
+#bench "str subst back echo | sed"
+@begin
+var=$(echo "$string" | sed -e 's/:ghi$/:ihg/g')
+@end
+
+#bench "str subst back here doc"
+@begin
+var=$(sed -e 's/:ghi$/:ihg/g' << EOF
+$string
+EOF
+)
+@end
+
+#bench "str subst back sed here str"
+@begin
+var=$(sed -e 's/:ghi$/:ihg/g' <<< "$string")
+@end

--- a/Tool/shellbench_cacheable/sample/subshell.sh
+++ b/Tool/shellbench_cacheable/sample/subshell.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+#bench "no subshell"
+@begin
+true
+@end
+
+#bench "brace"
+@begin
+{
+    true
+}
+@end
+
+#bench "subshell"
+@begin
+(
+    true
+)
+@end
+
+#bench "command subs"
+@begin
+var=$(true)
+@end
+
+#bench "external command"
+true=$(command which true)
+@begin
+"$true"
+@end

--- a/Tool/shellbench_cacheable/shellbench
+++ b/Tool/shellbench_cacheable/shellbench
@@ -1,0 +1,377 @@
+#!/bin/sh
+# shellcheck disable=SC2004,SC2016
+
+set -eu
+
+SHELLS=${SHELLBENCH_SHELLS:-sh}
+NUMBER_OF_SHELLS=0
+WARMUP_TIME=${SHELLBENCH_WARMUP_TIME:-1}
+BENCHMARK_TIME=${SHELLBENCH_BENCHMARK_TIME:-3}
+NAME_WIDTH=${SHELLBENCH_NAME_WIDTH:-50}
+COUNT_WIDTH=${SHELLBENCH_COUNT_WIDTH:-10}
+SHOW_ERROR=''
+CORRECTION_MODE=''
+NULLLOOP_COUNT=''
+
+usage() {
+cat<<HERE
+Usage: shellbench [options] files...
+
+  -s, --shell SHELL[,SHELL...]  The shell(s) to run the benchmark. [default: sh]
+  -t, --time SECONDS            Benchmark execution time. (SECONDS > 0) [default: 3]
+  -w, --warmup SECONDS          Benchmark preparation time. (SECONDS > 0) [default: 1]
+  -c, --correct                 Enable correction mode to eliminate loop overhead.
+  -e, --error                   Display error details.
+  -h, --help                    You're looking at it.
+HERE
+}
+
+preprocess() {
+  set -- '%s\n'
+  while IFS= read -r line; do
+    case $line in ("#bench" | "#bench"[[:space:]]*)
+      set -- "$@" "#bench"
+      line="@${line#?}"
+    esac
+    set -- "$@" "$line"
+  done
+  # shellcheck disable=SC2059
+  printf "$@"
+}
+
+generate_initialize_helper() {
+  echo 'set -e --'
+  echo 'setup() { :; }'
+  echo 'cleanup() { :; }'
+  echo '__finished() { cleanup; echo $(($__count-1)) >&3 2>/dev/null; }'
+  echo '__count=0'
+  echo 'trap : PIPE'
+  echo 'if [ "${ZSH_VERSION:-}" ]; then'
+  echo '  trap "__finished; __finished() { :; }; exit 1" TERM'
+  echo 'else'
+  echo '  trap "exit 1" TERM'
+  echo 'fi'
+  echo 'trap "__finished" EXIT'
+}
+
+generate_benchmark_begin_helper() {
+  echo '__ready='
+  echo 'trap __ready=1 HUP'
+  echo 'kill -HUP "$MAIN_PID"'
+  echo 'until [ "$__ready" ]; do __dummy=; done'
+  echo 'while __count=$(($__count+1)); do'
+  if [ "$CORRECTION_MODE" ]; then
+    echo '__CORRECTION_MODE='
+  fi
+}
+
+generate_benchmark_end_helper() {
+  echo 'done'
+}
+
+generate_syntax_begin_helper() {
+  echo 'while __count=$(($__count+1)) && [ "$__count" -eq 1 ]; do'
+}
+generate_syntax_end_helper() {
+  echo 'done'
+}
+
+read_initializer() {
+  generate_initialize_helper
+  read_chunk
+  echo "setup"
+}
+
+read_bench_directive() {
+  IFS= read -r line || return 1
+  printf '%s' "$line"
+}
+
+translate_bench_code() {
+  begin="" end="" type=${1:-benchmark}
+
+  set -- '%s\n'
+  while IFS= read -r line || [ "$line" ]; do
+    case ${line#"${line%%[![:space:]]*}"} in
+      @begin)
+        if [ "$begin" ]; then
+          abort "@begin is duplicated"
+        fi
+        begin=1
+        set -- "$@" "$("generate_${type}_begin_helper")" ;;
+      @end)
+        if ! [ "$begin" ]; then
+          abort "@begin is not defined"
+        fi
+        if [ "$end" ]; then
+          abort "@end is duplicated"
+        fi
+        end=1
+        set -- "$@" "$("generate_${type}_end_helper")" ;;
+      *) set -- "$@" "$line"
+    esac
+  done
+
+  if ! [ "$begin" ]; then
+    abort "@begin is not defined"
+  fi
+  if [ ! "$end" ]; then
+    abort "@end is not defined"
+  fi
+  # shellcheck disable=SC2059
+  [ $# -gt 1 ] && printf "$@"
+}
+
+read_chunk() {
+  set -- '%s\n'
+  while IFS= read -r line || [ "$line" ]; do
+    [ "${line#"${line%%[![:space:]]*}"}" = "#bench" ] && break
+    set -- "$@" "$line"
+  done
+  # shellcheck disable=SC2059
+  [ $# -eq 1 ] || printf "$@"
+}
+
+syntax_check() {
+  script_file=$(mktemp)
+  printf '%s' "$2" > "$script_file"
+  error=$("$1" "$script_file" 2>&1 >/dev/null 3>&1) &&:
+  ex=$?
+  rm -f "$script_file"
+  if [ "$ex" -ne 0 ] || [ "$error" ]; then
+    [ "$SHOW_ERROR" ] && printf '\n[ERROR] %s' "$error" >&2
+    return $(($ex == 0 ? 1 : $ex))
+  fi
+}
+
+bench() {
+  MAIN_PID=$(exec sh -c 'echo $PPID')
+  export MAIN_PID
+
+  ready=0
+  trap 'ready=$(($ready + 1))' HUP
+  trap 'kill -TERM -$$' INT
+
+  script_file=$(mktemp)
+  printf '%s' "$2" > "$script_file"
+
+  "$1" "$script_file" 3>&1 >/dev/null &
+  bench_pid=$!
+  stopper "$3" "$bench_pid" &
+
+  # wait for ready
+  while [ "$ready" -lt 2 ]; do dummy=; done
+  sleep "$WARMUP_TIME" &
+  wait "$!" || { rm -f "$script_file"; exit 1; }
+
+  # start benchmark
+  kill -HUP "-$$"
+  if ! wait; then
+    rm -f "$script_file"
+    exit 1
+  fi
+  rm -f "$script_file"
+}
+
+stopper() {
+  ready=''
+  trap 'ready=1' HUP
+  kill -HUP "$MAIN_PID"
+  # shellcheck disable=SC2034
+  until [ "$ready" ]; do dummy=; done
+  sleep "$1"
+  kill -TERM "$2"
+}
+
+parse_bench_directive() {
+  name=""
+  if [ $# -gt 0 ]; then
+    name="$1"
+    shift
+  fi
+}
+
+exists_shell() {
+  script_file=$(mktemp)
+  printf '%s' : > "$script_file"
+  "$1" "$script_file" 2>/dev/null
+  status=$?
+  rm -f "$script_file"
+  return $status
+}
+
+comma() {
+  eval "set -- $1 \"\${$1}\" \"\" \"\""
+  case $2 in (-*)
+    set -- "$1" "${2#-}" "$3" "-"
+  esac
+  while [ ${#2} -gt 3 ]; do
+    set -- "$1" "${2%???}" "$(($2 % 1000))${3:+,}$3" "$4"
+    case ${3%%,*} in
+      ?) set -- "$1" "$2" "00$3" "$4" ;;
+      ??) set -- "$1" "$2" "0$3" "$4" ;;
+    esac
+  done
+  set -- "$1" "" "$4$2${3:+,}$3"
+  eval "$1=\$3"
+}
+
+process() {
+  initializer=$(read_initializer)
+  while bench=$(read_bench_directive); do
+    eval "parse_bench_directive ${bench#@bench}"
+    printf "%-${NAME_WIDTH}s " "$1: $name"
+
+    chunk=$(printf '%s\n' "$initializer"; read_chunk)
+    syntax_check_code=$(printf '%s' "$chunk" | translate_bench_code syntax)
+    code=$(printf '%s' "$chunk" | translate_bench_code)
+
+    shells="$SHELLS,"
+    while [ "$shells" ] && shell=${shells%%,*} && shells=${shells#*,}; do
+      result='?' count=0
+      if ! exists_shell "$shell"; then
+        result="none"
+      elif syntax_check "$shell" "$syntax_check_code"; then
+        count=$(bench "$shell" "$code" "$BENCHMARK_TIME")
+        if [ "$count" ]; then
+          count=$(($count / $BENCHMARK_TIME))
+          nullloop=$(get_nullloop "$shell")
+          count=$(correct "$count" "$nullloop")
+          result="$count"
+          comma result
+        fi
+      else
+        result="error"
+      fi
+      printf "%${COUNT_WIDTH}s " "$result"
+    done
+    echo
+  done
+}
+
+correct() {
+  if [ "$2" ]; then
+    awk "BEGIN { print int($1 / ( 1 - ( $1 * ( 1 / $2 ) ) ) ) }" /dev/null
+  else
+    echo "$1"
+  fi
+}
+
+get_nullloop() {
+  set -- ",$1:" ",$NULLLOOP_COUNT,"
+  case $2 in (*"$1"*)
+    set -- "${2##*"$1"}"
+    echo "${1%%,*}"
+  esac
+}
+
+measure_nullloop() {
+  initializer=$(read_initializer)
+  bench=$(read_bench_directive)
+  chunk=$(read_chunk)
+  code=$(printf '%s\n' "$initializer" "$chunk" | translate_bench_code)
+  printf "%-${NAME_WIDTH}s " "[null loop]"
+
+  shells="$SHELLS," nullloop_count=''
+  while [ "$shells" ] && shell=${shells%%,*} && shells=${shells#*,}; do
+    result="?"
+    if exists_shell "$shell"; then
+      count=$(get_nullloop "$shell")
+      if [ ! "$count" ]; then
+        count=$(bench "$shell" "$code" "$BENCHMARK_TIME")
+        count=$(($count / $BENCHMARK_TIME))
+      fi
+      nullloop_count="${nullloop_count}${nullloop_count:+,}${shell}:$count"
+      result=$count
+      comma result
+    else
+      result="none"
+    fi
+    printf "%${COUNT_WIDTH}s " "$result"
+  done
+  NULLLOOP_COUNT=$nullloop_count
+  echo
+}
+
+line() {
+  set -- "$1" ""
+  while [ "$1" -gt 0 ]; do
+    set -- $(($1 - 1)) "${2}-"
+  done
+  echo "$2"
+}
+
+count_shells() {
+  NUMBER_OF_SHELLS=0
+  set -- "$1,"
+  while [ "$1" ]; do
+    set -- "${1#*,}"
+    NUMBER_OF_SHELLS=$(($NUMBER_OF_SHELLS + 1))
+  done
+}
+
+display_header() {
+  line $(( $NAME_WIDTH + $NUMBER_OF_SHELLS * ($COUNT_WIDTH + 1) ))
+  set -- "$1," ""
+  printf "%-${NAME_WIDTH}s" "name"
+  while [ "$1" ]; do
+    set -- "${1#*,}" "${1%%,*}"
+    printf " %${COUNT_WIDTH}s" "$2"
+  done
+  echo
+  line $(( $NAME_WIDTH + $NUMBER_OF_SHELLS * ($COUNT_WIDTH + 1) ))
+}
+
+display_footer() {
+  line $(( $NAME_WIDTH + $NUMBER_OF_SHELLS * ($COUNT_WIDTH + 1) ))
+  echo "* count: number of executions per second"
+}
+
+PARAMS=''
+
+abort() { echo "$@" >&2; exit 1; }
+unknown() { abort "Unrecognized option '$1'"; }
+required() { [ $# -gt 1 ] || abort "Option '$1' requires an argument"; }
+param() { eval "$1=\$$1\ \\\"\"\\\${$2}\"\\\""; }
+params() { [ "$2" -ge "$3" ] || params_ "$@"; }
+params_() { param "$1" "$2"; params "$1" $(($2 + 1)) "$3"; }
+
+parse_options() {
+  OPTIND=$(($# + 1))
+  while [ $# -gt 0 ]; do
+    case $1 in
+      -s | --shell  ) required "$@" && shift; SHELLS=$1 ;;
+      -t | --time   ) required "$@" && shift; BENCHMARK_TIME=$1 ;;
+      -w | --warmup ) required "$@" && shift; WARMUP_TIME=$1 ;;
+      -c | --correct) CORRECTION_MODE=1 ;;
+      -e | --error  ) SHOW_ERROR=1 ;;
+      -h | --help   ) usage; exit ;;
+      --) shift; params PARAMS $(($OPTIND - $#)) $OPTIND; break ;;
+      -?*) unknown "$@" ;;
+      *) param PARAMS $(($OPTIND - $#))
+    esac
+    shift
+  done
+}
+
+${__SOURCED__:+return}
+
+trap '' HUP
+parse_options "$@"
+eval "set -- $PARAMS"
+
+[ "$CORRECTION_MODE" ] && NULLLOOP_COUNT=${SHELLBENCH_NULLLOOP_COUNT:-}
+
+count_shells "$SHELLS"
+display_header "$SHELLS"
+[ "$CORRECTION_MODE" ] && measure_nullloop <<HERE
+  $(printf '%s\n' '#bench "loop only"' '@begin' '@end' | preprocess)
+HERE
+for file in "$@"; do
+  preprocess < "$file" | process "${file##*/}"
+done
+display_footer
+if [ "$CORRECTION_MODE" ] && [ ! "${SHELLBENCH_NULLLOOP_COUNT:-}" ]; then
+  echo "* To skip null loop measurement, set the environment variable below"
+  echo "export SHELLBENCH_NULLLOOP_COUNT=$NULLLOOP_COUNT"
+fi

--- a/Tool/shellbench_cacheable/spec/shellbench_spec.sh
+++ b/Tool/shellbench_cacheable/spec/shellbench_spec.sh
@@ -1,0 +1,419 @@
+Describe "Sample specfile"
+  Include ./shellbench
+
+  Describe "preprocess()"
+    Describe "@bench directive"
+      Data
+        #|foo
+        #|#bench
+        #|bar
+        #|baz
+      End
+
+      result() { %text
+        #|foo
+        #|#bench
+        #|@bench
+        #|bar
+        #|baz
+      }
+
+      It "outputs preproccesed texts"
+        When call preprocess
+        The output should eq "$(result)"
+      End
+    End
+
+    Describe "@bench directive with parameters"
+      Data
+        #|foo
+        #|#bench "name" key=value
+        #|bar
+        #|baz
+      End
+
+      result() { %text
+        #|foo
+        #|#bench
+        #|@bench "name" key=value
+        #|bar
+        #|baz
+      }
+
+      It "outputs preproccesed texts"
+        When call preprocess
+        The output should eq "$(result)"
+      End
+    End
+  End
+
+  Describe "generate_initialize_helper()"
+    It "generates initialize helper"
+      When call generate_initialize_helper
+      The output should include "trap"
+    End
+  End
+
+  Describe "generate_benchmark_begin_helper()"
+    It "generates @begin helper"
+      When call generate_benchmark_begin_helper
+      The output should include "while"
+    End
+  End
+
+  Describe "generate_benchmark_end_helper()"
+    It "generates @end helper"
+      When call generate_benchmark_end_helper
+      The output should include "done"
+    End
+  End
+
+  Describe "read_initializer()"
+    Data
+      #|#!/bin/sh
+      #|setup() { :; }
+      #|#bench
+      #|@bench
+      #|foo
+    End
+
+    generate_initialize_helper() { echo "initialize helper"; }
+
+    It "reads initializer"
+      When call read_initializer
+      The line 1 should eq "initialize helper"
+      The line 2 should eq "#!/bin/sh"
+      The line 3 should eq "setup() { :; }"
+      The line 4 should eq "setup"
+      The lines of output should eq 4
+    End
+  End
+
+  Describe "read_bench_directive()"
+    Data
+      #|@bench "name" skip=sh
+    End
+
+    It "reads @bench directive"
+      When call read_bench_directive
+      The output should eq '@bench "name" skip=sh'
+    End
+
+    Data
+    End
+
+    It "returns failure if there is no data"
+      When call read_bench_directive
+      The output should be blank
+      The status should be failure
+    End
+  End
+
+  Describe "read_chunk()"
+    Data
+      #|foo
+      #|bar
+      #|#bench
+      #|baz
+    End
+
+    result() { %text
+      #|foo
+      #|bar
+    }
+
+    It "reads chunk"
+      When call read_chunk
+      The output should eq "$(result)"
+    End
+  End
+
+  Describe "translate_bench_code()"
+    Data
+      #|@begin
+      #|foo
+      #|@end
+    End
+
+    result() { %text
+      #|@begin helper
+      #|foo
+      #|@end helper
+    }
+
+    generate_benchmark_begin_helper() { echo "@begin helper"; }
+    generate_benchmark_end_helper() { echo "@end helper"; }
+
+    It "reads file until the #bench directive"
+      When call translate_bench_code
+      The output should eq "$(result)"
+    End
+
+    Context "when @begin and @end are missing"
+      Data
+        #|foo
+      End
+
+      It "raise error"
+        When run translate_bench_code
+        The stderr should include "@begin is not defined"
+        The status should be failure
+      End
+    End
+
+    Context "when @begin is missing"
+      Data
+        #|foo
+        #|@end
+      End
+
+      It "raise error"
+        When run translate_bench_code
+        The stderr should include "@begin is not defined"
+        The status should be failure
+      End
+    End
+
+    Context "when @begin is duplicated"
+      Data
+        #|@begin
+        #|@begin
+        #|foo
+        #|@end
+      End
+
+      It "raise error"
+        When run translate_bench_code
+        The stderr should include "@begin is duplicated"
+        The status should be failure
+      End
+    End
+
+    Context "when @end is missing"
+      Data
+        #|@begin
+        #|foo
+      End
+
+      It "raise error"
+        When run translate_bench_code
+        The stderr should include "@end is not defined"
+        The status should be failure
+      End
+    End
+
+    Context "when @end is duplicated"
+      Data
+        #|@begin
+        #|foo
+        #|@end
+        #|@end
+      End
+
+      It "raise error"
+        When run translate_bench_code
+        The stderr should include "@end is duplicated"
+        The status should be failure
+      End
+    End
+  End
+
+  Describe "syntax_check()"
+    Parameters
+      sh ":" success blank
+      sh "{" failure present
+    End
+
+    It "checks syntax"
+      When call syntax_check "$1" "$2"
+      The status should be "$3"
+    End
+  End
+
+  Describe "parse_bench_directive()"
+    It "parses @bench arguments"
+      When call parse_bench_directive "name" "key=value"
+      The variable name should eq "name"
+    End
+  End
+
+  Describe "exists_shell()"
+    Parameters
+      sh success
+      no-such-a-shell failure
+    End
+
+    It "checks if exists shell"
+      When call exists_shell "$1"
+      The status should be "$2"
+    End
+  End
+
+  Describe "comma()"
+    Parameters
+      1 1
+      10 10
+      100 100
+      1000 1,000
+      111011001 111,011,001
+      -111011001 -111,011,001
+    End
+
+    _comma() {
+      value=$1
+      comma value
+      echo "$value"
+    }
+
+    It "inserts comma"
+      When call _comma "$1"
+      The output should eq "$2"
+    End
+  End
+
+
+  Describe "process()"
+    Data
+      #|#bench
+      #|@bench dummy
+      #|@begin
+      #|:
+      #|@end
+    End
+
+    Before SHELLS=sh,bash
+    Before WARMUP_TIME=0 BENCHMARK_TIME=2
+    bench() {
+      case $1 in
+        sh) echo 1000 ;;
+        bash) echo 2000 ;;
+      esac
+    }
+
+    It "outputs benchmark results"
+      When call process "file"
+      The word 1 should eq "file:"
+      The word 2 should eq "dummy"
+      The word 3 should eq "500"
+      The word 4 should eq "1,000"
+    End
+
+    Context "when shell not found"
+      exists_shell() { return 1; }
+      It "outputs skipped results"
+        When call process "file"
+        The word 1 should eq "file:"
+        The word 2 should eq "dummy"
+        The word 3 should eq "none"
+        The word 4 should eq "none"
+      End
+    End
+
+    Context "when syntax error"
+      syntax_check() { return 1; }
+      It "outputs error"
+        When call process "file"
+        The word 1 should eq "file:"
+        The word 2 should eq "dummy"
+        The word 3 should eq "error"
+        The word 4 should eq "error"
+      End
+    End
+  End
+
+  Describe "correct()"
+    It "corrects benchmark count"
+      When call correct 123 456
+      The output should eq "168"
+    End
+  End
+
+  Describe "get_nullloop()"
+    Before NULLLOOP_COUNT="sh:123,bash:456,zsh:789"
+
+    Parameters
+      sh 123
+      bash 456
+      zsh 789
+      ksh ""
+    End
+
+    It "gets nullloop value"
+      When call get_nullloop "$1"
+      The output should eq "$2"
+    End
+  End
+
+  Describe "measure_nullloop()"
+    Data
+      #|#bench
+      #|@bench nullloop
+      #|@begin
+      #|var=
+      #|@end
+    End
+
+    Before SHELLS=sh,bash
+    Before WARMUP_TIME=0 BENCHMARK_TIME=2
+    bench() {
+      case $1 in
+        sh) echo 1000 ;;
+        bash) echo 2000 ;;
+      esac
+    }
+
+    It "outputs benchmark results"
+      When call measure_nullloop
+      The word 1 should eq "[null"
+      The word 2 should eq "loop]"
+      The word 3 should eq "500"
+      The word 4 should eq "1,000"
+    End
+
+    Context "when shell not found"
+      exists_shell() { return 1; }
+      It "outputs skipped results"
+        When call measure_nullloop
+        The word 1 should eq "[null"
+        The word 2 should eq "loop]"
+        The word 3 should eq "none"
+        The word 4 should eq "none"
+      End
+    End
+  End
+
+  Describe "line()"
+    It "outputs line"
+      When call line "10"
+      The output should eq "----------"
+    End
+  End
+
+  Describe "count_shells()"
+    It "outputs line"
+      When call count_shells "sh,bash,zsh"
+      The variable NUMBER_OF_SHELLS should eq 3
+    End
+  End
+
+  Describe "display_header()"
+    Before NAME_WIDTH=20 COUNT_WIDTH=8 NUMBER_OF_SHELLS=3
+
+    It "outputs line"
+      When call display_header "sh,bash,zsh"
+      The line 1 should eq "-----------------------------------------------"
+      The line 2 should eq "name                       sh     bash      zsh"
+      The line 3 should eq "-----------------------------------------------"
+    End
+  End
+
+  Describe "display_footer()"
+    Before NAME_WIDTH=20 COUNT_WIDTH=8 NUMBER_OF_SHELLS=3
+
+    It "outputs line"
+      When call display_footer
+      The line 1 should eq "-----------------------------------------------"
+      The line 2 should eq "* count: number of executions per second"
+    End
+  End
+End

--- a/Tool/shellbench_cacheable/spec/spec_helper.sh
+++ b/Tool/shellbench_cacheable/spec/spec_helper.sh
@@ -1,0 +1,7 @@
+#shellcheck shell=sh
+
+# set -eu
+
+# shellspec_spec_helper_configure() {
+#   shellspec_import 'support/custom_matcher'
+# }


### PR DESCRIPTION
## Summary
- add a copy of shellbench under Tool/shellbench_cacheable for running benchmarks without relying on the `-c` option
- adjust the shell invocations in the benchmark, syntax check, and shell detection routines to execute temporary scripts so cached bytecode can be reused

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68fc885df8408329a89e22ee60cbe9d0