### PR TITLE
Fix ClosureEscapingWorkaround round counter naming conflict

### DIFF
--- a/Examples/pascal/base/ClosureEscapingWorkaround
+++ b/Examples/pascal/base/ClosureEscapingWorkaround
@@ -54,12 +54,12 @@ end;
 
 procedure DrainQueue;
 var
-  Round, I: integer;
+  RoundIndex, I: integer;
   Report: PReport;
 begin
-  for Round := 1 to 2 do
+  for RoundIndex := 1 to 2 do
   begin
-    WriteLn('--- Dispatch round ', Round, ' ---');
+    WriteLn('--- Dispatch round ', RoundIndex, ' ---');
     for I := 1 to TaskCount do
       Tasks[I].Handler(Tasks[I].Data);
   end;


### PR DESCRIPTION
## Summary
- rename the ClosureEscapingWorkaround dispatch loop counter to avoid the builtin Round function
- update the dispatch logging to use the renamed variable

## Testing
- ./Examples/pascal/base/ClosureEscapingWorkaround *(fails: /usr/bin/env: ‘pascal’: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_69011bc3f40c8329bfa89d5041524a36