### PR TITLE
Fix Pascal set literal constant handling

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -6001,8 +6001,18 @@ static void compileRValue(AST* node, BytecodeChunk* chunk, int current_line_appr
                                 addOrdinalToSetValue(&set_const_val, j);
                             }
                         } else {
-                            for (long long j = start_ord; j >= end_ord; j--) {
+                            long long j = start_ord;
+                            while (true) {
                                 addOrdinalToSetValue(&set_const_val, j);
+                                if (j == end_ord) {
+                                    break;
+                                }
+                                if (j == LLONG_MIN) {
+                                    fprintf(stderr, "L%d: Compiler error: Set range lower bound underflows ordinal minimum.\\n", getLine(member));
+                                    compiler_had_error = true;
+                                    break;
+                                }
+                                j--;
                             }
                         }
                     } else {


### PR DESCRIPTION
## Summary
- ensure Pascal set literals resolve ordinals through constants and enum aliases instead of failing on compile-time evaluation
- restore the HttpAsyncDemo example to use StringReplace with rfReplaceAll now that the compiler supports set constants again

## Testing
- not run (pascal interpreter unavailable in container)

------
https://chatgpt.com/codex/tasks/task_b_68fe51d2c1f4832993249aacbf13979d