### PR TITLE
🎨 Palette: UX improvements for copy actions

### DIFF
--- a/ios/Sources/App/AppDiagnosticsView.swift
+++ b/ios/Sources/App/AppDiagnosticsView.swift
@@ -880,15 +880,27 @@ struct AppDiagnosticsView: View {
                 ToolbarItemGroup(placement: .primaryAction) {
                     Button(copiedReport ? "Copied" : "Copy Report") {
                         runner.copyReportToPasteboard()
-                        copiedReport = true
+
+                        UINotificationFeedbackGenerator().notificationOccurred(.success)
+                        UIAccessibility.post(notification: .announcement, argument: "Report copied to clipboard")
+
+                        withAnimation {
+                            copiedReport = true
+                        }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                            copiedReport = false
+                            withAnimation {
+                                copiedReport = false
+                            }
                         }
                     }
                     .disabled(runner.report.isEmpty)
+                    .accessibilityLabel(copiedReport ? "Report copied to clipboard" : "Copy diagnostic report")
+                    .accessibilityHint("Copies the diagnostic results to the clipboard")
 
                     Button(runner.isRunning ? "Running..." : (runner.checks.isEmpty ? "Run Diagnostics" : "Run Again")) {
-                        copiedReport = false
+                        withAnimation {
+                            copiedReport = false
+                        }
                         runner.run()
                     }
                     .disabled(runner.isRunning)

--- a/ios/Sources/App/TerminalSettingsView.swift
+++ b/ios/Sources/App/TerminalSettingsView.swift
@@ -154,6 +154,10 @@ struct TerminalSettingsView: View {
 
                     Button {
                         _ = tabManager.copyFirstTabColors(tabId: tabId)
+
+                        UINotificationFeedbackGenerator().notificationOccurred(.success)
+                        UIAccessibility.post(notification: .announcement, argument: "Copied first tab colors")
+
                         withAnimation {
                             copiedColors = true
                         }


### PR DESCRIPTION
🎨 Palette: Add animation, haptics, and VoiceOver to copy buttons

💡 What:
- Wrapped `copiedReport` and `copiedColors` transient state changes in `withAnimation {}` blocks in `AppDiagnosticsView` and `TerminalSettingsView`.
- Added `UINotificationFeedbackGenerator` success haptics when copying.
- Added `UIAccessibility.post` announcements to explicitly tell screen reader users that the action succeeded.
- Added explicit `accessibilityLabel` and `accessibilityHint` to the App Diagnostics copy button.

🎯 Why:
- Actions like "Copy to Clipboard" provide no feedback on iOS for screen reader users or tactile feedback for sighted users. The state transitions were abrupt, causing a jarring visual experience. These changes soften the visual presentation while adding robust accessibility and haptic support.

♿ Accessibility:
- Users now hear a native "Report copied to clipboard" announcement.
- The button provides clear hints about its behavior via VoiceOver.

---
*PR created automatically by Jules for task [9063333604521525205](https://jules.google.com/task/9063333604521525205) started by @emkey1*