### PR TITLE
Improve SDL key polling reliability

### DIFF
--- a/src/backend_ast/sdl3d.c
+++ b/src/backend_ast/sdl3d.c
@@ -83,6 +83,7 @@ Value vmBuiltinInitgraph3d(VM* vm, int arg_count, Value* args) {
 #if SDL_VERSION_ATLEAST(2,0,5)
     SDL_SetWindowInputFocus(gSdlWindow);
 #endif
+    SDL_StartTextInput();
     sdlEnsureInputWatch();
 
     return makeVoid();


### PR DESCRIPTION
## Summary
- normalize SDL keycodes and enqueue UTF-8 text input so pollkeyany can report printable characters
- ensure SDL text input is started for both 2D and 3D windows and stopped during cleanup
- reuse the shared SDL event pump across key polling and waiting helpers so they see the same queue state

## Testing
- not run (SDL-dependent change)


------
https://chatgpt.com/codex/tasks/task_b_68ffa63249348329a1b98566db2b7181