### PR TITLE
Handle minus/equals names in SDL IsKeyDown

### DIFF
--- a/src/backend_ast/sdl.c
+++ b/src/backend_ast/sdl.c
@@ -208,6 +208,12 @@ static SDL_Scancode resolveScancodeFromName(const char* name) {
     if (strcmp(compact, "enter") == 0 || strcmp(compact, "return") == 0) {
         return SDL_SCANCODE_RETURN;
     }
+    if (strcmp(compact, "minus") == 0 || strcmp(compact, "hyphen") == 0) {
+        return SDL_SCANCODE_MINUS;
+    }
+    if (strcmp(compact, "equals") == 0 || strcmp(compact, "equal") == 0) {
+        return SDL_SCANCODE_EQUALS;
+    }
 
     char normalized[64];
     size_t normLen = srcLen;


### PR DESCRIPTION
## Summary
- allow the SDL input helper to resolve "minus"/"hyphen" and "equals"/"equal" into the appropriate scancodes
- prevent IsKeyDown from rejecting the speed controls in the inner planets demo

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68ff993b17148329980d32050cefa55a