### PR TITLE
🎨 Palette: Improve AppDiagnosticsView UX and Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+
+## 2024-05-27 - AppDiagnosticsView UX improvements
+**Learning:** Diagnostics tools and reports benefit from visual feedback on copy actions, similar to other UI elements. Without it, users are unsure if the report was copied.
+**Action:** Applied `withAnimation` and added an SF Symbol checkmark (`checkmark.circle.fill`) alongside `.accessibilityLabel` and `.accessibilityHint` to the "Copy Report" button in AppDiagnosticsView.

--- a/ios/Sources/App/AppDiagnosticsView.swift
+++ b/ios/Sources/App/AppDiagnosticsView.swift
@@ -878,17 +878,33 @@ struct AppDiagnosticsView: View {
                     }
                 }
                 ToolbarItemGroup(placement: .primaryAction) {
-                    Button(copiedReport ? "Copied" : "Copy Report") {
+                    Button {
                         runner.copyReportToPasteboard()
-                        copiedReport = true
+                        withAnimation {
+                            copiedReport = true
+                        }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                            copiedReport = false
+                            withAnimation {
+                                copiedReport = false
+                            }
+                        }
+                    } label: {
+                        HStack {
+                            Text(copiedReport ? "Copied!" : "Copy Report")
+                            if copiedReport {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .foregroundColor(.green)
+                            }
                         }
                     }
                     .disabled(runner.report.isEmpty)
+                    .accessibilityLabel(copiedReport ? "Copied diagnostics report" : "Copy diagnostics report")
+                    .accessibilityHint("Copies the diagnostics report to the clipboard")
 
                     Button(runner.isRunning ? "Running..." : (runner.checks.isEmpty ? "Run Diagnostics" : "Run Again")) {
-                        copiedReport = false
+                        withAnimation {
+                            copiedReport = false
+                        }
                         runner.run()
                     }
                     .disabled(runner.isRunning)


### PR DESCRIPTION
💡 What: Enhanced the "Copy Report" button in `AppDiagnosticsView.swift` by wrapping the `copiedReport` state toggle in `withAnimation` blocks, adding a visual checkmark icon, and implementing `.accessibilityLabel` and `.accessibilityHint`.

🎯 Why: To provide a graceful visual transition and transient feedback when the diagnostic report is copied, and to ensure the action is clear to VoiceOver users.

📸 Before/After: Visual transitions now fade in/out smoothly instead of popping abruptly, and a checkmark appears for visual confirmation. Screen readers correctly announce "Copy diagnostics report" and "Copied diagnostics report".

♿ Accessibility: Added detailed ARIA equivalents to improve VoiceOver support on the icon and dynamically updating text.

---
*PR created automatically by Jules for task [9379385691305372279](https://jules.google.com/task/9379385691305372279) started by @emkey1*