### PR TITLE
Fix Pascal string literal escape handling

### DIFF
--- a/src/Pascal/lexer.c
+++ b/src/Pascal/lexer.c
@@ -442,7 +442,6 @@ Token *stringLiteral(Lexer *lexer) {
                 case 'a': escaped_char = '\a'; break;
                 case 'e': escaped_char = '\x1B'; break;
                 case '\\': escaped_char = '\\'; break;
-                case '\'': escaped_char = '\''; break;
                 default: recognized = false; break;
             }
 


### PR DESCRIPTION
## Summary
- treat backslash-apostrophe sequences as literal backslashes so Pascal string literals close correctly

## Testing
- build/bin/pascal Tests/Pascal/HttpAsyncFileURL

------
https://chatgpt.com/codex/tasks/task_b_68fe42b4abb083299d093cf913bc5aa3