### PR TITLE
Handle proc pointer return assignments

### DIFF
--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -1462,10 +1462,14 @@ resolved_field: ;
                                     AST *resolvedReturnType = resolvedProcType ?
                                             resolveTypeAlias(resolvedProcType->right) : NULL;
 
-                                    verifyProcPointerAgainstDecl(lhsType, rhsProc->type_def, callName);
+                                    bool returnIsProcPointer = resolvedReturnType &&
+                                            resolvedReturnType->type == AST_PROC_PTR_TYPE;
 
-                                    if (resolvedReturnType &&
-                                            resolvedReturnType->type == AST_PROC_PTR_TYPE) {
+                                    if (!returnIsProcPointer) {
+                                        verifyProcPointerAgainstDecl(lhsType, rhsProc->type_def, callName);
+                                    }
+
+                                    if (returnIsProcPointer) {
                                         rhsIsProcPointer = true;
                                         rhs->var_type = TYPE_POINTER;
                                         rhs->type_def = resolvedReturnType;


### PR DESCRIPTION
## Summary
- resolve procedure call return types when assigning to procedure pointers
- propagate procedure pointer type information onto call nodes that return procedure pointers
- keep address-of rewriting for bare designators while preserving existing verification hooks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_69050a166fac8329bf3a82bc03798bd1