### PR TITLE
Fix Pascal unit symbol table hash usage

### DIFF
--- a/src/Pascal/parser.c
+++ b/src/Pascal/parser.c
@@ -1067,8 +1067,8 @@ AST *unitParser(Parser *parser_for_this_unit, int recursion_depth, const char* u
     AST *interface_decls = declarations(parser_for_this_unit, true);
     setLeft(unit_node, interface_decls);
     
-    Symbol *unitSymTable = buildUnitSymbolTable(interface_decls);
-    unit_node->symbol_table = unitSymTable;
+    HashTable *unitSymTable = buildUnitSymbolTable(interface_decls);
+    unit_node->symbol_table = (Symbol*)unitSymTable;
 
     eat(parser_for_this_unit, TOKEN_IMPLEMENTATION);
     AST *impl_decls = declarations(parser_for_this_unit, false);

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -246,8 +246,8 @@ int calculateArrayTotalSize(const Value* array_val);
 // Unit Stuff
 char *findUnitFile(const char *unit_name);
 void linkUnit(AST *unit_ast, int recursion_depth);
-Symbol *buildUnitSymbolTable(AST *interface_ast);
-void freeUnitSymbolTable(Symbol *symbol_table);
+HashTable *buildUnitSymbolTable(AST *interface_ast);
+void freeUnitSymbolTable(HashTable *symbol_table);
 bool isUnitDocumented(const char *unit_name);
 
 // General helpers


### PR DESCRIPTION
## Summary
- build unit interface symbol tables with the hash table helpers instead of a linked list
- update linking to iterate and free the hash-based tables without leaving dangling pointers
- adjust the parser declaration to expect the hash table handle

## Testing
- ../build/bin/pascal Pascal/CreateThreadClosureCaptureTest
- ../build/bin/pascal Pascal/CreateThreadClosurePointerTest

------
https://chatgpt.com/codex/tasks/task_b_69060866ea288329bf167ff431d66144