### PR TITLE
🎨 Palette: App Diagnostics View Accessibility and UX improvements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+## 2025-03-22 - Transient Animations and Toolbar Button Accessibility
+**Learning:** Found that secondary screens like App Diagnostics lacked graceful transitions when presenting temporary states (like 'Copied' text for reports) and lacked `accessibilityHint`s on primary navigation and action buttons (like Close and Run).
+**Action:** When adding transient text or modifying states in secondary view toolbars, always wrap the boolean assignments in `withAnimation` blocks. Additionally, verify that every `Button` element without inherently obvious text (like an icon or brief verb) has an `accessibilityHint` attached, dynamically updating its `accessibilityLabel` when transient state dictates it.

--- a/ios/Sources/App/AppDiagnosticsView.swift
+++ b/ios/Sources/App/AppDiagnosticsView.swift
@@ -876,22 +876,32 @@ struct AppDiagnosticsView: View {
                     Button("Close") {
                         dismiss()
                     }
+                    .accessibilityHint("Dismisses the diagnostics view")
                 }
                 ToolbarItemGroup(placement: .primaryAction) {
                     Button(copiedReport ? "Copied" : "Copy Report") {
                         runner.copyReportToPasteboard()
-                        copiedReport = true
+                        withAnimation {
+                            copiedReport = true
+                        }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                            copiedReport = false
+                            withAnimation {
+                                copiedReport = false
+                            }
                         }
                     }
                     .disabled(runner.report.isEmpty)
+                    .accessibilityLabel(copiedReport ? "Copied" : "Copy Report")
+                    .accessibilityHint("Copies the diagnostic report to the clipboard")
 
                     Button(runner.isRunning ? "Running..." : (runner.checks.isEmpty ? "Run Diagnostics" : "Run Again")) {
-                        copiedReport = false
+                        withAnimation {
+                            copiedReport = false
+                        }
                         runner.run()
                     }
                     .disabled(runner.isRunning)
+                    .accessibilityHint("Starts or restarts the diagnostic tests")
                 }
             }
         }


### PR DESCRIPTION
This PR adds a micro-UX enhancement to the iOS App Diagnostics view:

💡 **What:** Added `withAnimation` blocks for transient "Copied" text state, and added explicit `accessibilityHint`s to the toolbar buttons (Close, Copy Report, Run Diagnostics).
🎯 **Why:** To prevent abrupt visual state changes and provide critical context to VoiceOver users for toolbar actions.
♿ **Accessibility:** Added hints and dynamic labels to ensure screen readers announce the outcome of button actions clearly.

---
*PR created automatically by Jules for task [4185552086588590163](https://jules.google.com/task/4185552086588590163) started by @emkey1*