### PR TITLE
Handle non-numeric recursion levels in exsh Sierpinski demo

### DIFF
--- a/Examples/exsh/sierpinski
+++ b/Examples/exsh/sierpinski
@@ -373,6 +373,20 @@ draw_sierpinski() {
     local y3="$6"
     local level="$7"
 
+    local sanitized_level
+
+    if [ "${level#-}" != "$level" ]; then
+        sanitized_level=${level#-}
+    else
+        sanitized_level=$level
+    fi
+
+    case "$sanitized_level" in
+        ''|*[!0-9]*)
+            level=0
+            ;;
+    esac
+
     if [ "$level" -le 0 ]; then
         draw_point "$x1" "$y1"
         draw_point "$x2" "$y2"


### PR DESCRIPTION
## Summary
- normalize the recursion level argument in the sequential Sierpinski demo so numeric comparisons no longer fail when the value is missing or malformed

## Testing
- not run (demo script only)


------
https://chatgpt.com/codex/tasks/task_b_68fe3c744b4883299410b12461f28a97