### PR TITLE
Fix Sierpinski shell demo thread spawn

### DIFF
--- a/src/ext_builtins/user/sierpinski_threads.c
+++ b/src/ext_builtins/user/sierpinski_threads.c
@@ -138,7 +138,12 @@ Value vmBuiltinSierpinskiSpawnWorker(VM *vm, int arg_count, Value *args) {
     task->level = (int)AS_INTEGER(args[6]);
     task->drawChar = (arg_count == 8) ? coerceDrawChar(&args[7]) : '+';
 
-    int id = vmSpawnCallbackThread(vm, sierpinskiThreadEntry, task, sierpinskiThreadCleanup);
+    VM *targetVm = vm;
+    if (targetVm && targetVm->threadOwner) {
+        targetVm = targetVm->threadOwner;
+    }
+
+    int id = vmSpawnCallbackThread(targetVm, sierpinskiThreadEntry, task, sierpinskiThreadCleanup);
     if (id < 0) {
         runtimeError(vm, "SierpinskiSpawnWorker failed to spawn thread.");
         return makeInt(-1);


### PR DESCRIPTION
## Summary
- ensure SierpinskiSpawnWorker submits callback threads to the owning shell VM
- allow the threaded Sierpinski demo to render correctly once the workers run

## Testing
- SIERPINSKI_SKIP_WAIT=1 build/bin/exsh Examples/exsh/sierpinski_threads >/tmp/out.txt 2>/tmp/err.txt

------
https://chatgpt.com/codex/tasks/task_b_68fe2161e81c832990ad679638af8557