### PR TITLE
Enhance SDL spacegame example

### DIFF
--- a/Examples/clike/sdl/spacegame
+++ b/Examples/clike/sdl/spacegame
@@ -1,6 +1,6 @@
 #!/usr/bin/env clike
 /*
- * Simple Space style shooter using SDL graphics and sound.  WIP
+ * Simple Space style shooter using SDL graphics and sound.
  */
 
 str ConfiguredShotSoundPath = "@PSCAL_INSTALL_ROOT_RESOLVED@/lib/sounds/paddle_hit.wav";
@@ -15,6 +15,9 @@ int main() {
     int PlayerW;
     int PlayerH;
     int PlayerSpeed;
+    int PlayerLives;
+    int PlayerInvincibleTicks;
+    int PlayerShotCooldown;
 
     int BulletX;
     int BulletY;
@@ -25,29 +28,49 @@ int main() {
 
     const int AlienRows = 3;
     const int AlienCols = 6;
+    const int AlienCount = AlienRows * AlienCols;
     int AlienW;
     int AlienH;
     int AlienPaddingX;
     int AlienPaddingY;
     int AlienDir;
     int AlienSpeed;
+    int AlienBaseSpeed;
     int AliensAlive;
+    int AlienDiveChance;
+    int AlienFireChance;
+
     int i;
     int j;
     int minAlienX;
     int maxAlienX;
+    int mouseX;
+    int mouseY;
+    int mouseButtons;
+    int mouseInside;
     int ShotSound;
     int ExplodeSound;
     int ManualQuit;
+    int Score;
 
     /* Arrays are 1-based to match the underlying Pascal VM. */
-    int AlienX[AlienRows * AlienCols + 1];
-    int AlienY[AlienRows * AlienCols + 1];
-    int AlienAlive[AlienRows * AlienCols + 1];
+    int AlienX[AlienCount + 1];
+    int AlienY[AlienCount + 1];
+    int AlienAlive[AlienCount + 1];
+    int AlienHomeX[AlienCount + 1];
+    int AlienHomeY[AlienCount + 1];
+    int AlienDiving[AlienCount + 1];
 
+    const int MaxAlienBullets = 6;
+    int AlienBulletX[MaxAlienBullets];
+    int AlienBulletY[MaxAlienBullets];
+    int AlienBulletActive[MaxAlienBullets];
+    int AlienBulletSpeed;
+
+    randomize();
     ScreenWidth = 800;
     ScreenHeight = 600;
-    initgraph(ScreenWidth, ScreenHeight, "Space Shooter CLike(WIP)");
+    initgraph(ScreenWidth, ScreenHeight, "CLike Space Game");
 
     initsoundsystem();
     ShotSound = loadsound(ConfiguredShotSoundPath);
@@ -58,19 +81,34 @@ int main() {
     PlayerX = ScreenWidth / 2 - PlayerW / 2;
     PlayerY = ScreenHeight - PlayerH - 10;
     PlayerSpeed = 5;
+    PlayerLives = 3;
+    PlayerInvincibleTicks = 0;
+    PlayerShotCooldown = 0;
 
     BulletW = 4;
-    BulletH = 10;
-    BulletSpeed = 8;
+    BulletH = 12;
+    BulletSpeed = 10;
     BulletActive = 0;
 
     AlienW = 30;
     AlienH = 20;
     AlienPaddingX = 10;
     AlienPaddingY = 10;
-    AlienSpeed = 2;
+    AlienBaseSpeed = 2;
+    AlienSpeed = AlienBaseSpeed;
     AlienDir = 1;
     ManualQuit = 0;
+    Score = 0;
+
+    AlienFireChance = 90;
+    AlienDiveChance = 320;
+
+    AlienBulletSpeed = 6;
+    i = 0;
+    while (i < MaxAlienBullets) {
+        AlienBulletActive[i] = 0;
+        i = i + 1;
+    }
 
     i = 1;
     while (i <= AlienRows) {
@@ -78,16 +116,19 @@ int main() {
         while (j <= AlienCols) {
             int idx;
             idx = (i - 1) * AlienCols + j;
-            AlienX[idx] = 50 + (j - 1) * (AlienW + AlienPaddingX);
-            AlienY[idx] = 50 + (i - 1) * (AlienH + AlienPaddingY);
+            AlienHomeX[idx] = 80 + (j - 1) * (AlienW + AlienPaddingX);
+            AlienHomeY[idx] = 60 + (i - 1) * (AlienH + AlienPaddingY);
+            AlienX[idx] = AlienHomeX[idx];
+            AlienY[idx] = AlienHomeY[idx];
             AlienAlive[idx] = 1;
+            AlienDiving[idx] = 0;
             j = j + 1;
         }
         i = i + 1;
     }
-    AliensAlive = AlienRows * AlienCols;
+    AliensAlive = AlienCount;
 
-    while (!quitrequested() && !ManualQuit && AliensAlive > 0) {
+    while (!quitrequested() && !ManualQuit && AliensAlive > 0 && PlayerLives > 0) {
         graphloop(16);
 
         int key;
@@ -101,10 +142,11 @@ int main() {
             } else if (key == 1073741903) {
                 PlayerX = PlayerX + PlayerSpeed;
             } else if (key == 32) {
-                if (!BulletActive) {
+                if (!BulletActive && PlayerShotCooldown == 0) {
                     BulletActive = 1;
                     BulletX = PlayerX + PlayerW / 2 - BulletW / 2;
                     BulletY = PlayerY - BulletH;
+                    PlayerShotCooldown = 12;
                     if (ShotSound != -1) {
                         playsound(ShotSound);
                     }
@@ -115,12 +157,31 @@ int main() {
         if (ManualQuit) {
             break;
         }
+
+        getmousestate(&mouseX, &mouseY, &mouseButtons, &mouseInside);
+        if (mouseInside) {
+            PlayerX = mouseX - PlayerW / 2;
+            if ((mouseButtons & 1) && !BulletActive && PlayerShotCooldown == 0) {
+                BulletActive = 1;
+                BulletX = PlayerX + PlayerW / 2 - BulletW / 2;
+                BulletY = PlayerY - BulletH;
+                PlayerShotCooldown = 12;
+                if (ShotSound != -1) {
+                    playsound(ShotSound);
+                }
+            }
+        }
+
+        if (PlayerShotCooldown > 0) {
+            PlayerShotCooldown = PlayerShotCooldown - 1;
+        }
+
         if (PlayerX < 0) { PlayerX = 0; }
         if (PlayerX > ScreenWidth - PlayerW) { PlayerX = ScreenWidth - PlayerW; }
 
         if (BulletActive) {
             BulletY = BulletY - BulletSpeed;
-            if (BulletY < 0) {
+            if (BulletY + BulletH < 0) {
                 BulletActive = 0;
             }
         }
@@ -128,47 +189,82 @@ int main() {
         minAlienX = ScreenWidth;
         maxAlienX = 0;
         i = 1;
-        while (i <= AlienRows * AlienCols) {
+        while (i <= AlienCount) {
             if (AlienAlive[i]) {
-                if (AlienX[i] < minAlienX) { minAlienX = AlienX[i]; }
-                if (AlienX[i] + AlienW > maxAlienX) { maxAlienX = AlienX[i] + AlienW; }
+                if (AlienHomeX[i] < minAlienX) { minAlienX = AlienHomeX[i]; }
+                if (AlienHomeX[i] + AlienW > maxAlienX) { maxAlienX = AlienHomeX[i] + AlienW; }
             }
             i = i + 1;
         }
         if (AlienDir == 1 && maxAlienX >= ScreenWidth - 10) {
             AlienDir = -1;
             i = 1;
-            while (i <= AlienRows * AlienCols) {
-                AlienY[i] = AlienY[i] + AlienH;
+            while (i <= AlienCount) {
+                if (AlienAlive[i]) {
+                    AlienHomeY[i] = AlienHomeY[i] + AlienH;
+                    if (!AlienDiving[i]) {
+                        AlienY[i] = AlienHomeY[i];
+                    }
+                }
                 i = i + 1;
             }
         } else if (AlienDir == -1 && minAlienX <= 10) {
             AlienDir = 1;
             i = 1;
-            while (i <= AlienRows * AlienCols) {
-                AlienY[i] = AlienY[i] + AlienH;
+            while (i <= AlienCount) {
+                if (AlienAlive[i]) {
+                    AlienHomeY[i] = AlienHomeY[i] + AlienH;
+                    if (!AlienDiving[i]) {
+                        AlienY[i] = AlienHomeY[i];
+                    }
+                }
                 i = i + 1;
             }
         }
-        i = 1;
-        while (i <= AlienRows * AlienCols) {
-            if (AlienAlive[i]) {
-                AlienX[i] = AlienX[i] + AlienSpeed * AlienDir;
+
+        {
+            int delta;
+            delta = AlienSpeed * AlienDir;
+            i = 1;
+            while (i <= AlienCount) {
+                if (AlienAlive[i]) {
+                    AlienHomeX[i] = AlienHomeX[i] + delta;
+                    if (!AlienDiving[i]) {
+                        AlienX[i] = AlienX[i] + delta;
+                    } else {
+                        int targetX;
+                        targetX = PlayerX + PlayerW / 2 - AlienW / 2;
+                        if (AlienX[i] < targetX) {
+                            AlienX[i] = AlienX[i] + 3;
+                        } else if (AlienX[i] > targetX) {
+                            AlienX[i] = AlienX[i] - 3;
+                        }
+                        AlienY[i] = AlienY[i] + 4;
+                        if (AlienY[i] > ScreenHeight + AlienH) {
+                            AlienDiving[i] = 0;
+                            AlienX[i] = AlienHomeX[i];
+                            AlienY[i] = AlienHomeY[i];
+                        }
+                    }
+                }
+                i = i + 1;
             }
-            i = i + 1;
         }
 
         if (BulletActive) {
             i = 1;
-            while (i <= AlienRows * AlienCols) {
+            while (i <= AlienCount) {
                 if (AlienAlive[i]) {
                     if (BulletX < AlienX[i] + AlienW &&
                         BulletX + BulletW > AlienX[i] &&
                         BulletY < AlienY[i] + AlienH &&
                         BulletY + BulletH > AlienY[i]) {
                         AlienAlive[i] = 0;
+                        AlienDiving[i] = 0;
                         BulletActive = 0;
                         AliensAlive = AliensAlive - 1;
+                        Score = Score + 50;
+                        printf("Score: %d\n", Score);
                         if (ExplodeSound != -1) {
                             playsound(ExplodeSound);
                         }
@@ -179,27 +275,121 @@ int main() {
             }
         }
 
+        if (AliensAlive > 0) {
+            AlienSpeed = AlienBaseSpeed + (AlienCount - AliensAlive) / 4;
+            if (AlienSpeed > 6) {
+                AlienSpeed = 6;
+            }
+            if (AlienFireChance > 30 && (AlienCount - AliensAlive) > 6) {
+                AlienFireChance = 60;
+            }
+        }
+
+        if (PlayerInvincibleTicks > 0) {
+            PlayerInvincibleTicks = PlayerInvincibleTicks - 1;
+        }
+
+        if (random(AlienDiveChance) == 0) {
+            int choice;
+            choice = random(AlienCount) + 1;
+            if (AlienAlive[choice] && !AlienDiving[choice]) {
+                AlienDiving[choice] = 1;
+                AlienX[choice] = AlienHomeX[choice];
+                AlienY[choice] = AlienHomeY[choice];
+            }
+        }
+
+        if (random(AlienFireChance) == 0) {
+            int shooter;
+            shooter = random(AlienCount) + 1;
+            if (AlienAlive[shooter]) {
+                int slot;
+                slot = 0;
+                while (slot < MaxAlienBullets) {
+                    if (!AlienBulletActive[slot]) {
+                        AlienBulletActive[slot] = 1;
+                        AlienBulletX[slot] = AlienX[shooter] + AlienW / 2;
+                        AlienBulletY[slot] = AlienY[shooter] + AlienH;
+                        break;
+                    }
+                    slot = slot + 1;
+                }
+            }
+        }
+
+        i = 0;
+        while (i < MaxAlienBullets) {
+            if (AlienBulletActive[i]) {
+                AlienBulletY[i] = AlienBulletY[i] + AlienBulletSpeed;
+                if (AlienBulletY[i] > ScreenHeight) {
+                    AlienBulletActive[i] = 0;
+                } else {
+                    if (PlayerInvincibleTicks == 0 &&
+                        AlienBulletX[i] >= PlayerX &&
+                        AlienBulletX[i] <= PlayerX + PlayerW &&
+                        AlienBulletY[i] >= PlayerY &&
+                        AlienBulletY[i] <= PlayerY + PlayerH) {
+                        AlienBulletActive[i] = 0;
+                        PlayerLives = PlayerLives - 1;
+                        PlayerInvincibleTicks = 120;
+                        BulletActive = 0;
+                        printf("Hit! Lives remaining: %d\n", PlayerLives);
+                        PlayerX = ScreenWidth / 2 - PlayerW / 2;
+                    }
+                }
+            }
+            i = i + 1;
+        }
+
+        i = 1;
+        while (i <= AlienCount) {
+            if (AlienAlive[i]) {
+                if (!AlienDiving[i] && AlienY[i] + AlienH >= PlayerY) {
+                    PlayerLives = PlayerLives - 1;
+                    PlayerInvincibleTicks = 120;
+                    printf("Aliens breached the defenses! Lives remaining: %d\n", PlayerLives);
+                    break;
+                }
+            }
+            i = i + 1;
+        }
+
         cleardevice();
-        setrgbcolor(0, 255, 0);
-        /* fillrect expects top-left and bottom-right coordinates */
-        fillrect(PlayerX, PlayerY, PlayerX + PlayerW - 1, PlayerY + PlayerH - 1);
+        if (PlayerInvincibleTicks % 20 < 10 || PlayerInvincibleTicks == 0) {
+            setrgbcolor(0, 255, 0);
+            fillrect(PlayerX, PlayerY, PlayerX + PlayerW - 1, PlayerY + PlayerH - 1);
+        }
         if (BulletActive) {
             setrgbcolor(255, 255, 0);
             fillrect(BulletX, BulletY, BulletX + BulletW - 1, BulletY + BulletH - 1);
         }
         setrgbcolor(255, 0, 0);
         i = 1;
-        while (i <= AlienRows * AlienCols) {
+        while (i <= AlienCount) {
             if (AlienAlive[i]) {
                 fillrect(AlienX[i], AlienY[i], AlienX[i] + AlienW - 1, AlienY[i] + AlienH - 1);
             }
             i = i + 1;
         }
+        setrgbcolor(255, 255, 255);
+        i = 0;
+        while (i < MaxAlienBullets) {
+            if (AlienBulletActive[i]) {
+                drawline(AlienBulletX[i], AlienBulletY[i], AlienBulletX[i], AlienBulletY[i] + 6);
+            }
+            i = i + 1;
+        }
+
         updatescreen();
     }
 
     quitsoundsystem();
     closegraph();
+    if (AliensAlive == 0) {
+        printf("You saved the galaxy! Final score: %d\n", Score);
+    } else if (PlayerLives <= 0) {
+        printf("Game over. Final score: %d\n", Score);
+    }
     return 0;
 #else
     printf("SDL support not enabled.\n");


### PR DESCRIPTION
## Summary
- add mouse-driven controls, scoring, and player life tracking to the SDL spacegame demo
- enrich alien behaviour with formation offsets, random dives, and projectile attacks
- render enemy laser shots and player hit feedback for a more Galaxian-like experience

## Testing
- not run (SDL sample)


------
https://chatgpt.com/codex/tasks/task_b_68fde6e124848329be7772796f225bfd