### PR TITLE
Fix hangman guessed letter sorting

### DIFF
--- a/Examples/clike/base/hangman5
+++ b/Examples/clike/base/hangman5
@@ -103,9 +103,10 @@ void show_guesses_bar(int wrong, int max_wrong) {
     printf(" [%d/%d]", remaining, max_wrong);
 }
 
-void sort_string(str s) {
+void sort_string(str* sp) {
     int i, j, len;
     char tmp;
+    str s = *sp;
     len = strlen(s);
     i = 1;
     while (i <= len) {
@@ -120,6 +121,7 @@ void sort_string(str s) {
         }
         i++;
     }
+    *sp = s;
 }
 
 struct WordNode {
@@ -310,7 +312,7 @@ int play_round(struct WordNode* words, int word_count, int max_wrong) {
             continue;
         }
         guessed = guessed + ch;
-        sort_string(guessed);
+        sort_string(&guessed);
         found = 0; len = strlen(secret); i = 1;
         while (i <= len) { if (secret[i] == ch) { so_far[i] = ch; found = 1; } i++; }
         if (!found) { wrong++; }


### PR DESCRIPTION
## Summary
- update the hangman example's `sort_string` helper to operate on a caller-provided pointer
- ensure guessed letters are re-sorted after each guess so they display alphabetically

## Testing
- not run (example manual testing only)


------
https://chatgpt.com/codex/tasks/task_b_68fdbe3be26883298e4db71e3c82899a