### PR TITLE
Handle Pascal out keyword contextually

### DIFF
--- a/Tests/Pascal/OutContextualKeywordTest
+++ b/Tests/Pascal/OutContextualKeywordTest
@@ -1,0 +1,29 @@
+program OutContextualKeywordTest;
+
+procedure Increment(out value: integer);
+begin
+  value := value + 1;
+end;
+
+procedure ShowOutIdentifier;
+var
+  out: integer;
+begin
+  out := 10;
+  writeln('local out identifier=', out);
+end;
+
+var
+  outValue: integer;
+  out: integer;
+
+begin
+  outValue := 41;
+  Increment(outValue);
+  writeln('after Increment: outValue=', outValue);
+
+  out := 3;
+  writeln('global out identifier=', out);
+
+  ShowOutIdentifier;
+end.

--- a/Tests/Pascal/OutContextualKeywordTest.out
+++ b/Tests/Pascal/OutContextualKeywordTest.out
@@ -1,0 +1,3 @@
+after Increment: outValue=42
+global out identifier=3
+local out identifier=10

--- a/src/Pascal/lexer.c
+++ b/src/Pascal/lexer.c
@@ -152,7 +152,6 @@ static Keyword keywords[] = {
     {"initialization", TOKEN_INITIALIZATION},
     {"interface", TOKEN_INTERFACE}, {"is", TOKEN_IS}, {"join", TOKEN_JOIN}, {"label", TOKEN_LABEL}, {"mod", TOKEN_MOD}, {"nil", TOKEN_NIL},
     {"not", TOKEN_NOT}, {"of", TOKEN_OF}, {"or", TOKEN_OR},
-    {"out", TOKEN_OUT}, // Added OUT
     {"pointer", TOKEN_POINTER},
     {"procedure", TOKEN_PROCEDURE}, {"program", TOKEN_PROGRAM},
     {"read", TOKEN_READ}, {"readln", TOKEN_READLN},


### PR DESCRIPTION
## Summary
- stop treating `out` as a dedicated lexer token so contextual keywords remain identifiers
- detect `out` modifiers in the parser by matching identifier lexemes with a new helper
- add a regression fixture ensuring `out` works both as a parameter modifier and as an ordinary identifier

## Testing
- build/bin/pascal Tests/Pascal/OutContextualKeywordTest

------
https://chatgpt.com/codex/tasks/task_b_69058ad570a48329a5246bdd213ff447