### PR TITLE
Handle SDL text input in pollkeyany

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -2505,8 +2505,13 @@ Value vmBuiltinPollkeyany(VM* vm, int arg_count, Value* args) {
     }
 
 #ifdef SDL
+    int text_codepoint;
+    if (sdlPollNextText(&text_codepoint)) {
+        return makeInt(text_codepoint);
+    }
+
     SDL_Keycode sdl_code;
-    if (sdlPollNextKey(&sdl_code)) {
+    if (sdlPollNextKey(&sdl_code, false)) {
         return makeInt((int)sdl_code);
     }
 #endif

--- a/src/backend_ast/sdl.h
+++ b/src/backend_ast/sdl.h
@@ -38,7 +38,8 @@ bool sdlCachedKeyDown(SDL_Scancode sc);
 bool sdlIsGraphicsActive(void);
 bool sdlHasPendingKeycode(void);
 SDL_Keycode sdlWaitNextKeycode(void);
-bool sdlPollNextKey(SDL_Keycode* outCode);
+bool sdlPollNextKey(SDL_Keycode* outCode, bool allowPrintable);
+bool sdlPollNextText(int* outCode);
 
 
 // System Functions

--- a/src/backend_ast/sdl3d.c
+++ b/src/backend_ast/sdl3d.c
@@ -83,6 +83,9 @@ Value vmBuiltinInitgraph3d(VM* vm, int arg_count, Value* args) {
 #if SDL_VERSION_ATLEAST(2,0,5)
     SDL_SetWindowInputFocus(gSdlWindow);
 #endif
+    if (!SDL_IsTextInputActive()) {
+        SDL_StartTextInput();
+    }
     sdlEnsureInputWatch();
 
     return makeVoid();


### PR DESCRIPTION
## Summary
- add SDL text input buffering so `pollkeyany` returns printable characters alongside non-printable keycodes
- update event loops and polling helpers to process SDL_TEXTINPUT events while keeping PollKey behaviour intact
- start and stop SDL text input when graphics windows are created or destroyed

## Testing
- not run (SDL-dependent change)


------
https://chatgpt.com/codex/tasks/task_b_68ffa63249348329a1b98566db2b7181