### PR TITLE
Add extended builtin dump examples for each front end

### DIFF
--- a/Docs/extended_builtins.md
+++ b/Docs/extended_builtins.md
@@ -116,6 +116,12 @@ Pascal uses the Pascal-cased names shown above.  The C-like and Rea front ends
 expose the same helpers with lowercase identifiers (for example,
 `extbuiltincategorycount()`).
 
+Complete runnable examples that exercise these helpers live under
+`Examples/pascal/base/DumpExtBuiltins`,
+`Examples/clike/base/DumpExtBuiltins`,
+`Examples/rea/base/dump_ext_builtins`, and
+`Examples/exsh/dump_ext_builtins`.
+
 Example Pascal snippet that lists the available routines when the category is
 present:
 

--- a/Examples/clike/base/DumpExtBuiltins
+++ b/Examples/clike/base/DumpExtBuiltins
@@ -1,0 +1,30 @@
+#!/usr/bin/env clike
+int main() {
+    int categoryCount = extbuiltincategorycount();
+    printf("Extended builtin inventory\n");
+    int i = 0;
+    while (i < categoryCount) {
+        str category = extbuiltincategoryname(i);
+        printf("Category: %s\n", category);
+        int totalFns = extbuiltinfunctioncount(category);
+        int groupCount = extbuiltingroupcount(category);
+        int j = 0;
+        while (j < groupCount) {
+            str group = extbuiltingroupname(category, j);
+            printf("  Group: %s\n", group);
+            int groupFnCount = extbuiltingroupfunctioncount(category, group);
+            int k = 0;
+            while (k < groupFnCount) {
+                str fn = extbuiltingroupfunctionname(category, group, k);
+                printf("    %s\n", fn);
+                k = k + 1;
+            }
+            j = j + 1;
+        }
+        printf("  Total functions: %d\n\n", totalFns);
+        i = i + 1;
+    }
+    int hasPid = hasextbuiltin("system", "GetPid");
+    printf("Has system/GetPid: %s\n", hasPid ? "true" : "false");
+    return 0;
+}

--- a/Examples/exsh/dump_ext_builtins
+++ b/Examples/exsh/dump_ext_builtins
@@ -1,0 +1,44 @@
+#!/usr/bin/env exsh
+# Enumerate the VM's extended builtin categories, groups, and functions.
+
+category_count=$(builtin ExtBuiltinCategoryCount)
+if [ -z "$category_count" ]; then
+    echo "No extended builtin information available." >&2
+    exit 1
+fi
+
+echo "Extended builtin inventory"
+
+i=0
+while [ "$i" -lt "$category_count" ]; do
+    category=$(builtin ExtBuiltinCategoryName "int:$i")
+    echo "Category: $category"
+    total_fns=$(builtin ExtBuiltinFunctionCount "str:$category")
+    group_count=$(builtin ExtBuiltinGroupCount "str:$category")
+    j=0
+    while [ "$j" -lt "$group_count" ]; do
+        group=$(builtin ExtBuiltinGroupName "str:$category" "int:$j")
+        echo "  Group: $group"
+        group_fn_count=$(builtin ExtBuiltinGroupFunctionCount "str:$category" "str:$group")
+        k=0
+        while [ "$k" -lt "$group_fn_count" ]; do
+            fn=$(builtin ExtBuiltinGroupFunctionName "str:$category" "str:$group" "int:$k")
+            echo "    $fn"
+            k=$((k + 1))
+        done
+        j=$((j + 1))
+    done
+    echo "  Total functions: $total_fns"
+    echo
+    i=$((i + 1))
+done
+
+result=$(builtin HasExtBuiltin "str:system" "str:GetPid")
+case "$result" in
+    true|TRUE|1)
+        echo "Has system/GetPid: true"
+        ;;
+    *)
+        echo "Has system/GetPid: false"
+        ;;
+esac

--- a/Examples/pascal/base/DumpExtBuiltins
+++ b/Examples/pascal/base/DumpExtBuiltins
@@ -1,0 +1,31 @@
+#!/usr/bin/env pascal
+program DumpExtBuiltins;
+var
+  catCount, groupCount, fnCount, groupFnCount: integer;
+  i, j, k: integer;
+  catName, groupName, fnName: string;
+begin
+  writeln('Extended builtin inventory');
+  catCount := ExtBuiltinCategoryCount();
+  for i := 0 to catCount - 1 do
+  begin
+    catName := ExtBuiltinCategoryName(i);
+    writeln('Category: ', catName);
+    fnCount := ExtBuiltinFunctionCount(catName);
+    groupCount := ExtBuiltinGroupCount(catName);
+    for j := 0 to groupCount - 1 do
+    begin
+      groupName := ExtBuiltinGroupName(catName, j);
+      writeln('  Group: ', groupName);
+      groupFnCount := ExtBuiltinGroupFunctionCount(catName, groupName);
+      for k := 0 to groupFnCount - 1 do
+      begin
+        fnName := ExtBuiltinGroupFunctionName(catName, groupName, k);
+        writeln('    ', fnName);
+      end;
+    end;
+    writeln('  Total functions: ', fnCount);
+    writeln;
+  end;
+  writeln('Has system/GetPid: ', HasExtBuiltin('system', 'GetPid'));
+end.

--- a/Examples/rea/base/dump_ext_builtins
+++ b/Examples/rea/base/dump_ext_builtins
@@ -1,0 +1,34 @@
+#!/usr/bin/env rea
+
+int dump() {
+  int categoryCount = extbuiltincategorycount();
+  writeln("Extended builtin inventory");
+  int i = 0;
+  while (i < categoryCount) {
+    str category = extbuiltincategoryname(i);
+    writeln("Category: ", category);
+    int totalFns = extbuiltinfunctioncount(category);
+    int groupCount = extbuiltingroupcount(category);
+    int j = 0;
+    while (j < groupCount) {
+      str group = extbuiltingroupname(category, j);
+      writeln("  Group: ", group);
+      int groupFnCount = extbuiltingroupfunctioncount(category, group);
+      int k = 0;
+      while (k < groupFnCount) {
+        str fn = extbuiltingroupfunctionname(category, group, k);
+        writeln("    ", fn);
+        k = k + 1;
+      }
+      j = j + 1;
+    }
+    writeln("  Total functions: ", totalFns);
+    writeln("");
+    i = i + 1;
+  }
+  bool hasPid = hasextbuiltin("system", "GetPid");
+  writeln("Has system/GetPid: ", hasPid ? "true" : "false");
+  return 0;
+}
+
+dump();


### PR DESCRIPTION
## Summary
- add runnable examples for the Pascal, CLike, Rea, and exsh front ends that enumerate the VM's extended builtins
- document where to find the new enumeration samples

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_6904fadedd588329a46391455f41c9a7