### PR TITLE
🎨 Palette: Improve accessibility and transient state transitions in AppDiagnosticsView

### DIFF
--- a/ios/Sources/App/AppDiagnosticsView.swift
+++ b/ios/Sources/App/AppDiagnosticsView.swift
@@ -876,22 +876,34 @@ struct AppDiagnosticsView: View {
                     Button("Close") {
                         dismiss()
                     }
+                    .accessibilityLabel("Close Diagnostics")
+                    .accessibilityHint("Closes the app diagnostics view")
                 }
                 ToolbarItemGroup(placement: .primaryAction) {
                     Button(copiedReport ? "Copied" : "Copy Report") {
                         runner.copyReportToPasteboard()
-                        copiedReport = true
+                        withAnimation {
+                            copiedReport = true
+                        }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                            copiedReport = false
+                            withAnimation {
+                                copiedReport = false
+                            }
                         }
                     }
                     .disabled(runner.report.isEmpty)
+                    .accessibilityLabel(copiedReport ? "Copied diagnostic report" : "Copy diagnostic report")
+                    .accessibilityHint("Copies the diagnostic report to the clipboard")
 
                     Button(runner.isRunning ? "Running..." : (runner.checks.isEmpty ? "Run Diagnostics" : "Run Again")) {
-                        copiedReport = false
+                        withAnimation {
+                            copiedReport = false
+                        }
                         runner.run()
                     }
                     .disabled(runner.isRunning)
+                    .accessibilityLabel(runner.isRunning ? "Running diagnostics" : (runner.checks.isEmpty ? "Run Diagnostics" : "Run Diagnostics Again"))
+                    .accessibilityHint("Starts running the local diagnostics checks")
                 }
             }
         }


### PR DESCRIPTION
🎨 Palette: Improve accessibility and transient state transitions in AppDiagnosticsView

💡 What:
- Wrapped the transient `copiedReport` state mutations in `withAnimation` blocks to provide smoother visual transitions when interacting with the "Copy Report" button.
- Added descriptive `.accessibilityLabel` and `.accessibilityHint` modifiers to the "Close", "Copy Report", and "Run Diagnostics" buttons in the navigation toolbar, dynamically adapting the accessibility labels based on the buttons' transient states.

🎯 Why:
- Transient feedback like a "Copied!" text popping in can feel unpolished and abrupt; wrapping these changes in standard SwiftUI transitions improves the user experience.
- The VoiceOver experience was subpar for the toolbar buttons. Detailed accessibility hints and state-aware labels were added to clearly inform screen reader users of the specific functionalities and dynamic outcomes of their actions.

♿ Accessibility:
- Added explicit state-aware labels to VoiceOver and dynamic hints for the `AppDiagnosticsView` primary actions.

---
*PR created automatically by Jules for task [3750829758085749416](https://jules.google.com/task/3750829758085749416) started by @emkey1*