### PR TITLE
Support closure captures in threaded calls

### DIFF
--- a/Docs/pascal_closures_for_dummies.md
+++ b/Docs/pascal_closures_for_dummies.md
@@ -49,7 +49,7 @@ writeln(Stored()); // prints 3 on the first call
 Because the closure owns its environment, using it after `MakeCounter` has returned is safe and produces the expected sequence.【F:Tests/compiler/pascal/cases/closure_capturing_store_return.pas†L19-L34】
 
 ### Limitations to Remember
-- **Threads still expect raw procedure pointers.** `CreateThread` currently rejects closures that capture locals, so use helper records if you need to shuttle state into a thread entry point.【F:src/vm/vm.c†L2600-L2628】
+- **Threads now retain closure environments.** `CreateThread` accepts capturing closures, keeps their environments alive until the worker finishes, and releases them automatically; the `Threading` unit’s `SpawnProcedure` helper lets Pascal code forward nested routines without building custom payload records.【F:src/vm/vm.c†L2588-L2676】【F:lib/pascal/threading.pl†L11-L61】
 - **Global scope cannot host capturing closures.** Attempting to take the address of a capturing routine declared at the top level still produces a compiler error.【F:src/compiler/compiler.c†L965-L1003】
 
 ## Interface Payloads Without Boilerplate

--- a/Tests/Pascal/CreateThreadClosureCaptureTest
+++ b/Tests/Pascal/CreateThreadClosureCaptureTest
@@ -1,0 +1,34 @@
+program CreateThreadClosureCaptureTest;
+uses Threading;
+
+type
+  PInteger = ^Integer;
+
+procedure Run;
+var
+  seed: integer;
+  observed: PInteger;
+  tid: integer;
+  status: integer;
+
+  procedure Worker(arg: pointer);
+  begin
+    if observed <> nil then
+      observed^ := seed;
+  end;
+
+begin
+  seed := 41;
+  New(observed);
+  observed^ := 0;
+  tid := SpawnProcedure(@Worker, observed);
+  status := WaitForThread(tid);
+  writeln('status=', status);
+  writeln('observed=', observed^);
+  writeln('stats=', ThreadStatsCount);
+  Dispose(observed);
+end;
+
+begin
+  Run;
+end.

--- a/Tests/Pascal/CreateThreadClosureCaptureTest.out
+++ b/Tests/Pascal/CreateThreadClosureCaptureTest.out
@@ -1,0 +1,3 @@
+status=0
+observed=41
+stats=0

--- a/Tests/Pascal/CreateThreadClosurePointerTest
+++ b/Tests/Pascal/CreateThreadClosurePointerTest
@@ -1,0 +1,37 @@
+program CreateThreadClosurePointerTest;
+uses Threading;
+
+type
+  PInteger = ^Integer;
+
+procedure Run;
+var
+  base: integer;
+  data: PInteger;
+  tid: integer;
+  status: integer;
+
+  procedure Worker(param: pointer);
+  var
+    p: PInteger;
+  begin
+    p := PInteger(param);
+    if p <> nil then
+      p^ := p^ + base;
+  end;
+
+begin
+  base := 5;
+  New(data);
+  data^ := 37;
+  tid := CreateThread(@Worker, data);
+  status := WaitForThread(tid);
+  writeln('status=', status);
+  writeln('heap=', data^);
+  writeln('stats=', ThreadStatsCount);
+  Dispose(data);
+end;
+
+begin
+  Run;
+end.

--- a/Tests/Pascal/CreateThreadClosurePointerTest.out
+++ b/Tests/Pascal/CreateThreadClosurePointerTest.out
@@ -1,0 +1,3 @@
+status=0
+heap=42
+stats=0

--- a/lib/pascal/threading.pl
+++ b/lib/pascal/threading.pl
@@ -12,6 +12,8 @@ function ThreadOptionsNamed(const ThreadName: string): ThreadRequestOptions;
 function ThreadOptionsQueue(const ThreadName: string): ThreadRequestOptions;
 function ThreadOptionsQueueOnly: ThreadRequestOptions;
 
+function SpawnProcedure(const Proc: Pointer; Arg: Pointer): Integer;
+
 function SpawnBuiltinNamed(const BuiltinName, ThreadName: string): Integer;
 function PoolSubmitNamed(const BuiltinName, ThreadName: string): Integer;
 function SpawnBuiltinWithOptions(const BuiltinName: string; const Options: ThreadRequestOptions): Integer;
@@ -51,6 +53,11 @@ begin
   Options.Name := '';
   Options.SubmitOnly := True;
   ThreadOptionsQueueOnly := Options;
+end;
+
+function SpawnProcedure(const Proc: Pointer; Arg: Pointer): Integer;
+begin
+  SpawnProcedure := CreateThread(Proc, Arg);
 end;
 
 function SpawnBuiltinNamed(const BuiltinName, ThreadName: string): Integer;


### PR DESCRIPTION
## Summary
- retain closure environments when CreateThread receives capturing closures and hand them to worker frames
- add a SpawnProcedure helper in the Pascal Threading unit and document closure-aware thread support
- cover capturing closures in new Pascal thread tests that ensure captured values reach worker threads

## Testing
- cmake --build build
- build/bin/pascal --no-cache Tests/Pascal/CreateThreadClosureCaptureTest
- build/bin/pascal --no-cache Tests/Pascal/CreateThreadClosurePointerTest

------
https://chatgpt.com/codex/tasks/task_b_6904c250afb88329bab2699825cfdd05