### PR TITLE
🎨 Palette: Add native iOS keyboard click sounds to custom terminal accessory view

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+## 2024-06-23 - iOS Custom Keyboard Accessory Sounds
+**Learning:** Custom `UIInputView` keyboard accessory bars on iOS do not automatically produce the expected typing click sounds when users interact with them.
+**Action:** The view must conform to `UIInputViewAudioFeedback` with `enableInputClicksWhenVisible` returning `true`, and each key press action must manually invoke `UIDevice.current.playInputClick()` to match native keyboard UX.

--- a/ios/Sources/App/TerminalInputBridge.swift
+++ b/ios/Sources/App/TerminalInputBridge.swift
@@ -893,50 +893,62 @@ final class TerminalKeyInputView: UITextView {
 
     // MARK: - Accessory button actions
     @objc private func handleEsc() {
+        UIDevice.current.playInputClick()
         onInput?("\u{1B}")
     }
     
     @objc private func handleTab() {
+        UIDevice.current.playInputClick()
         onInput?("\t")
     }
 
     @objc private func handleCtrlToggle(_ sender: UIButton) {
+        UIDevice.current.playInputClick()
         controlLatch.toggle()
     }
 
     @objc private func handleAltToggle(_ sender: UIButton) {
+        UIDevice.current.playInputClick()
         optionLatch.toggle()
     }
 
     @objc private func handleUp() {
+        UIDevice.current.playInputClick()
         onInput?(arrowSequence("A"))
     }
 
     @objc private func handleDown() {
+        UIDevice.current.playInputClick()
         onInput?(arrowSequence("B"))
     }
 
     @objc private func handleLeft() {
+        UIDevice.current.playInputClick()
         onInput?(arrowSequence("D"))
     }
 
     @objc private func handleRight() {
+        UIDevice.current.playInputClick()
         onInput?(arrowSequence("C"))
     }
 
     @objc private func handleFSlash() {
+        UIDevice.current.playInputClick()
         onInput?("/")
     }
 
     @objc private func handleDot() {
+        UIDevice.current.playInputClick()
         onInput?(".")
     }
 
     @objc private func handleMinus() {
+        UIDevice.current.playInputClick()
         onInput?("-")
     }
    
     @objc private func handlePipe() {
+        UIDevice.current.playInputClick()
         onInput?("|")
     }
     
@@ -1054,4 +1066,9 @@ final class TerminalKeyInputView: UITextView {
             button.accessibilityTraits.remove(.selected)
         }
     }
+}
+
+
+extension TerminalKeyInputView: UIInputViewAudioFeedback {
+    var enableInputClicksWhenVisible: Bool { true }
 }


### PR DESCRIPTION
🎨 Palette: Add native iOS keyboard click sounds to custom terminal accessory view

💡 What: Conforms `TerminalKeyInputView` to `UIInputViewAudioFeedback` and manually invokes `UIDevice.current.playInputClick()` on all custom accessory button taps.
🎯 Why: Custom `UIInputView` keyboard accessory bars on iOS do not automatically produce typing click sounds, making them feel detached from the native keyboard experience. This restores the expected auditory feedback.
♿ Accessibility/UX: Restores standard tactile-auditory expectations for iOS users typing on the custom accessory bar.

---
*PR created automatically by Jules for task [9236320028732157775](https://jules.google.com/task/9236320028732157775) started by @emkey1*