### PR TITLE
Fix OOWebServer default index fallback

### DIFF
--- a/Examples/pascal/base/OOWebServer
+++ b/Examples/pascal/base/OOWebServer
@@ -77,7 +77,6 @@ var
     RootDir: string;
     IndexPath: string;
     Body: string; // Default index.html body
-    GFile: text;
     ConfiguredAssetRoot: string = '@PSCAL_INSTALL_ROOT_RESOLVED@/misc/htdocs';
     //ConfiguredAssetRoot: string = '/usr/local/pscal/misc/htdocs';
 
@@ -691,9 +690,7 @@ begin
     
     if (copied = 0) or (fileexists(IndexPath) = 0) then
     begin
-        GFile := fopen(IndexPath, 'w');
-        fprintf(GFile, '%s' + #10, Body);
-        fclose(GFile);
+        saveStringToFile(IndexPath, Body);
     end;
 end;
 
@@ -736,9 +733,7 @@ begin
         mkdir(RootDir);
         if (fileexists(IndexPath) = 0) then
         begin
-            GFile := fopen(IndexPath, 'w');
-            fprintf(GFile, '%s' + #10, Body);
-            fclose(GFile);
+            saveStringToFile(IndexPath, Body);
         end;
         
         if (paramcount >= 3) then


### PR DESCRIPTION
## Summary
- replace the OOWebServer fallback index writer to use the existing saveStringToFile helper
- remove the unused GFile handle to avoid invoking fopen/fprintf in Pascal code

## Testing
- not run (example only)


------
https://chatgpt.com/codex/tasks/task_b_69065bc49f588329b448ba57b3944261