### PR TITLE
Fix CLike thread join releasing worker slots

### DIFF
--- a/Tests/clike/ThreadSpawnJoin.cl
+++ b/Tests/clike/ThreadSpawnJoin.cl
@@ -3,8 +3,11 @@ void child() {
 }
 
 int main() {
-    int tid = spawn child();
-    join tid;
+    int i;
+    for (i = 0; i < 6; i++) {
+        int tid = spawn child();
+        join tid;
+    }
     printf("parent\n");
     return 0;
 }

--- a/Tests/clike/ThreadSpawnJoin.out
+++ b/Tests/clike/ThreadSpawnJoin.out
@@ -1,2 +1,7 @@
 child
+child
+child
+child
+child
+child
 parent

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1584,7 +1584,12 @@ static bool joinThreadInternal(VM* vm, int id) {
 }
 
 static void joinThread(VM* vm, int id) {
-    joinThreadInternal(vm, id);
+    if (!vm) {
+        return;
+    }
+    if (!vmThreadTakeResult(vm, id, NULL, true, NULL, true)) {
+        joinThreadInternal(vm, id);
+    }
 }
 
 bool vmJoinThreadById(VM* vm, int id) {
@@ -6737,7 +6742,9 @@ comparison_error_label:
                     freeValue(&popped_tid);
                     return INTERPRET_RUNTIME_ERROR;
                 }
-                joinThread(vm, tid);
+                if (!vmThreadTakeResult(vm, tid, NULL, true, NULL, true)) {
+                    joinThreadInternal(vm, tid);
+                }
                 Value popped_tid = pop(vm);
                 freeValue(&popped_tid);
                 break;


### PR DESCRIPTION
## Summary
- ensure thread joins consume the cached result so worker slots return to the pool
- extend the CLike thread spawn/join test to exercise repeated joins

## Testing
- `cmake --build pscal/build --target pscalvm`


------
https://chatgpt.com/codex/tasks/task_b_68fde0cdd93c8329872a23d711748467