### PR TITLE
Fix OOWebServer example asset path and decode numeric index files

### DIFF
--- a/Examples/pascal/base/OOWebServer
+++ b/Examples/pascal/base/OOWebServer
@@ -77,7 +77,7 @@ var
     RootDir: string;
     IndexPath: string;
     Body: string; // Default index.html body
-    ConfiguredAssetRoot: string = '@PSCAL_INSTALL_ROOT_RESOLVED@/misc/htdocs';
+    ConfiguredAssetRoot: string = '@PSCAL_INSTALL_ROOT_RESOLVED@/lib/misc/simple_web_server/htdocs';
     //ConfiguredAssetRoot: string = '/usr/local/pscal/misc/htdocs';
 
     MaxThreads: integer = 8;
@@ -601,6 +601,48 @@ var
     f: file of byte;
     status, size, idx: integer;
     value: byte;
+    procedure maybeDecodeDecimalHtml(var s: string);
+    var
+        i, n, len: integer;
+        decoded: string;
+        code: integer;
+        ch: string;
+    begin
+        len := length(s);
+        if (len = 0) then exit;
+        for i := 1 to len do
+        begin
+            if (s[i] = '%') and (i = len) then break;
+            if (s[i] < '0') or (s[i] > '9') then exit;
+        end;
+        decoded := '';
+        i := 1;
+        while (i <= len) do
+        begin
+            if (s[i] = '%') and (i = len) then break;
+            if (s[i] = '%') then exit;
+            if (s[i] = '1') and (i + 2 <= len) then
+            begin
+                ch := copy(s, i, 3);
+                i := i + 3;
+            end
+            else if (i + 1 <= len) then
+            begin
+                ch := copy(s, i, 2);
+                i := i + 2;
+            end
+            else exit;
+            code := 0;
+            for n := 1 to length(ch) do
+            begin
+                if (ch[n] < '0') or (ch[n] > '9') then exit;
+                code := code * 10 + (ord(ch[n]) - ord('0'));
+            end;
+            if (code < 0) or (code > 255) then exit;
+            decoded := decoded + chr(code);
+        end;
+        if (length(decoded) > 0) and (pos('<', decoded) > 0) then s := decoded;
+    end;
 begin
     assign(f, path);
     {$I-} reset(f); {$I+}
@@ -633,6 +675,7 @@ begin
     end;
 
     close(f);
+    maybeDecodeDecimalHtml(data);
     loadFileToString := 1;
 end;
 


### PR DESCRIPTION
## Summary
- update the configured asset root so the OOWebServer example copies the installed htdocs assets correctly
- teach loadFileToString to detect and decode decimal-only index.html files so the fallback page renders as HTML instead of a number stream

## Testing
- not run (example-only change)


------
https://chatgpt.com/codex/tasks/task_b_69068938d1b08329bb1bccef84e09707