### PR TITLE
Make Mandelbrot demos adjust iteration caps during zoom

### DIFF
--- a/Examples/clike/sdl/mandelbrot_interactive
+++ b/Examples/clike/sdl/mandelbrot_interactive
@@ -6,7 +6,9 @@
 
 const int Width = 1200;
 const int Height = 900;
-const int MaxIterations = 200;
+const int BaseIterations = 200;
+const int IterationStep = 50;
+const int MaxIterationCap = 1000;
 const int BytesPerPixel = 4;
 const int ScreenUpdateInterval = 1; /* update every row for responsiveness */
 const double ZoomFactor = 2.0;
@@ -50,9 +52,39 @@ int computing = 0;
 int nextPresentRow = 0;
 int tid[ThreadCount];
 int textReady = 0;
+int currentIterations = BaseIterations;
+double initialSpanRe = 0.0;
 
 
 #ifdef SDL_ENABLED
+void updateIterationLimit(double span) {
+    double baseSpan = initialSpanRe;
+    double localSpan = span;
+    int zoomSteps = 0;
+    if (baseSpan <= 0.0) {
+        baseSpan = localSpan;
+    }
+    if (localSpan <= 0.0) {
+        localSpan = baseSpan;
+    }
+    if (baseSpan > 0.0 && localSpan > 0.0) {
+        double ratio = baseSpan / localSpan;
+        if (ratio > 1.0) {
+            while (ratio >= 2.0 && (BaseIterations + (zoomSteps + 1) * IterationStep) <= MaxIterationCap) {
+                zoomSteps++;
+                ratio /= 2.0;
+            }
+        }
+    }
+    if (zoomSteps < 0) {
+        zoomSteps = 0;
+    }
+    currentIterations = BaseIterations + zoomSteps * IterationStep;
+    if (currentIterations > MaxIterationCap) {
+        currentIterations = MaxIterationCap;
+    }
+}
+
 int getQuit() {
     int q;
     lock(quitMutex);
@@ -86,11 +118,13 @@ void applyViewBounds(double newMinRe, double newMaxRe, double newMinIm, double n
     maxRe = newMaxRe;
     minIm = newMinIm;
     maxIm = newMaxIm;
+    updateIterationLimit(maxRe - minRe);
 }
 
 void commitPendingViewBounds() {
     if (hasPendingBounds) {
         applyViewBounds(pendingMinRe, pendingMaxRe, pendingMinIm, pendingMaxIm);
+        updateIterationLimit(maxRe - minRe);
         hasPendingBounds = 0;
     }
 }
@@ -379,11 +413,11 @@ void computeRows(int startY, int endY) {
     for (y = startY; y <= endY && !getQuit(); y++) {
         if (getAbortRender()) break;
         c_im = maxIm - y * imFactor;
-        mandelbrotrow(minRe, reFactor, c_im, MaxIterations, Width - 1, &row);
+        mandelbrotrow(minRe, reFactor, c_im, currentIterations, Width - 1, &row);
         idx = y * Width * BytesPerPixel;
         for (x = 0; x < Width; x++) {
             n = row[x];
-            if (n == MaxIterations) { R = G = B = 0; }
+            if (n == currentIterations) { R = G = B = 0; }
             else {
                 R = (n * 5) % 256;
                 G = (n * 7 + 85) % 256;
@@ -429,6 +463,12 @@ int main() {
     abortMutex = mutex();
 
     resetThreadIds();
+
+    initialSpanRe = maxRe - minRe;
+    if (initialSpanRe <= 0.0) {
+        initialSpanRe = 1.0;
+    }
+    updateIterationLimit(maxRe - minRe);
 
     while (!getQuit()) {
         pollRenderProgress();

--- a/Examples/pascal/sdl/InteractiveMandelbrot_ext
+++ b/Examples/pascal/sdl/InteractiveMandelbrot_ext
@@ -7,7 +7,9 @@ CONST
   MandelWindowWidth   = 1024;
   MandelWindowHeight  = 768;
   MandelWindowTitle   = 'Mandelbrot (Builtin Row - LMB:Zoom, RMB:Reset, Q:Quit)';
-  MandelMaxIterations = 50;
+  BaseIterations      = 50;
+  IterationStep       = 50;
+  MaxIterationCap     = 1000;
   MandelZoomFactor    = 2.0;
   MandelBytesPerPixel = 4;
   MandelTextureUpdateIntervalRows = 1;
@@ -34,6 +36,9 @@ VAR
   ViewPixelWidth, ViewPixelHeight : Integer;
   ReRange, ImRange           : Real;
   ScaleRe, ScaleIm           : Real;
+
+  InitialSpanRe : Real;
+  CurrentMaxIterations : Integer;
 
   MandelTextureID : Integer;
   PixelData, DisplayPixelData : PixelBuffer;
@@ -76,6 +81,34 @@ BEGIN
     SetLength(RowDone, ViewPixelHeight);
 END;
 
+PROCEDURE RecomputeMaxIterations;
+VAR
+  spanRe, baseSpan, zoomRatio : Real;
+  zoomSteps : Integer;
+BEGIN
+  baseSpan := InitialSpanRe;
+  IF baseSpan <= 0.0 THEN
+    baseSpan := MaxRe - MinRe;
+
+  spanRe := MaxRe - MinRe;
+  IF spanRe <= 0.0 THEN
+    spanRe := baseSpan;
+
+  zoomSteps := 0;
+  IF (spanRe > 0.0) AND (baseSpan > 0.0) THEN BEGIN
+    zoomRatio := baseSpan / spanRe;
+    IF zoomRatio > 0.0 THEN
+      zoomSteps := Trunc(Ln(zoomRatio) / Ln(2.0));
+  END;
+
+  IF zoomSteps < 0 THEN
+    zoomSteps := 0;
+
+  CurrentMaxIterations := BaseIterations + (zoomSteps * IterationStep);
+  IF CurrentMaxIterations > MaxIterationCap THEN
+    CurrentMaxIterations := MaxIterationCap;
+END;
+
 // This procedure recalculates MaxIm and scaling factors based on CURRENT MinRe, MaxRe, MinIm
 PROCEDURE UpdateScalingAndDependentViewParams;
 BEGIN
@@ -98,10 +131,12 @@ BEGIN
   ELSE IF ViewPixelHeight = 1 THEN ScaleIm := ImRange
   ELSE ScaleIm := 0;
 
+  RecomputeMaxIterations;
+
   // Update console display
   GotoXY(1, 2); ClrEol; Write('View: Re[', MinRe:0:4,'..',MaxRe:0:4,'], Im[',MinIm:0:4,'..',MaxIm:0:4,']');
   GotoXY(1, ControlsStartY + 4); ClrEol;
-  Write('Max Iter: ', MandelMaxIterations, ', Zoom Factor: ', MandelZoomFactor:0:1, ', Texture ID: ', MandelTextureID); ClrEol;
+  Write('Max Iter: ', CurrentMaxIterations, ', Zoom Factor: ', MandelZoomFactor:0:1, ', Texture ID: ', MandelTextureID); ClrEol;
   EnsurePixelBuffersSized;
 END;
 
@@ -110,6 +145,8 @@ BEGIN
   MinRe := InitialMinRe;
   MaxRe := InitialMaxRe;
   MinIm := InitialMinIm;
+  InitialSpanRe := MaxRe - MinRe;
+  RecomputeMaxIterations;
   UpdateScalingAndDependentViewParams; // Now calculate MaxIm and scales for these initial values
 END;
 
@@ -165,10 +202,10 @@ BEGIN
       BREAK;
     END;
     y0 := MaxIm - (LocalPy * ScaleIm);
-    MandelbrotRow(MinRe, ScaleRe, y0, MandelMaxIterations, ViewPixelWidth - 1, RowIterations);
+    MandelbrotRow(MinRe, ScaleRe, y0, CurrentMaxIterations, ViewPixelWidth - 1, RowIterations);
     FOR LocalPx := 0 TO ViewPixelWidth - 1 DO BEGIN
       Iteration := RowIterations[LocalPx];
-      IF Iteration = MandelMaxIterations THEN BEGIN
+      IF Iteration = CurrentMaxIterations THEN BEGIN
         R_calc := Byte(0);
         G_calc := Byte(0);
         B_calc := Byte(0);
@@ -349,6 +386,7 @@ BEGIN
     MinRe := InitialMinRe;
     MaxRe := InitialMaxRe;
     MinIm := InitialMinIm;
+    RecomputeMaxIterations;
     UpdateScalingAndDependentViewParams;
     RedrawNeeded := True;
     GotoXY(1,StatusLineY); ClrEol; Write('Resetting view...');

--- a/Examples/pascal/sdl/InteractiveMandelbrot_native
+++ b/Examples/pascal/sdl/InteractiveMandelbrot_native
@@ -7,7 +7,9 @@ CONST
   MandelWindowWidth   = 800;
   MandelWindowHeight  = 600;
   MandelWindowTitle   = 'Mandelbrot (Zoom Fixed - LMB:Zoom, RMB:Reset, Q:Quit)';
-  MandelMaxIterations = 50;
+  BaseIterations      = 50;
+  IterationStep       = 50;
+  MaxIterationCap     = 1000;
   MandelZoomFactor    = 2.0;
   MandelBytesPerPixel = 4;
   MandelTextureUpdateIntervalRows = 1;
@@ -32,6 +34,9 @@ VAR
   ReRange, ImRange           : Real;
   ScaleRe, ScaleIm           : Real;
 
+  InitialSpanRe : Real;
+  CurrentMaxIterations : Integer;
+
   MandelTextureID : Integer;
   PixelData, DisplayPixelData : FlatPixelBuffer;
   QuitProgram     : Boolean;
@@ -55,6 +60,34 @@ VAR
   i : Integer;
 
 // This procedure recalculates MaxIm and scaling factors based on CURRENT MinRe, MaxRe, MinIm
+PROCEDURE RecomputeMaxIterations;
+VAR
+  spanRe, baseSpan, zoomRatio : Real;
+  zoomSteps : Integer;
+BEGIN
+  baseSpan := InitialSpanRe;
+  IF baseSpan <= 0.0 THEN
+    baseSpan := MaxRe - MinRe;
+
+  spanRe := MaxRe - MinRe;
+  IF spanRe <= 0.0 THEN
+    spanRe := baseSpan;
+
+  zoomSteps := 0;
+  IF (spanRe > 0.0) AND (baseSpan > 0.0) THEN BEGIN
+    zoomRatio := baseSpan / spanRe;
+    IF zoomRatio > 0.0 THEN
+      zoomSteps := Trunc(Ln(zoomRatio) / Ln(2.0));
+  END;
+
+  IF zoomSteps < 0 THEN
+    zoomSteps := 0;
+
+  CurrentMaxIterations := BaseIterations + (zoomSteps * IterationStep);
+  IF CurrentMaxIterations > MaxIterationCap THEN
+    CurrentMaxIterations := MaxIterationCap;
+END;
+
 PROCEDURE UpdateScalingAndDependentViewParams;
 BEGIN
   // GetMaxX/Y are based on InitGraph, which uses MandelWindowWidth/Height constants for texture too
@@ -76,10 +109,12 @@ BEGIN
   ELSE IF ViewPixelHeight = 1 THEN ScaleIm := ImRange
   ELSE ScaleIm := 0;
 
+  RecomputeMaxIterations;
+
   // Update console display
   GotoXY(1, 2); ClrEol; Write('View: Re[', MinRe:0:4,'..',MaxRe:0:4,'], Im[',MinIm:0:4,'..',MaxIm:0:4,']');
   GotoXY(1, ControlsStartY + 4); ClrEol;
-  Write('Max Iter: ', MandelMaxIterations, ', Zoom Factor: ', MandelZoomFactor:0:1, ', Texture ID: ', MandelTextureID); ClrEol;
+  Write('Max Iter: ', CurrentMaxIterations, ', Zoom Factor: ', MandelZoomFactor:0:1, ', Texture ID: ', MandelTextureID); ClrEol;
 END;
 
 PROCEDURE ResetViewToInitial;
@@ -87,6 +122,8 @@ BEGIN
   MinRe := InitialMinRe;
   MaxRe := InitialMaxRe;
   MinIm := InitialMinIm;
+  InitialSpanRe := MaxRe - MinRe;
+  RecomputeMaxIterations;
   UpdateScalingAndDependentViewParams; // Now calculate MaxIm and scales for these initial values
 END;
 
@@ -108,13 +145,13 @@ BEGIN
     FOR LocalPx := 0 TO ViewPixelWidth - 1 DO BEGIN
       x0 := MinRe + (LocalPx * ScaleRe); y0 := MaxIm - (LocalPy * ScaleIm);
       zx := 0.0; zy := 0.0; Iteration := 0;
-      WHILE (zx*zx + zy*zy <= 4.0) AND (Iteration < MandelMaxIterations) DO BEGIN
+      WHILE (zx*zx + zy*zy <= 4.0) AND (Iteration < CurrentMaxIterations) DO BEGIN
         zxTemp := zx*zx - zy*zy + x0;
         zy := 2*zx*zy + y0;
         zx := zxTemp;
         Iteration := Iteration + 1;
       END;
-      IF Iteration = MandelMaxIterations THEN BEGIN
+      IF Iteration = CurrentMaxIterations THEN BEGIN
         R_calc := Byte(0);
         G_calc := Byte(0);
         B_calc := Byte(0);
@@ -181,6 +218,7 @@ BEGIN
     MinRe := InitialMinRe;
     MaxRe := InitialMaxRe;
     MinIm := InitialMinIm;
+    RecomputeMaxIterations;
     UpdateScalingAndDependentViewParams;
     RedrawNeeded := True;
     GotoXY(1,StatusLineY); ClrEol; Write('Resetting view...');

--- a/Examples/rea/sdl/mandelbrot_interactive
+++ b/Examples/rea/sdl/mandelbrot_interactive
@@ -25,7 +25,6 @@ str resolveFontPath() {
 class MandelbrotApp {
   const int Width = 800;
   const int Height = 600;
-  const int MaxIterations = 100;
   const int BytesPerPixel = 4;
   const int ScreenUpdateInterval = 1;
   // Minimum rows between UI texture updates; actual threshold adapts to image size and thread count.
@@ -59,6 +58,37 @@ class MandelbrotApp {
   int tids[ThreadCount];
   int lastUpdatedRows;
   int pollCounter;
+  int baseIterations;
+  int iterationStep;
+  int maxIterationCap;
+  int currentIterations;
+  double initialSpanRe;
+
+  str renderStatusLabel() {
+    return "Rendering... (max " + inttostr(myself.currentIterations) + ")";
+  }
+
+  void updateIterationLimit() {
+    double baseSpan = myself.initialSpanRe;
+    double span = myself.maxRe - myself.minRe;
+    int zoomSteps = 0;
+    if (baseSpan <= 0.0) { baseSpan = span; }
+    if (span <= 0.0) { span = baseSpan; }
+    if (baseSpan > 0.0 && span > 0.0) {
+      double ratio = baseSpan / span;
+      if (ratio > 1.0) {
+        while (ratio >= 2.0 && (myself.baseIterations + (zoomSteps + 1) * myself.iterationStep) <= myself.maxIterationCap) {
+          zoomSteps = zoomSteps + 1;
+          ratio = ratio / 2.0;
+        }
+      }
+    }
+    if (zoomSteps < 0) zoomSteps = 0;
+    myself.currentIterations = myself.baseIterations + zoomSteps * myself.iterationStep;
+    if (myself.currentIterations > myself.maxIterationCap) {
+      myself.currentIterations = myself.maxIterationCap;
+    }
+  }
 
   void init() {
     printf("[int] init: begin\n");
@@ -87,6 +117,13 @@ class MandelbrotApp {
     for (i = 0; i < myself.ThreadCount; i = i + 1) { myself.tids[i] = -1; }
     myself.lastUpdatedRows = 0;
     myself.pollCounter = 0;
+    myself.baseIterations = 100;
+    myself.iterationStep = 50;
+    myself.maxIterationCap = 1000;
+    myself.currentIterations = myself.baseIterations;
+    myself.initialSpanRe = myself.maxRe - myself.minRe;
+    if (myself.initialSpanRe <= 0.0) { myself.initialSpanRe = 1.0; }
+    myself.updateIterationLimit();
   }
 
   int getQuit() {
@@ -123,11 +160,11 @@ class MandelbrotApp {
     double c_im;
     for (y = startY; y <= endY && !myself.getQuit() && !myself.getCancel(); y = y + 1) {
       c_im = myself.maxIm - y * myself.imFactor;
-      mandelbrotrow(myself.minRe, myself.reFactor, c_im, myself.MaxIterations, myself.Width - 1, row);
+      mandelbrotrow(myself.minRe, myself.reFactor, c_im, myself.currentIterations, myself.Width - 1, row);
       idx = y * myself.Width * myself.BytesPerPixel;
       for (x = 0; x < myself.Width; x = x + 1) {
         n = row[x];
-        if (n == myself.MaxIterations) { R = G = B = 0; }
+        if (n == myself.currentIterations) { R = G = B = 0; }
         else {
           R = (n * 5) % 256;
           G = (n * 7 + 85) % 256;
@@ -206,14 +243,14 @@ class MandelbrotApp {
     shouldUpdate = (initialFrame || (periodicTick && (doneCount > myself.lastUpdatedRows)) || (doneCount == myself.Height));
     if (shouldUpdate) {
       updatetexture(myself.textureID, myself.pixels);
-      cleardevice(); rendercopy(myself.textureID); outtextxy(8, 8, "Rendering..."); updatescreen();
+      cleardevice(); rendercopy(myself.textureID); outtextxy(8, 8, myself.renderStatusLabel()); updatescreen();
       myself.lastUpdatedRows = doneCount;
     }
     // Finalize when all rows are done or cancelled
     if ((doneCount == myself.Height) || myself.getCancel()) {
       if (doneCount > myself.lastUpdatedRows) {
         updatetexture(myself.textureID, myself.pixels);
-        cleardevice(); rendercopy(myself.textureID); outtextxy(8, 8, "Rendering..."); updatescreen();
+        cleardevice(); rendercopy(myself.textureID); outtextxy(8, 8, myself.renderStatusLabel()); updatescreen();
         myself.lastUpdatedRows = doneCount;
       }
       myself.joinAndResetThreads();
@@ -243,11 +280,13 @@ class MandelbrotApp {
     myself.maxRe = centerRe + widthRe / 2.0;
     myself.minIm = centerIm - heightIm / 2.0;
     myself.maxIm = centerIm + heightIm / 2.0;
+    myself.updateIterationLimit();
   }
 
   bool handleInput() {
     graphloop(0);
     bool changed = false;
+    bool keyboardChanged = false;
     int key = pollkeyany();
     while (key != 0) {
       if (key == 'q' || key == 'Q') {
@@ -258,10 +297,10 @@ class MandelbrotApp {
       double heightIm = (myself.maxIm - myself.minIm);
       double dx = widthRe * 0.5;
       double dy = heightIm * 0.5;
-      if (key == myself.KEY_LEFT) { myself.minRe -= dx; myself.maxRe -= dx; changed = true; }
-      else if (key == myself.KEY_RIGHT) { myself.minRe += dx; myself.maxRe += dx; changed = true; }
-      else if (key == myself.KEY_UP) { myself.minIm += dy; myself.maxIm += dy; changed = true; }
-      else if (key == myself.KEY_DOWN) { myself.minIm -= dy; myself.maxIm -= dy; changed = true; }
+      if (key == myself.KEY_LEFT) { myself.minRe -= dx; myself.maxRe -= dx; changed = true; keyboardChanged = true; }
+      else if (key == myself.KEY_RIGHT) { myself.minRe += dx; myself.maxRe += dx; changed = true; keyboardChanged = true; }
+      else if (key == myself.KEY_UP) { myself.minIm += dy; myself.maxIm += dy; changed = true; keyboardChanged = true; }
+      else if (key == myself.KEY_DOWN) { myself.minIm -= dy; myself.maxIm -= dy; changed = true; keyboardChanged = true; }
       key = pollkeyany();
     }
     int x = 0;
@@ -288,6 +327,9 @@ class MandelbrotApp {
       changed = true;
     }
     myself.prevButtons = b;
+    if (keyboardChanged) {
+      myself.updateIterationLimit();
+    }
     return changed;
   }
 

--- a/Examples/rea/sdl/mandelbrot_interactive_ext
+++ b/Examples/rea/sdl/mandelbrot_interactive_ext
@@ -25,7 +25,6 @@ str resolveFontPath() {
 class MandelbrotApp {
   const int Width = 1024;
   const int Height = 768;
-  const int MaxIterations = 100;
   const int BytesPerPixel = 4;
   const int ScreenUpdateInterval = 1;
   const int UpdateQuantum = 4;
@@ -58,6 +57,37 @@ class MandelbrotApp {
   int tids[ThreadCount];
   int lastUpdatedRows;
   int pollCounter;
+  int baseIterations;
+  int iterationStep;
+  int maxIterationCap;
+  int currentIterations;
+  double initialSpanRe;
+
+  str renderStatusLabel() {
+    return "Rendering... (max " + inttostr(myself.currentIterations) + ")";
+  }
+
+  void updateIterationLimit() {
+    double baseSpan = myself.initialSpanRe;
+    double span = myself.maxRe - myself.minRe;
+    int zoomSteps = 0;
+    if (baseSpan <= 0.0) { baseSpan = span; }
+    if (span <= 0.0) { span = baseSpan; }
+    if (baseSpan > 0.0 && span > 0.0) {
+      double ratio = baseSpan / span;
+      if (ratio > 1.0) {
+        while (ratio >= 2.0 && (myself.baseIterations + (zoomSteps + 1) * myself.iterationStep) <= myself.maxIterationCap) {
+          zoomSteps = zoomSteps + 1;
+          ratio = ratio / 2.0;
+        }
+      }
+    }
+    if (zoomSteps < 0) zoomSteps = 0;
+    myself.currentIterations = myself.baseIterations + zoomSteps * myself.iterationStep;
+    if (myself.currentIterations > myself.maxIterationCap) {
+      myself.currentIterations = myself.maxIterationCap;
+    }
+  }
 
   void init() {
     myself.minRe = -2.0;
@@ -80,6 +110,13 @@ class MandelbrotApp {
     for (i = 0; i < myself.ThreadCount; i = i + 1) { myself.tids[i] = -1; }
     myself.lastUpdatedRows = 0;
     myself.pollCounter = 0;
+    myself.baseIterations = 100;
+    myself.iterationStep = 50;
+    myself.maxIterationCap = 1000;
+    myself.currentIterations = myself.baseIterations;
+    myself.initialSpanRe = myself.maxRe - myself.minRe;
+    if (myself.initialSpanRe <= 0.0) { myself.initialSpanRe = 1.0; }
+    myself.updateIterationLimit();
   }
 
   int getQuit() {
@@ -101,11 +138,11 @@ class MandelbrotApp {
     double c_im;
     for (y = startY; y <= endY && !myself.getQuit() && !myself.getCancel(); y = y + 1) {
       c_im = myself.maxIm - y * myself.imFactor;
-      mandelbrotrow(myself.minRe, myself.reFactor, c_im, myself.MaxIterations, myself.Width - 1, row);
+      mandelbrotrow(myself.minRe, myself.reFactor, c_im, myself.currentIterations, myself.Width - 1, row);
       idx = y * myself.Width * myself.BytesPerPixel;
       for (x = 0; x < myself.Width; x = x + 1) {
         n = row[x];
-        if (n == myself.MaxIterations) { R = G = B = 0; }
+        if (n == myself.currentIterations) { R = G = B = 0; }
         else { R = (n * 5) % 256; G = (n * 7 + 85) % 256; B = (n * 11 + 170) % 256; }
         myself.pixels[idx + 0] = char(R);
         myself.pixels[idx + 1] = char(G);
@@ -188,14 +225,14 @@ class MandelbrotApp {
     shouldUpdate = (initialFrame || (periodicTick && (doneCount > myself.lastUpdatedRows)) || (doneCount == myself.Height));
     if (shouldUpdate) {
       updatetexture(myself.textureID, myself.pixels);
-      cleardevice(); rendercopy(myself.textureID); outtextxy(8, 8, "Rendering..."); updatescreen();
+      cleardevice(); rendercopy(myself.textureID); outtextxy(8, 8, myself.renderStatusLabel()); updatescreen();
       myself.lastUpdatedRows = doneCount;
     }
     // Finalize when all rows are done or cancelled
     if ((doneCount == myself.Height) || myself.getCancel()) {
       if (doneCount > myself.lastUpdatedRows) {
         updatetexture(myself.textureID, myself.pixels);
-        cleardevice(); rendercopy(myself.textureID); outtextxy(8, 8, "Rendering..."); updatescreen();
+        cleardevice(); rendercopy(myself.textureID); outtextxy(8, 8, myself.renderStatusLabel()); updatescreen();
         myself.lastUpdatedRows = doneCount;
       }
       myself.finishThreads();
@@ -215,11 +252,13 @@ class MandelbrotApp {
     myself.maxRe = centerRe + widthRe / 2.0;
     myself.minIm = centerIm - heightIm / 2.0;
     myself.maxIm = centerIm + heightIm / 2.0;
+    myself.updateIterationLimit();
   }
 
   bool handleInput() {
     graphloop(0);
     bool changed = false;
+    bool keyboardChanged = false;
     int key = pollkeyany();
     while (key != 0) {
       if (key == 'q' || key == 'Q') {
@@ -230,10 +269,10 @@ class MandelbrotApp {
       double heightIm = (myself.maxIm - myself.minIm);
       double dx = widthRe * 0.5;
       double dy = heightIm * 0.5;
-      if (key == myself.KEY_LEFT) { myself.minRe -= dx; myself.maxRe -= dx; changed = true; }
-      else if (key == myself.KEY_RIGHT) { myself.minRe += dx; myself.maxRe += dx; changed = true; }
-      else if (key == myself.KEY_UP) { myself.minIm += dy; myself.maxIm += dy; changed = true; }
-      else if (key == myself.KEY_DOWN) { myself.minIm -= dy; myself.maxIm -= dy; changed = true; }
+      if (key == myself.KEY_LEFT) { myself.minRe -= dx; myself.maxRe -= dx; changed = true; keyboardChanged = true; }
+      else if (key == myself.KEY_RIGHT) { myself.minRe += dx; myself.maxRe += dx; changed = true; keyboardChanged = true; }
+      else if (key == myself.KEY_UP) { myself.minIm += dy; myself.maxIm += dy; changed = true; keyboardChanged = true; }
+      else if (key == myself.KEY_DOWN) { myself.minIm -= dy; myself.maxIm -= dy; changed = true; keyboardChanged = true; }
       key = pollkeyany();
     }
     int x = 0;
@@ -260,6 +299,9 @@ class MandelbrotApp {
       changed = true;
     }
     myself.prevButtons = b;
+    if (keyboardChanged) {
+      myself.updateIterationLimit();
+    }
     return changed;
   }
 
@@ -283,7 +325,7 @@ class MandelbrotApp {
         myself.setCancel(false);
         needRender = true;
         updatetexture(myself.textureID, myself.pixels);
-        cleardevice(); rendercopy(myself.textureID); updatescreen();
+        cleardevice(); rendercopy(myself.textureID); outtextxy(8, 8, myself.renderStatusLabel()); updatescreen();
       }
     }
     if (myself.computing) {


### PR DESCRIPTION
## Summary
- add dynamic iteration caps to the Pascal interactive Mandelbrot demos and refresh their status displays
- teach the CLike SDL Mandelbrot sample to recompute iteration limits as the view zooms or pans
- update the Rea Mandelbrot demos to track base spans, recalculate iteration budgets, and surface the limits in their overlays

## Testing
- cmake -S . -B build -DSDL=ON
- cmake --build build
- SDL_VIDEODRIVER=dummy build/bin/pascal Examples/pascal/sdl/InteractiveMandelbrot_native

------
https://chatgpt.com/codex/tasks/task_b_68ff5f40a2548329a11eb8dcdb414a89