### PR TITLE
Support record-size arguments for Reset/Rewrite builtins

### DIFF
--- a/src/backend_ast/builtin.c
+++ b/src/backend_ast/builtin.c
@@ -2960,8 +2960,9 @@ Value vmBuiltinRewrite(VM* vm, int arg_count, Value* args) {
     if (fileVarLValue->filename == NULL) { runtimeError(vm, "File variable not assigned a name before Rewrite."); return makeVoid(); }
     if (fileVarLValue->f_val) fclose(fileVarLValue->f_val);
 
+    bool has_record_size_arg = (arg_count == 2);
     int new_record_size = fileVarLValue->record_size;
-    if (arg_count == 2) {
+    if (has_record_size_arg) {
         if (!IS_INTLIKE(args[1])) {
             runtimeError(vm, "Rewrite: Record size must be an integer value.");
             return makeVoid();
@@ -2972,12 +2973,15 @@ Value vmBuiltinRewrite(VM* vm, int arg_count, Value* args) {
             return makeVoid();
         }
         new_record_size = (int)size_val;
+        fileVarLValue->record_size_explicit = true;
     } else if (new_record_size <= 0) {
         new_record_size = PSCAL_DEFAULT_FILE_RECORD_SIZE;
+        fileVarLValue->record_size_explicit = false;
     }
     fileVarLValue->record_size = new_record_size;
 
-    const char* mode = (new_record_size != PSCAL_DEFAULT_FILE_RECORD_SIZE) ? "wb" : "w";
+    bool use_binary_mode = has_record_size_arg || fileVarLValue->record_size_explicit;
+    const char* mode = use_binary_mode ? "wb" : "w";
 
     FILE* f = fopen(fileVarLValue->filename, mode);
     if (f == NULL) {
@@ -3740,8 +3744,9 @@ Value vmBuiltinReset(VM* vm, int arg_count, Value* args) {
     if (fileVarLValue->filename == NULL) { runtimeError(vm, "File variable not assigned a name before Reset."); return makeVoid(); }
     if (fileVarLValue->f_val) fclose(fileVarLValue->f_val);
 
+    bool has_record_size_arg = (arg_count == 2);
     int new_record_size = fileVarLValue->record_size;
-    if (arg_count == 2) {
+    if (has_record_size_arg) {
         if (!IS_INTLIKE(args[1])) {
             runtimeError(vm, "Reset: Record size must be an integer value.");
             return makeVoid();
@@ -3752,12 +3757,15 @@ Value vmBuiltinReset(VM* vm, int arg_count, Value* args) {
             return makeVoid();
         }
         new_record_size = (int)size_val;
+        fileVarLValue->record_size_explicit = true;
     } else if (new_record_size <= 0) {
         new_record_size = PSCAL_DEFAULT_FILE_RECORD_SIZE;
+        fileVarLValue->record_size_explicit = false;
     }
     fileVarLValue->record_size = new_record_size;
 
-    const char* mode = (new_record_size != PSCAL_DEFAULT_FILE_RECORD_SIZE) ? "rb" : "r";
+    bool use_binary_mode = has_record_size_arg || fileVarLValue->record_size_explicit;
+    const char* mode = use_binary_mode ? "rb" : "r";
 
     FILE* f = fopen(fileVarLValue->filename, mode);
     if (f == NULL) {

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -138,6 +138,7 @@ typedef struct ValueStruct {
 
     char *filename;
     int record_size;      // Active record size for untyped file operations
+    bool record_size_explicit; // Whether the record size was explicitly requested
     int lower_bound;    // For single-dimensional arrays
     int upper_bound;    // For single-dimensional arrays
     int max_length;     // For fixed length strings (text: string[100];)

--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -943,7 +943,12 @@ Value makeValueForType(VarType type, AST *type_def_param, Symbol* context_symbol
         }
         case TYPE_CHAR:    v.c_val = '\0'; v.max_length = 1; break;
         case TYPE_BOOLEAN: v.i_val = 0; break;
-        case TYPE_FILE:    v.f_val = NULL; v.filename = NULL; v.record_size = PSCAL_DEFAULT_FILE_RECORD_SIZE; break;
+        case TYPE_FILE:
+            v.f_val = NULL;
+            v.filename = NULL;
+            v.record_size = PSCAL_DEFAULT_FILE_RECORD_SIZE;
+            v.record_size_explicit = false;
+            break;
         case TYPE_RECORD:
             if (node_to_inspect) {
                 v.record_val = createEmptyRecord(node_to_inspect);


### PR DESCRIPTION
## Summary
- allow the Pascal Reset/Rewrite builtins to accept an optional record-size argument, validating the value and opening binary streams when a non-default size is selected
- store the current record size on file values with a Turbo Pascal compatible default so untyped-file helpers can reuse it
- restore the OOWebServer example to pass an explicit record size now that the runtime supports it

## Testing
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_b_690634ddc87483298915b52c9c91d9d1