### PR TITLE
Improve SDL text input handling for pollkeyany

### DIFF
--- a/src/backend_ast/sdl3d.c
+++ b/src/backend_ast/sdl3d.c
@@ -85,6 +85,10 @@ Value vmBuiltinInitgraph3d(VM* vm, int arg_count, Value* args) {
 #endif
     sdlEnsureInputWatch();
 
+    if (!SDL_IsTextInputActive()) {
+        SDL_StartTextInput();
+    }
+
     return makeVoid();
 }
 


### PR DESCRIPTION
## Summary
- update sdlIsGraphicsActive to treat OpenGL contexts as active graphics windows
- ensure pollkeyany continues to receive key events when only an SDL GL context is present
- enqueue SDL text input characters and start text input so pollkeyany captures printable keys
- avoid double-queuing printable keydowns when text input is active by relying on text events

## Testing
- not run (SDL-dependent change)

------
https://chatgpt.com/codex/tasks/task_b_68ffa63249348329a1b98566db2b7181