### PR TITLE
🎨 Palette: Add missing audio feedback for iOS accessory bar buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-18 - Missing keyboard sounds on custom iOS accessory views
+**Learning:** Custom UIInputView accessory bars on iOS do not automatically play native keyboard click sounds, which can feel broken to users who rely on audio feedback. They must explicitly conform to UIInputViewAudioFeedback (returning true for enableInputClicksWhenVisible) and manually trigger UIDevice.current.playInputClick() on each key press.
+**Action:** Whenever implementing custom keyboard buttons or accessory views on iOS, implement UIInputViewAudioFeedback and explicitly trigger playInputClick().

--- a/ios/Sources/App/TerminalInputBridge.swift
+++ b/ios/Sources/App/TerminalInputBridge.swift
@@ -87,7 +87,11 @@ struct TerminalInputBridge: UIViewRepresentable {
 }
 
 @MainActor
-final class TerminalKeyInputView: UITextView {
+final class TerminalKeyInputView: UITextView, UIInputViewAudioFeedback {
+    var enableInputClicksWhenVisible: Bool {
+        return true
+    }
+
     var onInput: ((String) -> Void)?
     var onPaste: ((String) -> Void)?
     var onCopy: (() -> Void)?
@@ -893,50 +897,62 @@ final class TerminalKeyInputView: UITextView {
 
     // MARK: - Accessory button actions
     @objc private func handleEsc() {
+        UIDevice.current.playInputClick()
         onInput?("\u{1B}")
     }
     
     @objc private func handleTab() {
+        UIDevice.current.playInputClick()
         onInput?("\t")
     }
 
     @objc private func handleCtrlToggle(_ sender: UIButton) {
+        UIDevice.current.playInputClick()
         controlLatch.toggle()
     }
 
     @objc private func handleAltToggle(_ sender: UIButton) {
+        UIDevice.current.playInputClick()
         optionLatch.toggle()
     }
 
     @objc private func handleUp() {
+        UIDevice.current.playInputClick()
         onInput?(arrowSequence("A"))
     }
 
     @objc private func handleDown() {
+        UIDevice.current.playInputClick()
         onInput?(arrowSequence("B"))
     }
 
     @objc private func handleLeft() {
+        UIDevice.current.playInputClick()
         onInput?(arrowSequence("D"))
     }
 
     @objc private func handleRight() {
+        UIDevice.current.playInputClick()
         onInput?(arrowSequence("C"))
     }
 
     @objc private func handleFSlash() {
+        UIDevice.current.playInputClick()
         onInput?("/")
     }
 
     @objc private func handleDot() {
+        UIDevice.current.playInputClick()
         onInput?(".")
     }
 
     @objc private func handleMinus() {
+        UIDevice.current.playInputClick()
         onInput?("-")
     }
    
     @objc private func handlePipe() {
+        UIDevice.current.playInputClick()
         onInput?("|")
     }
     


### PR DESCRIPTION
💡 **What**: Added native keyboard audio feedback (typing sounds) to the custom iOS keyboard accessory bar buttons in the terminal emulator.

🎯 **Why**: When users tap standard keys on the iOS software keyboard, they hear a distinct typing click (if enabled in settings). However, tapping the custom keys on the accessory bar above the keyboard (like Esc, Tab, arrows, modifier keys) was completely silent. This lack of feedback breaks user expectations and makes the custom keys feel disconnected or unresponsive compared to the native keyboard experience.

♿ **Accessibility**: This is an auditory accessibility enhancement. Users who rely on auditory feedback to confirm key presses (including those with visual impairments using the keyboard, or users typing quickly without looking at the screen) now receive the same confirmation for custom terminal keys as they do for standard alphanumeric keys.

* Conformed `TerminalKeyInputView` to `UIInputViewAudioFeedback` and set `enableInputClicksWhenVisible` to true.
* Added `UIDevice.current.playInputClick()` to all button handlers in `TerminalInputBridge.swift`.
* Documented this pattern in the `.jules/palette.md` journal.

---
*PR created automatically by Jules for task [7688516268390291404](https://jules.google.com/task/7688516268390291404) started by @emkey1*