### PR TITLE
Retry transient DNS lookup failures

### DIFF
--- a/src/backend_ast/builtin_network_api.c
+++ b/src/backend_ast/builtin_network_api.c
@@ -2392,11 +2392,49 @@ Value vmBuiltinDnsLookup(VM* vm, int arg_count, Value* args) {
     struct addrinfo hints, *res = NULL;
     memset(&hints, 0, sizeof(hints));
     hints.ai_family = AF_UNSPEC;
-    int e = getaddrinfo(host, NULL, &hints, &res);
-    if (e != 0) {
+
+    const int max_attempts = 3;
+    int attempt = 0;
+    int e = 0;
+    do {
+        if (res) {
+            freeaddrinfo(res);
+            res = NULL;
+        }
+        e = getaddrinfo(host, NULL, &hints, &res);
+        if (e == 0) {
+            break;
+        }
+
         if (isLocalhostName(host)) {
+            if (res) freeaddrinfo(res);
             return makeLocalhostFallbackResult();
         }
+
+        bool transient = false;
+#ifdef EAI_AGAIN
+        if (e == EAI_AGAIN) {
+            transient = true;
+        }
+#endif
+#ifdef EAI_FAIL
+        if (e == EAI_FAIL) {
+            transient = true;
+        }
+#endif
+#ifdef EAI_SYSTEM
+        if (e == EAI_SYSTEM && (errno == EINTR || errno == EAGAIN)) {
+            transient = true;
+        }
+#endif
+        if (!transient || attempt + 1 >= max_attempts) {
+            break;
+        }
+        attempt++;
+        sleep_ms(25 * attempt);
+    } while (attempt < max_attempts);
+
+    if (e != 0) {
         if (res) freeaddrinfo(res);
         setSocketAddrInfoError(e);
         markDnsLookupFailure(vm);


### PR DESCRIPTION
## Summary
- add a bounded retry loop to the dnslookup VM builtin so transient resolver failures no longer abort threaded lookups

## Testing
- cmake --build build --target exsh -j$(nproc)
- build/bin/exsh Examples/exsh/parallel-check google.com yahoo.com example.com news.google.com www.llnl.gov nobody.foo
- build/bin/exsh Tests/exsh/tests/thread_spawn_builtin_success.exsh

------
https://chatgpt.com/codex/tasks/task_b_6900505ecbd08329b79b4b87f5ec2b09