### PR TITLE
🎨 Palette: Add native typing audio feedback to custom terminal accessory keys

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+## 2025-05-18 - Missing Typing Sounds in Custom Keyboard Accessory Bars
+**Learning:** Custom input accessory views (like a terminal's extra keys row) often fail to play the native iOS keyboard typing click sound, making them feel dead or non-native compared to the standard keyboard.
+**Action:** When implementing custom `UIInputView` keyboards or accessory bars, ensure the view conforms to `UIInputViewAudioFeedback` with `enableInputClicksWhenVisible` returning true, and manually call `UIDevice.current.playInputClick()` on key presses to provide expected native typing sounds.

--- a/ios/Sources/App/TerminalInputBridge.swift
+++ b/ios/Sources/App/TerminalInputBridge.swift
@@ -87,6 +87,11 @@ struct TerminalInputBridge: UIViewRepresentable {
 }
 
 @MainActor
+final class TerminalAccessoryView: UIInputView, UIInputViewAudioFeedback {
+    var enableInputClicksWhenVisible: Bool { return true }
+}
+
+@MainActor
 final class TerminalKeyInputView: UITextView {
     var onInput: ((String) -> Void)?
     var onPaste: ((String) -> Void)?
@@ -136,7 +141,7 @@ final class TerminalKeyInputView: UITextView {
     }
 
     override init(frame: CGRect, textContainer: NSTextContainer?) {
-        self.accessoryBar = UIInputView(frame: .zero, inputViewStyle: .keyboard)
+        self.accessoryBar = TerminalAccessoryView(frame: .zero, inputViewStyle: .keyboard)
         self.repeatKeyCommands = []
         super.init(frame: frame, textContainer: textContainer)
         configureAccessoryBar()
@@ -146,7 +151,7 @@ final class TerminalKeyInputView: UITextView {
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
-        self.accessoryBar = UIInputView(frame: .zero, inputViewStyle: .keyboard)
+        self.accessoryBar = TerminalAccessoryView(frame: .zero, inputViewStyle: .keyboard)
         self.repeatKeyCommands = []
         super.init(coder: coder)
         configureAccessoryBar()
@@ -172,7 +177,7 @@ final class TerminalKeyInputView: UITextView {
     private weak var optionButton: UIButton?
 
     // MARK: - FIXED ACCESSORY BAR
-    private let accessoryBar: UIInputView
+    private let accessoryBar: TerminalAccessoryView
 
     override var inputAccessoryView: UIView? {
         get {
@@ -218,6 +223,7 @@ final class TerminalKeyInputView: UITextView {
             button.configuration = config
             button.titleLabel?.font = UIFontMetrics.default.scaledFont(for: .systemFont(ofSize: 15, weight: .semibold))
             button.addTarget(self, action: action, for: .touchUpInside)
+            button.addTarget(self, action: #selector(playInputClickSound), for: .touchDown)
             return button
         }
 
@@ -892,6 +898,10 @@ final class TerminalKeyInputView: UITextView {
     }
 
     // MARK: - Accessory button actions
+    @objc private func playInputClickSound() {
+        UIDevice.current.playInputClick()
+    }
+
     @objc private func handleEsc() {
         onInput?("\u{1B}")
     }


### PR DESCRIPTION
💡 What: Implemented `UIInputViewAudioFeedback` on the custom terminal accessory bar and bound `UIDevice.current.playInputClick()` to the `.touchDown` events of the keys.
🎯 Why: Custom `UIInputView` keys default to being silent, making the terminal's top row feel non-native and detached from the standard iOS keyboard below it. 
♿ Accessibility: Honors system-level keyboard click settings seamlessly by relying on native APIs.
📓 Learning: Recorded insight in `.Jules/palette.md` for future custom keyboard implementations.

---
*PR created automatically by Jules for task [6797571852848488829](https://jules.google.com/task/6797571852848488829) started by @emkey1*