### PR TITLE
🎨 Palette: AppDiagnosticsView Micro-UX & Accessibility Improvements

### DIFF
--- a/ios/Sources/App/AppDiagnosticsView.swift
+++ b/ios/Sources/App/AppDiagnosticsView.swift
@@ -880,18 +880,27 @@ struct AppDiagnosticsView: View {
                 ToolbarItemGroup(placement: .primaryAction) {
                     Button(copiedReport ? "Copied" : "Copy Report") {
                         runner.copyReportToPasteboard()
-                        copiedReport = true
+                        withAnimation {
+                            copiedReport = true
+                        }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                            copiedReport = false
+                            withAnimation {
+                                copiedReport = false
+                            }
                         }
                     }
                     .disabled(runner.report.isEmpty)
+                    .accessibilityLabel(copiedReport ? "Copied Report" : "Copy Report")
+                    .accessibilityHint("Copies the diagnostic report text to the clipboard")
 
                     Button(runner.isRunning ? "Running..." : (runner.checks.isEmpty ? "Run Diagnostics" : "Run Again")) {
-                        copiedReport = false
+                        withAnimation {
+                            copiedReport = false
+                        }
                         runner.run()
                     }
                     .disabled(runner.isRunning)
+                    .accessibilityHint("Executes the app's diagnostic sanity checks")
                 }
             }
         }


### PR DESCRIPTION
💡 **What**: Added `withAnimation` blocks around the state changes for the "Copied Report" transient text, and added explicit `accessibilityLabel` and `accessibilityHint` modifiers to the "Copy Report" and "Run Diagnostics" buttons in `AppDiagnosticsView`.
🎯 **Why**: Previously, the "Copied!" text would snap in and out abruptly, creating a jarring visual experience. Wrapping the state toggle in `withAnimation` provides a smooth cross-dissolve transition. Additionally, VoiceOver users lacked clear context for what the "Copy Report" and "Run Diagnostics" buttons did, especially regarding the transient success state. The new accessibility modifiers ensure the actions and their outcomes are clearly announced.
♿ **Accessibility**: 
- Added `.accessibilityLabel` to dynamically read "Copied Report" when the copy action succeeds.
- Added `.accessibilityHint` to the copy button to clarify it copies the diagnostic report text to the clipboard.
- Added `.accessibilityHint` to the run button to clarify it executes the app's diagnostic sanity checks.

---
*PR created automatically by Jules for task [7435828072089591663](https://jules.google.com/task/7435828072089591663) started by @emkey1*