### PR TITLE
🎨 Palette: Add native keyboard click sounds to terminal accessory keys

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+## 2024-05-24 - Input View Audio Feedback
+**Learning:** In iOS, custom keyboard accessory views (like `inputAccessoryView`) do not automatically play native keyboard click sounds. Even with haptics triggered manually, the expected typing audio feedback is missing unless explicitly implemented.
+**Action:** Always conform custom input views to `UIInputViewAudioFeedback` (returning `true` for `enableInputClicksWhenVisible`) and manually call `UIDevice.current.playInputClick()` on key presses to ensure custom keyboards feel indistinguishable from native ones.

--- a/ios/Sources/App/TerminalNativeTextView.swift
+++ b/ios/Sources/App/TerminalNativeTextView.swift
@@ -2,7 +2,7 @@ import UIKit
 
 // MARK: - Helper Class for Self-Sizing Accessory View
 
-final class TerminalAccessoryView: UIView {
+final class TerminalAccessoryView: UIView, UIInputViewAudioFeedback {
     var targetHeight: CGFloat = 44 {
         didSet { invalidateIntrinsicContentSize() }
     }
@@ -10,6 +10,8 @@ final class TerminalAccessoryView: UIView {
     override var intrinsicContentSize: CGSize {
         CGSize(width: UIView.noIntrinsicMetric, height: targetHeight)
     }
+
+    var enableInputClicksWhenVisible: Bool { true }
 }
 
 // MARK: - Custom Native View with Expandable Settings Drawer
@@ -190,6 +192,7 @@ final class NativeTerminalView: UITextView {
 
     @objc private func keyTapped(_ sender: UIButton) {
         guard let title = sender.title(for: .normal) else { return }
+        UIDevice.current.playInputClick()
         if title == "⚙️" {
             toggleSettings()
         } else if title == "Tab" {


### PR DESCRIPTION
💡 What: The UX enhancement added native keyboard click sounds to the custom accessory keys above the terminal keyboard.
🎯 Why: Without this, tapping the custom keys (Tab, Esc, Ctrl, etc.) felt "dead" compared to the standard iOS keyboard keys, which provide satisfying auditory and haptic feedback. This change makes the custom terminal accessory bar feel like a first-class citizen of the iOS keyboard.
📸 Before/After: Visuals unchanged, purely an auditory and haptic (on supported devices) improvement.
♿ Accessibility: Provides necessary non-visual feedback that a key was successfully pressed, benefiting all users but particularly those relying on auditory cues.

---
*PR created automatically by Jules for task [12902152211864907260](https://jules.google.com/task/12902152211864907260) started by @emkey1*