### PR TITLE
Prevent duplicate playback status in psound demo

### DIFF
--- a/Examples/pascal/base/psound
+++ b/Examples/pascal/base/psound
@@ -193,14 +193,8 @@ begin
       writeln('Sound finished playing.');
     end;
 
-    if QuitRequested then
+    if not QuitRequested then
     begin
-      writeln('Playback interrupted by user.');
-    end
-    else
-    begin
-      writeln('Sound finished playing.');
-
       // Free the loaded sound from memory when done.
       writeln('Freeing sound...');
       FreeSound(SoundID);


### PR DESCRIPTION
## Summary
- adjust the psound example so that it only prints the playback status message once
- keep sound cleanup logic while avoiding duplicate status output when playback completes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ff072059708329abdb9d1b15b3ec1e