### PR TITLE
Include terrain generator runtime in REA and json2bc builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -737,6 +737,7 @@ set(REA_SOURCES
     src/rea/parser.c
     src/rea/semantic.c
     src/rea/builtins/thread.c
+    src/runtime/terrain/terrain_generator.c
     src/Pascal/lexer.c
     src/Pascal/parser.c
     src/ast/ast.c
@@ -1004,6 +1005,7 @@ set(JSON2BC_SOURCES
     src/symbol/symbol.c
     src/vm/vm.c
     src/Pascal/globals.c
+    src/runtime/terrain/terrain_generator.c
 )
 list(APPEND JSON2BC_SOURCES ${PSCAL_EXT_BUILTIN_SOURCES})
 list(APPEND JSON2BC_SOURCES src/third_party/yyjson/yyjson.c)


### PR DESCRIPTION
## Summary
- add the terrain generator runtime source to the Rea frontend target so landscape builtins resolve
- include the terrain generator runtime when building the json2bc tool to provide the same symbols

## Testing
- `cmake --build build` *(fails: /workspace/pscal/build is not a directory)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e33425e5483298df8cbe5e6d6bceb)