### PR TITLE
Handle semicolon-separated proc pointer params

### DIFF
--- a/Tests/Pascal/ProcPtrParamSemicolon
+++ b/Tests/Pascal/ProcPtrParamSemicolon
@@ -1,0 +1,26 @@
+program ProcPtrParamSemicolon;
+
+type
+  TMixedProc = procedure(var a: Integer; const b: Real; c: Boolean);
+
+procedure Impl(var a: Integer; const b: Real; c: Boolean);
+begin
+  if c then
+    a := a + 1;
+  if b > 0.0 then
+    a := a + 1;
+end;
+
+var
+  handler: TMixedProc;
+  value: Integer;
+begin
+  handler := @Impl;
+  value := 2;
+  { Ensure the routine identifier also parses with matching modifiers }
+  Impl(value, 3.0, True);
+  if value <> 4 then
+    writeln('unexpected result: ', value);
+  { Keep the pointer in scope so the parser must handle the semicolon-separated modifiers }
+  handler := @Impl;
+end.


### PR DESCRIPTION
## Summary
- allow procedure/function pointer type parsing to consume var/const/out modifiers and either comma or semicolon separators
- add a Pascal regression fixture exercising semicolon-separated procedural type parameters

## Testing
- Tests/run_pascal_tests.sh

------
https://chatgpt.com/codex/tasks/task_b_6905228dc28483298606f14663732bab