### PR TITLE
Populate interface self pointer during dispatch

### DIFF
--- a/Docs/pascal_closures_for_dummies.md
+++ b/Docs/pascal_closures_for_dummies.md
@@ -19,6 +19,16 @@ Taken together, nested routines can finally outlive their defining scope, and in
 ### Practical takeaway
 You can now safely return or store nested routines that touch outer-scope variables. The environment lives on the heap and is reference counted, so multiple closures can share the same captured data without leaks.
 
+## Quick Demo
+
+For a compact walkthrough, see `Examples/pascal/base/docs_examples/GoStyleClosureInterfaceDemo`.
+It returns a nested function that captures its local counter, stores the resulting
+closure inside a record, and boxes that record behind an interface. Each call goes
+through the interface method, unpacks the receiver, and invokes the captured
+closure so the counter keeps advancing even after the factory routine has exited.
+During dispatch the VM now seeds the implicit `myself` pointer, letting the record
+method reach its own fields without any extra scaffolding.
+
 ## Everyday Closure Patterns
 
 ### Returning a Counter Function

--- a/Examples/pascal/base/docs_examples/GoStyleClosureInterfaceDemo
+++ b/Examples/pascal/base/docs_examples/GoStyleClosureInterfaceDemo
@@ -1,0 +1,62 @@
+program GoStyleClosureInterfaceDemo;
+
+// Demonstrates Go-style closures that escape their defining scope and
+// interface boxing that carries a receiver pointer plus its method table.
+
+type
+    TCounterFactory = function: integer;
+
+    IRunnable = interface
+        procedure Run;
+    end;
+
+    TClosureRunner = record
+        labelText: string;
+        nextValue: TCounterFactory;
+        procedure Run; virtual;
+    end;
+
+procedure TClosureRunner.Run;
+var
+    value: integer;
+    runner: ^TClosureRunner;
+    next: TCounterFactory;
+begin
+    runner := myself;
+    next := runner^.nextValue;
+    value := next();
+    writeln(runner^.labelText, ' tick=', value);
+end;
+
+function MakeRunner(const name: string; start, step: integer): IRunnable;
+var
+    current: integer;
+    runner: ^TClosureRunner;
+
+    function Next: integer;
+    begin
+        current := current + step;
+        Next := current;
+    end;
+begin
+    new(runner);
+    current := start;
+    runner^.labelText := name;
+    runner^.nextValue := @Next;
+    MakeRunner := IRunnable(runner);
+end;
+
+var
+    fast, slow: IRunnable;
+    i: integer;
+begin
+    fast := MakeRunner('fast', 0, 2);
+    slow := MakeRunner('slow', 10, -1);
+
+    for i := 1 to 3 do
+        fast.Run;
+
+    slow.Run;
+    fast.Run;
+    slow.Run;
+end.

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -3238,7 +3238,18 @@ static Value vmHostInterfaceLookup(VM* vm) {
         return makeNil();
     }
 
-    push(vm, copyValueForStack(receiverCell));
+    Value receiverCopy = copyValueForStack(receiverCell);
+
+    if (vm->vmGlobalSymbols) {
+        pthread_mutex_lock(&globals_mutex);
+        Symbol* myselfSym = hashTableLookup(vm->vmGlobalSymbols, "myself");
+        if (myselfSym) {
+            updateSymbol("myself", copyValueForStack(receiverCell));
+        }
+        pthread_mutex_unlock(&globals_mutex);
+    }
+
+    push(vm, receiverCopy);
 
     uint16_t target_address = (uint16_t)AS_INTEGER(entry);
 


### PR DESCRIPTION
## Summary
- seed the `myself` pointer inside `vmHostInterfaceLookup` so interface method calls receive their record receiver
- update the Go-style closure/interface demo to use the implicit `myself` pointer when invoking the captured closure
- document that interface dispatch now primes `myself`, letting record methods reach their fields without extra glue

## Testing
- build/bin/pascal Examples/pascal/base/docs_examples/GoStyleClosureInterfaceDemo

------
https://chatgpt.com/codex/tasks/task_b_6904cdcf47a48329838573ba981d94e4