### PR TITLE
Ensure interface dispatch counts the receiver argument

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -5919,8 +5919,8 @@ static void compileStatement(AST* node, BytecodeChunk* chunk, int current_line_a
                 }
 
                 writeBytecodeChunk(chunk, PROC_CALL_INDIRECT, line);
-                int total_args = node->child_count - interfaceArgStart;
-                if (total_args < 0) total_args = 0;
+                int total_args = node->child_count - interfaceArgStart + 1;
+                if (total_args < 1) total_args = 1;
                 writeBytecodeChunk(chunk, (uint8_t)total_args, line);
                 break;
             }
@@ -7285,8 +7285,8 @@ static void compileRValue(AST* node, BytecodeChunk* chunk, int current_line_appr
                 }
 
                 writeBytecodeChunk(chunk, CALL_INDIRECT, line);
-                int total_args = node->child_count - interfaceArgStart;
-                if (total_args < 0) total_args = 0;
+                int total_args = node->child_count - interfaceArgStart + 1;
+                if (total_args < 1) total_args = 1;
                 writeBytecodeChunk(chunk, (uint8_t)total_args, line);
                 break;
             }


### PR DESCRIPTION
## Summary
- include the interface receiver when calculating total arguments for PROC_CALL_INDIRECT and CALL_INDIRECT

## Testing
- build/bin/pascal --no-cache Tests/Pascal/InterfaceDispatch *(fails: build/bin/pascal not present in environment)*

------
https://chatgpt.com/codex/tasks/task_b_690475208e9c8329917f5d4654d19812