### PR TITLE
Fix Pascal interface dispatch argument handling

### DIFF
--- a/Docs/pascal_overview.md
+++ b/Docs/pascal_overview.md
@@ -107,6 +107,12 @@ begin
 end.
 ```
 
+Running the program prints the log message instead of the boxed receiver pointer:
+
+```
+[console] ready
+```
+
 ## Builtins
 
 Builtins are implemented in C and exposed to Pascal through a lookup table【F:src/backend_ast/builtin.c†L35-L176】. They cover:

--- a/Tests/Pascal/InterfaceDispatch
+++ b/Tests/Pascal/InterfaceDispatch
@@ -1,0 +1,24 @@
+program InterfaceDispatch;
+
+type
+  ILogger = interface
+    procedure Log(const msg: string);
+  end;
+
+  TConsoleLogger = record
+    procedure Log(const msg: string); virtual;
+  end;
+
+procedure TConsoleLogger.Log(const msg: string);
+begin
+  writeln('[console] ', msg);
+end;
+
+var
+  logger: ILogger;
+  concrete: ^TConsoleLogger;
+begin
+  new(concrete);
+  logger := ILogger(concrete);
+  logger.Log('ready');
+end.

--- a/Tests/Pascal/InterfaceDispatch.out
+++ b/Tests/Pascal/InterfaceDispatch.out
@@ -1,0 +1,1 @@
+[console] ready

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -5555,6 +5555,15 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
                         interfaceReceiver = node->left;
                         interfaceType = candidateType;
                         interfaceArgStart = 0;
+
+                        if (node->child_count > 0) {
+                            AST* firstChild = node->children[0];
+                            if (firstChild == interfaceReceiver ||
+                                (firstChild && firstChild->type == AST_FIELD_ACCESS &&
+                                 firstChild->left == interfaceReceiver)) {
+                                interfaceArgStart = 1;
+                            }
+                        }
                     }
                 }
             }
@@ -5888,7 +5897,8 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
                 writeBytecodeChunk(chunk, CALL_HOST, line);
                 writeBytecodeChunk(chunk, (uint8_t)HOST_FN_INTERFACE_LOOKUP, line);
 
-                int metadataOffset = (interfaceArgStart == 0) ? 1 : 0;
+                int metadataOffset = 1 - interfaceArgStart;
+                if (metadataOffset < 0) metadataOffset = 0;
                 for (int i = interfaceArgStart; i < node->child_count; i++) {
                     AST* arg_node = node->children[i];
                     bool is_var_param = false;
@@ -5909,7 +5919,7 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
                 }
 
                 writeBytecodeChunk(chunk, PROC_CALL_INDIRECT, line);
-                int total_args = node->child_count - interfaceArgStart + 1;
+                int total_args = node->child_count - interfaceArgStart;
                 if (total_args < 0) total_args = 0;
                 writeBytecodeChunk(chunk, (uint8_t)total_args, line);
                 break;
@@ -7160,6 +7170,15 @@ static void compileRValue(AST* node, BytecodeChunk* chunk, int current_line_appr
                         interfaceReceiver = node->left;
                         interfaceType = candidateType;
                         interfaceArgStart = 0;
+
+                        if (node->child_count > 0) {
+                            AST* firstChild = node->children[0];
+                            if (firstChild == interfaceReceiver ||
+                                (firstChild && firstChild->type == AST_FIELD_ACCESS &&
+                                 firstChild->left == interfaceReceiver)) {
+                                interfaceArgStart = 1;
+                            }
+                        }
                     }
                 }
             }
@@ -7246,7 +7265,8 @@ static void compileRValue(AST* node, BytecodeChunk* chunk, int current_line_appr
                 writeBytecodeChunk(chunk, CALL_HOST, line);
                 writeBytecodeChunk(chunk, (uint8_t)HOST_FN_INTERFACE_LOOKUP, line);
 
-                int metadataOffset = (interfaceArgStart == 0) ? 1 : 0;
+                int metadataOffset = 1 - interfaceArgStart;
+                if (metadataOffset < 0) metadataOffset = 0;
                 for (int i = interfaceArgStart; i < node->child_count; i++) {
                     AST* arg_node = node->children[i];
                     bool is_var_param = false;
@@ -7265,7 +7285,7 @@ static void compileRValue(AST* node, BytecodeChunk* chunk, int current_line_appr
                 }
 
                 writeBytecodeChunk(chunk, CALL_INDIRECT, line);
-                int total_args = node->child_count - interfaceArgStart + 1;
+                int total_args = node->child_count - interfaceArgStart;
                 if (total_args < 0) total_args = 0;
                 writeBytecodeChunk(chunk, (uint8_t)total_args, line);
                 break;


### PR DESCRIPTION
## Summary
- adjust Pascal interface dispatch to skip the synthetic selector child and avoid counting the receiver as an argument
- realign metadata lookups and argument counts with the new starting index for interface calls
- add an InterfaceDispatch regression test and refresh the documentation example output

## Testing
- build/bin/pascal --no-cache Tests/Pascal/InterfaceDispatch

------
https://chatgpt.com/codex/tasks/task_b_69046981535c8329a9d6049693d6cc3a