### PR TITLE
Fix nested procedure pointer resolution

### DIFF
--- a/Tests/scope_verify/pascal/tests/manifest.json
+++ b/Tests/scope_verify/pascal/tests/manifest.json
@@ -106,6 +106,15 @@
       "expected_stdout": "counter=8"
     },
     {
+      "id": "routine_nested_proc_ptr_compiles",
+      "name": "Nested procedure pointer resolves local handler",
+      "category": "routine_scope",
+      "description": "Nested procedure pointers passed with '@' should resolve local helpers declared in the same scope.",
+      "expect": "compile_ok",
+      "code": "program RoutineNestedProcPtr;\ntype\n  THandler = procedure;\n\nprocedure Setup;\n  procedure Register(handler: THandler);\n  begin\n  end;\n\n  procedure LocalHandler;\n  begin\n  end;\n\nbegin\n  Register(@LocalHandler);\nend;\n\nbegin\n  Setup;\nend.",
+      "failure_reason": "Regression coverage for nested procedure pointer lookup."
+    },
+    {
       "id": "routine_sibling_local_access_error",
       "name": "Sibling routine cannot access another's local",
       "category": "routine_scope",

--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -898,7 +898,7 @@ void annotateTypes(AST *node, AST *currentScopeNode, AST *globalProgramNode) {
                 bool operand_is_procedure = false;
                 if (node->left->type == AST_VARIABLE && node->left->token && node->left->token->value) {
                     const char* name = node->left->token->value;
-                    Symbol* procSym = lookupProcedure(name);
+                    Symbol* procSym = resolveProcedureSymbolInScope(name, node, globalProgramNode);
                     if (procSym) {
                         operand_is_procedure = true;
                     }
@@ -1226,7 +1226,7 @@ resolved_field: ;
                 node->var_type = (node->token && node->token->type == TOKEN_NOT) ? TYPE_BOOLEAN : (node->left ? node->left->var_type : TYPE_VOID);
                 break;
             case AST_PROCEDURE_CALL: {
-                 Symbol *procSymbol = node->token ? lookupProcedure(node->token->value) : NULL;
+                 Symbol *procSymbol = node->token ? resolveProcedureSymbolInScope(node->token->value, node, globalProgramNode) : NULL;
                 if (procSymbol) {
                     node->var_type = procSymbol->type;
                 } else {
@@ -1257,7 +1257,7 @@ resolved_field: ;
                              if (ftype && ftype->type == AST_PROC_PTR_TYPE) {
                                  if (actual->type == AST_ADDR_OF && actual->left && actual->left->token) {
                                      const char* aname = actual->left->token->value;
-                                     Symbol* as = lookupProcedure(aname);
+                                     Symbol* as = resolveProcedureSymbolInScope(aname, node, globalProgramNode);
                                      if (as && as->type_def) {
                                          AST* adecl = as->type_def;
                                          AST* fparams = (ftype->child_count > 0) ? ftype->children[0] : NULL;


### PR DESCRIPTION
## Summary
- resolve procedure pointer annotations using scope-aware symbol lookup so nested/local procedures are found
- add a Pascal scope regression test covering nested procedure pointer arguments

## Testing
- python3 Tests/scope_verify/pascal/pascal_scope_test_harness.py --only routine_nested_proc_ptr_compiles

------
https://chatgpt.com/codex/tasks/task_b_6905ecbdd3548329a58894c3a558d696