### PR TITLE
Fix SDL multibouncingballs quit handling

### DIFF
--- a/Examples/clike/sdl/multibouncingballs
+++ b/Examples/clike/sdl/multibouncingballs
@@ -75,14 +75,25 @@ int main() {
     }
 
     quit = 0;
-    printf("Multi Bouncing Balls... Press Q in the console to quit.\n");
+    printf("Multi Bouncing Balls... Press Q to quit.\n");
     while (!quit) {
-        if (keypressed()) {
-            char c;
-            c = readkey();
-            if (toupper(c) == 'Q') {
+        int keyCode;
+
+        if (quitrequested()) {
+            quit = 1;
+            break;
+        }
+        keyCode = pollkeyany();
+        while (keyCode != 0) {
+            if (keyCode == 'q' || keyCode == 'Q') {
                 quit = 1;
+                break;
             }
+            keyCode = pollkeyany();
+        }
+
+        if (quit) {
+            break;
         }
 
         i = 1;


### PR DESCRIPTION
## Summary
- allow the SDL multibouncingballs demo to quit when Q is pressed in the window by polling SDL/console input
- honor SDL quit events and update the on-screen instructions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68fde491cde8832998d711233d76c3a2