### PR TITLE
Fix VAR semantics for procedure pointer signatures

### DIFF
--- a/Tests/scope_verify/pascal/tests/build_manifest.py
+++ b/Tests/scope_verify/pascal/tests/build_manifest.py
@@ -317,6 +317,68 @@ add({
 })
 
 add({
+    "id": "routine_proc_ptr_assignment_var_mismatch",
+    "name": "Procedure pointer assignment enforces VAR parameters",
+    "category": "routine_scope",
+    "description": "Assignments to procedure pointers must preserve VAR/OUT passing conventions.",
+    "expect": "compile_error",
+    "code": """
+        program ProcPtrAssignVarMismatch;
+        type
+          TVarHandler = procedure(var value: Integer);
+          TValueHandler = procedure(value: Integer);
+
+        procedure UsesVar(var value: Integer);
+        begin
+          value := value + 1;
+        end;
+
+        procedure UsesValue(value: Integer);
+        begin
+        end;
+
+        var
+          handler: TVarHandler;
+
+        begin
+          handler := @UsesVar;
+          handler := @UsesValue;
+        end.
+    """,
+    "expected_stderr_substring": "passing convention mismatch",
+})
+
+add({
+    "id": "routine_proc_ptr_call_var_passthrough",
+    "name": "Procedure pointer call preserves VAR semantics",
+    "category": "routine_scope",
+    "description": "Calling through a procedure pointer should pass VAR parameters by reference and observe mutations.",
+    "expect": "runtime_ok",
+    "code": """
+        program ProcPtrCallVar;
+        type
+          TVarHandler = procedure(var value: Integer);
+
+        procedure Increment(var value: Integer);
+        begin
+          value := value + 5;
+        end;
+
+        var
+          handler: TVarHandler;
+          counter: Integer;
+
+        begin
+          handler := @Increment;
+          counter := 3;
+          handler(counter);
+          writeln('counter=', counter);
+        end.
+    """,
+    "expected_stdout": "counter=8",
+})
+
+add({
     "id": "routine_sibling_local_access_error",
     "name": "Sibling routine cannot access another's local",
     "category": "routine_scope",

--- a/Tests/scope_verify/pascal/tests/manifest.json
+++ b/Tests/scope_verify/pascal/tests/manifest.json
@@ -88,6 +88,24 @@
       "expected_stdout": "inner=5\nouter=3\nglobal=7"
     },
     {
+      "id": "routine_proc_ptr_assignment_var_mismatch",
+      "name": "Procedure pointer assignment enforces VAR parameters",
+      "category": "routine_scope",
+      "description": "Assignments to procedure pointers must preserve VAR/OUT passing conventions.",
+      "expect": "compile_error",
+      "code": "program ProcPtrAssignVarMismatch;\ntype\n  TVarHandler = procedure(var value: Integer);\n  TValueHandler = procedure(value: Integer);\n\nprocedure UsesVar(var value: Integer);\nbegin\n  value := value + 1;\nend;\n\nprocedure UsesValue(value: Integer);\nbegin\nend;\n\nvar\n  handler: TVarHandler;\n\nbegin\n  handler := @UsesVar;\n  handler := @UsesValue;\nend.",
+      "expected_stderr_substring": "passing convention mismatch"
+    },
+    {
+      "id": "routine_proc_ptr_call_var_passthrough",
+      "name": "Procedure pointer call preserves VAR semantics",
+      "category": "routine_scope",
+      "description": "Calling through a procedure pointer should pass VAR parameters by reference and observe mutations.",
+      "expect": "runtime_ok",
+      "code": "program ProcPtrCallVar;\ntype\n  TVarHandler = procedure(var value: Integer);\n\nprocedure Increment(var value: Integer);\nbegin\n  value := value + 5;\nend;\n\nvar\n  handler: TVarHandler;\n  counter: Integer;\n\nbegin\n  handler := @Increment;\n  counter := 3;\n  handler(counter);\n  writeln('counter=', counter);\nend.",
+      "expected_stdout": "counter=8"
+    },
+    {
       "id": "routine_sibling_local_access_error",
       "name": "Sibling routine cannot access another's local",
       "category": "routine_scope",


### PR DESCRIPTION
## Summary
- capture VAR/CONST modifiers when parsing procedure pointer parameters and model them as AST_VAR_DECL nodes
- include by-ref checks when comparing procedure pointer signatures and when resolving assignments
- resolve procedure pointer signatures during indirect calls so VAR parameters compile via l-values and add targeted regression coverage

## Testing
- python Tests/scope_verify/pascal/pascal_scope_test_harness.py --only routine_proc_ptr_assignment_var_mismatch
- python Tests/scope_verify/pascal/pascal_scope_test_harness.py --only routine_proc_ptr_call_var_passthrough

------
https://chatgpt.com/codex/tasks/task_b_690538b794588329921aa1bfb8264d7c