### PR TITLE
Handle interface nil comparisons

### DIFF
--- a/Tests/Pascal/InterfaceNilComparisonTest
+++ b/Tests/Pascal/InterfaceNilComparisonTest
@@ -1,0 +1,59 @@
+program InterfaceNilComparisonTest;
+
+type
+  IRunner = interface
+    procedure Run;
+  end;
+
+  TRunner = record
+    procedure Run; virtual;
+  end;
+
+procedure TRunner.Run;
+begin
+  { no-op }
+end;
+
+var
+  runner: ^TRunner;
+  maybe: IRunner;
+begin
+  maybe := nil;
+
+  if maybe = nil then
+    writeln('initial eq nil ok')
+  else
+    writeln('initial eq nil fail');
+
+  if maybe <> nil then
+    writeln('initial ne nil fail')
+  else
+    writeln('initial ne nil ok');
+
+  new(runner);
+  maybe := IRunner(runner);
+
+  if maybe <> nil then
+    writeln('assigned ne nil ok')
+  else
+    writeln('assigned ne nil fail');
+
+  if maybe = nil then
+    writeln('assigned eq nil fail')
+  else
+    writeln('assigned eq nil ok');
+
+  maybe := nil;
+
+  if maybe = nil then
+    writeln('reset eq nil ok')
+  else
+    writeln('reset eq nil fail');
+
+  if maybe <> nil then
+    writeln('reset ne nil fail')
+  else
+    writeln('reset ne nil ok');
+
+  dispose(runner);
+end.

--- a/Tests/Pascal/InterfaceNilComparisonTest.out
+++ b/Tests/Pascal/InterfaceNilComparisonTest.out
@@ -1,0 +1,6 @@
+initial eq nil ok
+initial ne nil ok
+assigned ne nil ok
+assigned eq nil ok
+reset eq nil ok
+reset ne nil ok

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -5108,6 +5108,23 @@ dispatch_switch:
                     }
                     comparison_succeeded = true;
                 }
+                // Interface and NIL comparison
+                else if ((a_val.type == TYPE_INTERFACE || a_val.type == TYPE_NIL) &&
+                         (b_val.type == TYPE_INTERFACE || b_val.type == TYPE_NIL)) {
+                    ClosureEnvPayload* payload_a = (a_val.type == TYPE_INTERFACE) ? a_val.interface.payload : NULL;
+                    ClosureEnvPayload* payload_b = (b_val.type == TYPE_INTERFACE) ? b_val.interface.payload : NULL;
+                    bool interfaces_equal = (payload_a == payload_b);
+
+                    if (instruction_val == EQUAL) {
+                        result_val = makeBoolean(interfaces_equal);
+                    } else if (instruction_val == NOT_EQUAL) {
+                        result_val = makeBoolean(!interfaces_equal);
+                    } else {
+                        runtimeError(vm, "Runtime Error: Invalid operator for interface comparison. Only '=' and '<>' are allowed. Got opcode %d.", instruction_val);
+                        freeValue(&a_val); freeValue(&b_val); return INTERPRET_RUNTIME_ERROR;
+                    }
+                    comparison_succeeded = true;
+                }
                 // Pointer and NIL comparison
                 else if ((a_val.type == TYPE_POINTER || a_val.type == TYPE_NIL) &&
                          (b_val.type == TYPE_POINTER || b_val.type == TYPE_NIL)) {


### PR DESCRIPTION
## Summary
- allow interface values to compare to nil in the VM equality/inequality handler
- add a Pascal regression test that checks interface values against nil

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `Tests/run_pascal_tests.sh --only InterfaceNilComparisonTest`


------
https://chatgpt.com/codex/tasks/task_b_6904fa35cc24832988610d24c1ce2639