### PR TITLE
Fix Sierpinski thread demo synchronization

### DIFF
--- a/Examples/exsh/sierpinski_threads
+++ b/Examples/exsh/sierpinski_threads
@@ -495,6 +495,14 @@ else
         exit 1
     fi
 
+    trimmed_ids=${THREAD_IDS//[[:space:]]/}
+    if [ -n "$trimmed_ids" ]; then
+        if ! builtin SierpinskiReleaseWorkers >/dev/null 2>&1; then
+            echo "sierpinski_threads: failed to release worker threads." >&2
+            exit 1
+        fi
+    fi
+
     worker_failure=0
     for tid in $THREAD_IDS; do
         if run_exsh_builtin WaitForThread "int:$tid"; then

--- a/src/ext_builtins/user/register.c
+++ b/src/ext_builtins/user/register.c
@@ -25,6 +25,8 @@ void registerUserBuiltins(void) {
                                "LandscapeBakeVertexData");
     extBuiltinRegisterFunction(category, "demos",
                                "SierpinskiSpawnWorker");
+    extBuiltinRegisterFunction(category, "demos",
+                               "SierpinskiReleaseWorkers");
 
     registerLandscapeBuiltins();
     registerSierpinskiBuiltins();

--- a/src/ext_builtins/user/sierpinski_threads.c
+++ b/src/ext_builtins/user/sierpinski_threads.c
@@ -4,6 +4,7 @@
 #include "Pascal/globals.h"
 
 #include <pthread.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -19,6 +20,29 @@ typedef struct {
 } SierpinskiWorkerTask;
 
 static pthread_mutex_t gSierpinskiMutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t gSierpinskiStartMutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t gSierpinskiStartCond = PTHREAD_COND_INITIALIZER;
+static int gSierpinskiPendingWorkers = 0;
+static bool gSierpinskiWorkersReleased = false;
+
+static void sierpinskiWorkerAwaitRelease(void) {
+    pthread_mutex_lock(&gSierpinskiStartMutex);
+    while (!gSierpinskiWorkersReleased) {
+        pthread_cond_wait(&gSierpinskiStartCond, &gSierpinskiStartMutex);
+    }
+    pthread_mutex_unlock(&gSierpinskiStartMutex);
+}
+
+static void sierpinskiWorkerFinished(void) {
+    pthread_mutex_lock(&gSierpinskiStartMutex);
+    if (gSierpinskiPendingWorkers > 0) {
+        gSierpinskiPendingWorkers--;
+        if (gSierpinskiPendingWorkers == 0) {
+            gSierpinskiWorkersReleased = false;
+        }
+    }
+    pthread_mutex_unlock(&gSierpinskiStartMutex);
+}
 
 static void sierpinskiDrawPoint(VM *vm, int x, int y, char drawChar) {
     if (!vm) {
@@ -78,6 +102,8 @@ static void sierpinskiThreadEntry(VM *threadVm, void *user_data) {
         return;
     }
 
+    sierpinskiWorkerAwaitRelease();
+
     int level = task->level >= 0 ? task->level : 0;
     sierpinskiDrawRecursive(threadVm,
                             task->x1,
@@ -88,6 +114,8 @@ static void sierpinskiThreadEntry(VM *threadVm, void *user_data) {
                             task->y3,
                             level,
                             task->drawChar);
+
+    sierpinskiWorkerFinished();
 }
 
 static void sierpinskiThreadCleanup(void *user_data) {
@@ -143,16 +171,44 @@ Value vmBuiltinSierpinskiSpawnWorker(VM *vm, int arg_count, Value *args) {
         targetVm = targetVm->threadOwner;
     }
 
+    pthread_mutex_lock(&gSierpinskiStartMutex);
+    if (gSierpinskiPendingWorkers == 0) {
+        gSierpinskiWorkersReleased = false;
+    }
+    pthread_mutex_unlock(&gSierpinskiStartMutex);
+
     int id = vmSpawnCallbackThread(targetVm, sierpinskiThreadEntry, task, sierpinskiThreadCleanup);
     if (id < 0) {
         runtimeError(vm, "SierpinskiSpawnWorker failed to spawn thread.");
         return makeInt(-1);
     }
 
+    pthread_mutex_lock(&gSierpinskiStartMutex);
+    gSierpinskiPendingWorkers++;
+    pthread_mutex_unlock(&gSierpinskiStartMutex);
+
     return makeInt(id);
+}
+
+Value vmBuiltinSierpinskiReleaseWorkers(VM *vm, int arg_count, Value *args) {
+    (void)args;
+
+    if (arg_count != 0) {
+        runtimeError(vm, "SierpinskiReleaseWorkers expects no arguments.");
+        return makeVoid();
+    }
+
+    pthread_mutex_lock(&gSierpinskiStartMutex);
+    gSierpinskiWorkersReleased = true;
+    pthread_cond_broadcast(&gSierpinskiStartCond);
+    pthread_mutex_unlock(&gSierpinskiStartMutex);
+
+    return makeVoid();
 }
 
 void registerSierpinskiBuiltins(void) {
     registerVmBuiltin("SierpinskiSpawnWorker", vmBuiltinSierpinskiSpawnWorker,
                       BUILTIN_TYPE_FUNCTION, NULL);
+    registerVmBuiltin("SierpinskiReleaseWorkers", vmBuiltinSierpinskiReleaseWorkers,
+                      BUILTIN_TYPE_PROCEDURE, NULL);
 }


### PR DESCRIPTION
## Summary
- add a release barrier around threaded Sierpinski workers so they wait for the shell to finish spawning them
- expose a new `SierpinskiReleaseWorkers` builtin and update the exsh demo to use it before joining the workers
- only trigger the release step when at least one worker was spawned

## Testing
- `SIERPINSKI_SKIP_WAIT=1 build/bin/exsh Examples/exsh/sierpinski_threads`

------
https://chatgpt.com/codex/tasks/task_b_68fe282664b88329a136c8f12315eb52