### PR TITLE
Expand Pascal closure examples with queue demos

### DIFF
--- a/Docs/pascal_overview.md
+++ b/Docs/pascal_overview.md
@@ -24,6 +24,15 @@ Examples
 - See `Examples/pascal/base/ThreadsProcPtrDemo` for a compact demonstration of:
   - Procedure/function pointers (including indirect calls), and
   - `CreateThread(@Worker, argPtr)`/`WaitForThread(t)` passing a pointer argument.
+- `Examples/pascal/base/ClosureSafeCapture` walks through a mini league table
+  where nested procedures track team scores while staying inside the defining
+  scope, so the compiler accepts the captures.
+- `Examples/pascal/base/ClosureEscapeError` intentionally fails to compile,
+  demonstrating the "closure captures a local value that would escape its
+  lifetime" diagnostic when a delayed callback keeps stack-allocated state.
+- `Examples/pascal/base/ClosureEscapingWorkaround` shows how to enqueue
+  stateful callbacks safely by boxing the payload on the heap and passing it to
+  a global handler instead of capturing local variables.
 
 Example program:
 

--- a/Examples/pascal/base/ClosureEscapeError
+++ b/Examples/pascal/base/ClosureEscapeError
@@ -1,0 +1,49 @@
+#!/usr/bin/env pascal
+program ClosureEscapeError;
+
+// Run with: pascal Examples/pascal/base/ClosureEscapeError
+// Expected: compiler error "closure captures a local value that would escape its
+// lifetime." Registering @Reporter stores a closure that still refers to
+// stack-allocated values (Message and Occurrences), so the compiler rejects it.
+
+type
+  TProc = procedure();
+
+var
+  Pending: array[1..2] of TProc;
+  PendingCount: integer = 0;
+
+procedure RegisterDelayedReport(const Message: string);
+var
+  Occurrences: integer;
+
+  procedure Reporter;
+  begin
+    Occurrences := Occurrences + 1;
+    WriteLn('[delayed] ', Message, ' (run #', Occurrences, ')');
+  end;
+
+begin
+  if PendingCount = High(Pending) then
+  begin
+    WriteLn('queue full');
+    exit;
+  end;
+
+  Inc(PendingCount);
+  Pending[PendingCount] := @Reporter; // Illegal escaping closure.
+end;
+
+procedure RunAll;
+var
+  I: integer;
+begin
+  for I := 1 to PendingCount do
+    Pending[I]();
+end;
+
+begin
+  RegisterDelayedReport('Daily rollup');
+  RegisterDelayedReport('After-hours summary');
+  RunAll;
+end.

--- a/Examples/pascal/base/ClosureEscapingWorkaround
+++ b/Examples/pascal/base/ClosureEscapingWorkaround
@@ -1,0 +1,81 @@
+#!/usr/bin/env pascal
+program ClosureEscapingWorkaround;
+
+// Run with: pascal Examples/pascal/base/ClosureEscapingWorkaround
+// Expected: runs both delayed reports successfully across two dispatch rounds.
+// Instead of capturing a stack variable, we store heap-allocated payloads and
+// pass them to a global handler, allowing stateful callbacks without tripping
+// the closure check.
+
+type
+  TTaskHandler = procedure(Data: pointer);
+  TTask = record
+    Handler: TTaskHandler;
+    Data: pointer;
+  end;
+
+  PReport = ^TReport;
+  TReport = record
+    Message: string;
+    Occurrences: integer;
+  end;
+
+var
+  Tasks: array[1..4] of TTask;
+  TaskCount: integer = 0;
+
+procedure RunReport(Data: pointer);
+var
+  Report: PReport;
+begin
+  Report := PReport(Data);
+  Report^.Occurrences := Report^.Occurrences + 1;
+  WriteLn('[delayed] ', Report^.Message, ' (run #', Report^.Occurrences, ')');
+end;
+
+procedure EnqueueReport(const Message: string);
+var
+  Report: PReport;
+begin
+  if TaskCount = High(Tasks) then
+  begin
+    WriteLn('queue full');
+    exit;
+  end;
+
+  New(Report);
+  Report^.Message := Message;
+  Report^.Occurrences := 0;
+
+  Inc(TaskCount);
+  Tasks[TaskCount].Handler := @RunReport;
+  Tasks[TaskCount].Data := Report;
+end;
+
+procedure DrainQueue;
+var
+  Round, I: integer;
+  Report: PReport;
+begin
+  for Round := 1 to 2 do
+  begin
+    WriteLn('--- Dispatch round ', Round, ' ---');
+    for I := 1 to TaskCount do
+      Tasks[I].Handler(Tasks[I].Data);
+  end;
+
+  for I := 1 to TaskCount do
+  begin
+    Report := PReport(Tasks[I].Data);
+    Dispose(Report);
+    Tasks[I].Data := nil;
+  end;
+
+  TaskCount := 0;
+end;
+
+begin
+  EnqueueReport('Daily rollup');
+  EnqueueReport('After-hours summary');
+  DrainQueue;
+end.

--- a/Examples/pascal/base/ClosureSafeCapture
+++ b/Examples/pascal/base/ClosureSafeCapture
@@ -1,0 +1,66 @@
+#!/usr/bin/env pascal
+program ClosureSafeCapture;
+
+// Run with: pascal Examples/pascal/base/ClosureSafeCapture
+// Expected: prints per-match updates and a final summary. The nested
+// procedures `RecordWin` and `PrintSummary` capture state from `RunLeague`
+// but execute synchronously, so they remain within scope and compile.
+
+type
+  TTeam = record
+    Name: string;
+    Score: integer;
+  end;
+
+procedure RunLeague;
+var
+  Teams: array[1..3] of TTeam;
+  TotalScore: integer;
+
+  procedure InitTeams;
+  begin
+    Teams[1].Name := 'Firebirds'; Teams[1].Score := 0;
+    Teams[2].Name := 'Storm';     Teams[2].Score := 0;
+    Teams[3].Name := 'Glaciers';  Teams[3].Score := 0;
+    TotalScore := 0;
+  end;
+
+  procedure RecordWin(const TeamName: string; Points: integer);
+  var
+    I: integer;
+  begin
+    for I := Low(Teams) to High(Teams) do
+      if Teams[I].Name = TeamName then
+      begin
+        Teams[I].Score := Teams[I].Score + Points;
+        TotalScore := TotalScore + Points;
+        WriteLn(TeamName, ' earns ', Points, ' point(s); running total = ',
+          Teams[I].Score);
+        exit;
+      end;
+  end;
+
+  procedure PrintSummary;
+  var
+    I: integer;
+  begin
+    WriteLn('--- Final standings ---');
+    for I := Low(Teams) to High(Teams) do
+      WriteLn(Teams[I].Name, ': ', Teams[I].Score, ' point(s)');
+    WriteLn('League-wide points awarded: ', TotalScore);
+  end;
+
+begin
+  InitTeams;
+
+  RecordWin('Firebirds', 3);
+  RecordWin('Storm', 2);
+  RecordWin('Glaciers', 1);
+  RecordWin('Firebirds', 2);
+
+  PrintSummary;
+end;
+
+begin
+  RunLeague;
+end.


### PR DESCRIPTION
## Summary
- expand the safe capture sample into a mini league score tracker that stays within scope
- rewrite the escaping example to illustrate why delayed callbacks fail to compile
- add a heap-boxed workaround example and document all three programs in the Pascal overview

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_6901055aeed483299689f00750cb28cf