### PR TITLE
Fix Pascal record interface cast recognition

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -1732,7 +1732,23 @@ static const char* getTypeNameFromAST(AST* typeAst) {
 // Check if a record type defines methods and therefore reserves a vtable slot.
 static bool recordTypeHasVTable(AST* recordType) {
     recordType = resolveTypeAlias(recordType);
+    if (!recordType) return false;
+
+    if (recordType->type == AST_TYPE_DECL && recordType->left) {
+        recordType = resolveTypeAlias(recordType->left);
+    }
+
     if (!recordType || recordType->type != AST_RECORD_TYPE) return false;
+
+    for (int i = 0; i < recordType->child_count; i++) {
+        AST* member = recordType->children[i];
+        if (!member) continue;
+        if ((member->type == AST_PROCEDURE_DECL || member->type == AST_FUNCTION_DECL) &&
+            member->is_virtual) {
+            return true;
+        }
+    }
+
     const char* name = getTypeNameFromAST(recordType);
     if (!name) return false;
     size_t len = strlen(name);


### PR DESCRIPTION
## Summary
- detect virtual methods directly on Pascal record declarations so vtable slots are reserved
- retain symbol-table fallback for legacy cases while allowing interface casts of virtual records

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_6902ea0584a88329b4c35f18cc25a661