### PR TITLE
⚡ Bolt: Optimize ADD, SUBTRACT, MULTIPLY VM instructions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-18 - [Optimization of INT_DIV and MOD]
 **Learning:** When adding fast paths for arithmetic in the VM using smaller data types (like 32-bit math for `TYPE_INT32`), you must be extremely careful to preserve the original semantics of the fallback path. In this codebase, the standard integer types are backed by 64-bit `long long`. Therefore, an operation that overflows a 32-bit integer (like `INT32_MIN / -1`) should *not* trap or throw an error; it needs to be promoted cleanly to its valid 64-bit result to avoid breaking valid language semantics.
 **Action:** Always verify that edge cases in numerical fast paths yield the exact same result as the slower generic path, rather than naively enforcing the bounds of the smaller optimized type.
+## 2024-06-25 - [Optimization of ADD, SUBTRACT, MULTIPLY]
+**Learning:** `TYPE_INT32` is commonly used in `ADD`, `SUBTRACT` and `MULTIPLY` operations inside `vm.c` inside `for` loops. The fallback `BINARY_OP` macro incurs a performance penalty when doing type checks and popping off stack items. Adding in-place operations for `TYPE_INT32` directly accessing and mutating the values on stack increases performance.
+**Action:** When adding arithmetic operators fast path check if you can just access stack pointer by offsets (`vm->stackTop[-1]`, `vm->stackTop[-2]`) and decrement `stackTop`.

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -6342,9 +6342,42 @@ dispatch_switch:
                 push(vm, makePointer(&frame->slots[slot], NULL));
                 break;
             }
-            case ADD:      BINARY_OP("+", instruction_val); break;
-            case SUBTRACT: BINARY_OP("-", instruction_val); break;
-            case MULTIPLY: BINARY_OP("*", instruction_val); break;
+            case ADD: {
+                if (vm->stackTop[-1].type == TYPE_INT32 && vm->stackTop[-2].type == TYPE_INT32) {
+                    int32_t iresult;
+                    if (!__builtin_add_overflow((int32_t)vm->stackTop[-2].i_val, (int32_t)vm->stackTop[-1].i_val, &iresult)) {
+                        vm->stackTop[-2].i_val = iresult;
+                        vm->stackTop--;
+                        break;
+                    }
+                }
+                BINARY_OP("+", instruction_val);
+                break;
+            }
+            case SUBTRACT: {
+                if (vm->stackTop[-1].type == TYPE_INT32 && vm->stackTop[-2].type == TYPE_INT32) {
+                    int32_t iresult;
+                    if (!__builtin_sub_overflow((int32_t)vm->stackTop[-2].i_val, (int32_t)vm->stackTop[-1].i_val, &iresult)) {
+                        vm->stackTop[-2].i_val = iresult;
+                        vm->stackTop--;
+                        break;
+                    }
+                }
+                BINARY_OP("-", instruction_val);
+                break;
+            }
+            case MULTIPLY: {
+                if (vm->stackTop[-1].type == TYPE_INT32 && vm->stackTop[-2].type == TYPE_INT32) {
+                    int32_t iresult;
+                    if (!__builtin_mul_overflow((int32_t)vm->stackTop[-2].i_val, (int32_t)vm->stackTop[-1].i_val, &iresult)) {
+                        vm->stackTop[-2].i_val = iresult;
+                        vm->stackTop--;
+                        break;
+                    }
+                }
+                BINARY_OP("*", instruction_val);
+                break;
+            }
             case DIVIDE:   BINARY_OP("/", instruction_val); break;
 
             case NEGATE: {


### PR DESCRIPTION
⚡ Bolt: Optimize ADD, SUBTRACT, MULTIPLY VM instructions

💡 What: Implemented fast paths in `src/vm/vm.c` for `ADD`, `SUBTRACT`, and `MULTIPLY` VM instructions when both operands are `TYPE_INT32`. 
🎯 Why: These operations are extremely common, especially in loops. The fast path directly modifies the values on the stack, bypassing the `BINARY_OP` macro which involves multiple stack pops/pushes and type checks. It uses `__builtin_*_overflow` to ensure safety and correctly fall back to the slower path that handles 64-bit promotion when bounds are exceeded.
📊 Impact: Expected to reduce execution time for tight integer loops by >5% (tested using a 5000x5000 nested integer addition loop).
🔬 Measurement: Verified with `make -C build pascal` and `./Tests/run_pascal_tests.sh`. Can be benchmarked using large integer math loops.

---
*PR created automatically by Jules for task [4428333649891824831](https://jules.google.com/task/4428333649891824831) started by @emkey1*