### PR TITLE
Register atan2 builtin for Rea front end

### DIFF
--- a/Examples/rea/sdl/planets_inner_3d
+++ b/Examples/rea/sdl/planets_inner_3d
@@ -11,6 +11,7 @@ const int NumStars = 2861;
 const float TargetFPS = 60.0;
 
 const float Pi = 3.141592653589793;
+const float HalfPi = 1.5707963267948966;
 const float TwoPi = 6.283185307179586;
 const float DegToRad = 0.017453292519943295;
 

--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -6264,6 +6264,7 @@ static void populateBuiltinRegistry(void) {
     registerBuiltinFunctionUnlocked("ArcSin", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunctionUnlocked("ArcTan", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunctionUnlocked("ArcTan2", AST_FUNCTION_DECL, NULL);
+    registerBuiltinFunctionUnlocked("atan2", AST_FUNCTION_DECL, NULL);
     registerBuiltinFunctionUnlocked("Assign", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunctionUnlocked("Beep", AST_PROCEDURE_DECL, NULL);
     registerBuiltinFunctionUnlocked("Byte", AST_FUNCTION_DECL, NULL);


### PR DESCRIPTION
## Summary
- register the lowercase atan2 builtin so the Rea front end can resolve it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ffc13e71cc832994725a40803a6234