### PR TITLE
Fix exsh and clike missing terrain generator linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -539,6 +539,8 @@ set(SHELL_SOURCES
     src/compiler/bytecode.c
     src/vm/vm.c
     src/symbol/symbol.c
+    lib/noise/noise.c
+    src/runtime/terrain/terrain_generator.c
 )
 
 list(APPEND SHELL_SOURCES ${PSCAL_EXT_BUILTIN_SOURCES})
@@ -625,6 +627,8 @@ set(CLIKE_SOURCES
     src/backend_ast/shell_runtime_stub.c
     src/symbol/symbol.c
     src/clike/stubs.c
+    lib/noise/noise.c
+    src/runtime/terrain/terrain_generator.c
 )
 
 # Include user-supplied builtins in clike as well


### PR DESCRIPTION
## Summary
- add the terrain generator runtime and noise sources to the shell and clike executable builds so the new landscape builtin links correctly

## Testing
- cmake --build build --target exsh
- cmake --build build --target clike
- cmake --build build --target clike-repl

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e30bd8f148329b973e719a72eb6b4)