### PR TITLE
Handle closure environments for indirect calls

### DIFF
--- a/Tests/compiler/pascal/cases/closure_capturing_proc_store.pas
+++ b/Tests/compiler/pascal/cases/closure_capturing_proc_store.pas
@@ -1,0 +1,45 @@
+program ClosureProcStore;
+
+type
+  TThunk = procedure;
+
+var
+  Stored: TThunk;
+  Counter: integer;
+
+procedure MakeStepper(start: integer);
+var
+  value: integer;
+  procedure Step;
+  begin
+    value := value + 1;
+    Counter := Counter + value;
+  end;
+begin
+  value := start;
+  Stored := @Step;
+end;
+
+var
+  expected: integer;
+begin
+  Counter := 0;
+  MakeStepper(5);
+  Stored();
+  Stored();
+  expected := 6 + 7;
+  if Counter <> expected then
+    writeln('FAIL: stored procedure closure produced ', Counter, ' expected ', expected)
+  else
+  begin
+    Counter := 100;
+    MakeStepper(1);
+    Stored();
+    Stored();
+    expected := 100 + 2 + 3;
+    if Counter <> expected then
+      writeln('FAIL: reassigned procedure closure produced ', Counter, ' expected ', expected)
+    else
+      writeln('PASS: capturing procedure closure stored and invoked');
+  end;
+end.

--- a/Tests/compiler/pascal/manifest.json
+++ b/Tests/compiler/pascal/manifest.json
@@ -21,6 +21,12 @@
       "path": "Tests/compiler/pascal/cases/closure_capturing_store_return.pas",
       "expect": "compile_success",
       "stdout_substring": "PASS: capturing closure stored and returned"
+    },
+    {
+      "id": "closure_capturing_proc_store",
+      "path": "Tests/compiler/pascal/cases/closure_capturing_proc_store.pas",
+      "expect": "compile_success",
+      "stdout_substring": "PASS: capturing procedure closure stored and invoked"
     }
   ]
 }

--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -2211,6 +2211,21 @@ void printValueToStream(Value v, FILE *stream) {
         case TYPE_WORD:
             fprintf(stream, "%lld", v.i_val & 0xFFFF);
             break;
+        case TYPE_CLOSURE: {
+            fprintf(stream, "CLOSURE(entry=%u", v.closure.entry_offset);
+            if (v.closure.symbol && v.closure.symbol->name) {
+                fprintf(stream, ", symbol=%s", v.closure.symbol->name);
+            }
+            if (v.closure.env) {
+                fprintf(stream, ", env=%p, slots=%u, ref=%u)",
+                        (void*)v.closure.env,
+                        (unsigned)v.closure.env->slot_count,
+                        (unsigned)v.closure.env->refcount);
+            } else {
+                fprintf(stream, ", env=NULL)");
+            }
+            break;
+        }
         case TYPE_THREAD:
             fprintf(stream, "%lld", v.i_val);
             break;

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -2364,6 +2364,14 @@ static Value copyValueForStack(const Value* src) {
         return alias;
     }
 
+    if (src->type == TYPE_CLOSURE) {
+        Value alias = *src;
+        if (alias.closure.env) {
+            retainClosureEnv(alias.closure.env);
+        }
+        return alias;
+    }
+
     return makeCopyOfValue(src);
 }
 


### PR DESCRIPTION
## Summary
- retain closure environments when copying values and expose closure details in trace/disassembly output
- teach printValueToStream to describe closures with entry, symbol, and captured environment metadata
- add a Pascal regression exercising stored procedure closures invoked after their defining routine exits

## Testing
- cmake --build build --target pascal
- cmake --build build --target pscalvm
- build/bin/pascal --no-cache Tests/compiler/pascal/cases/closure_capturing_proc_store.pas
- build/bin/pascal --no-cache Tests/compiler/pascal/cases/closure_capturing_store_return.pas
- build/bin/pascal --no-cache Tests/compiler/pascal/cases/closure_non_capturing_pointer_ok.pas

------
https://chatgpt.com/codex/tasks/task_b_690201c75d048329b50c3d9c81b16b01