### PR TITLE
Fix GET_CHAR_ADDRESS instruction length

### DIFF
--- a/src/compiler/bytecode.c
+++ b/src/compiler/bytecode.c
@@ -246,8 +246,9 @@ int getInstructionLength(BytecodeChunk* chunk, int offset) {
             return 5; // opcode + slot + element type + 2-byte type name index
         case GET_ELEMENT_ADDRESS:
         case LOAD_ELEMENT_VALUE:
-        case GET_CHAR_ADDRESS:
             return 2; // opcode + operand byte
+        case GET_CHAR_ADDRESS:
+            return 1; // opcode only
         case GET_ELEMENT_ADDRESS_CONST:
         case LOAD_ELEMENT_VALUE_CONST:
             return 5; // opcode + 4-byte flat offset


### PR DESCRIPTION
## Summary
- correct getInstructionLength so GET_CHAR_ADDRESS reports a single-byte instruction
- confirm the disassembler walks bytecode containing GET_CHAR_ADDRESS without misalignment

## Testing
- build/bin/pascal --dump-bytecode-only /tmp/test_char_address.pas

------
https://chatgpt.com/codex/tasks/task_b_6909474ae7c48329858fde38413b1396