### PR TITLE
🎨 Palette: Add native typing sounds to custom keyboard accessory view

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+## 2026-06-30 - Native Typing Sounds for Custom Keyboard Accessory Views
+**Learning:** Custom UIInputView accessory bars on iOS do not play standard keyboard typing clicks by default, making them feel unresponsive compared to the system keyboard.
+**Action:** Always make the custom view conform to `UIInputViewAudioFeedback` with `enableInputClicksWhenVisible = true` and manually call `UIDevice.current.playInputClick()` in the button action handlers.

--- a/ios/Sources/App/TerminalInputBridge.swift
+++ b/ios/Sources/App/TerminalInputBridge.swift
@@ -87,7 +87,7 @@ struct TerminalInputBridge: UIViewRepresentable {
 }
 
 @MainActor
-final class TerminalKeyInputView: UITextView {
+final class TerminalKeyInputView: UITextView, UIInputViewAudioFeedback {
     var onInput: ((String) -> Void)?
     var onPaste: ((String) -> Void)?
     var onCopy: (() -> Void)?
@@ -104,6 +104,9 @@ final class TerminalKeyInputView: UITextView {
         }
     }
     var applicationCursorEnabled: Bool = false
+
+    var enableInputClicksWhenVisible: Bool { return true }
+
     private var hardwareKeyboardConnected: Bool = false
     private var softKeyboardVisible: Bool = false
     private var keyboardObservers: [NSObjectProtocol] = []
@@ -893,50 +896,62 @@ final class TerminalKeyInputView: UITextView {
 
     // MARK: - Accessory button actions
     @objc private func handleEsc() {
+        UIDevice.current.playInputClick()
         onInput?("\u{1B}")
     }
     
     @objc private func handleTab() {
+        UIDevice.current.playInputClick()
         onInput?("\t")
     }
 
     @objc private func handleCtrlToggle(_ sender: UIButton) {
+        UIDevice.current.playInputClick()
         controlLatch.toggle()
     }
 
     @objc private func handleAltToggle(_ sender: UIButton) {
+        UIDevice.current.playInputClick()
         optionLatch.toggle()
     }
 
     @objc private func handleUp() {
+        UIDevice.current.playInputClick()
         onInput?(arrowSequence("A"))
     }
 
     @objc private func handleDown() {
+        UIDevice.current.playInputClick()
         onInput?(arrowSequence("B"))
     }
 
     @objc private func handleLeft() {
+        UIDevice.current.playInputClick()
         onInput?(arrowSequence("D"))
     }
 
     @objc private func handleRight() {
+        UIDevice.current.playInputClick()
         onInput?(arrowSequence("C"))
     }
 
     @objc private func handleFSlash() {
+        UIDevice.current.playInputClick()
         onInput?("/")
     }
 
     @objc private func handleDot() {
+        UIDevice.current.playInputClick()
         onInput?(".")
     }
 
     @objc private func handleMinus() {
+        UIDevice.current.playInputClick()
         onInput?("-")
     }
    
     @objc private func handlePipe() {
+        UIDevice.current.playInputClick()
         onInput?("|")
     }
     

--- a/ios/Sources/App/TerminalNativeTextView.swift
+++ b/ios/Sources/App/TerminalNativeTextView.swift
@@ -14,9 +14,12 @@ final class TerminalAccessoryView: UIView {
 
 // MARK: - Custom Native View with Expandable Settings Drawer
 
-final class NativeTerminalView: UITextView {
+final class NativeTerminalView: UITextView, UIInputViewAudioFeedback {
     var onSettingsChanged: ((CGFloat, UIColor) -> Void)?
     var onInput: ((String) -> Void)?
+
+    var enableInputClicksWhenVisible: Bool { return true }
+
     private var softKeyboardVisible: Bool = false
     private let amberColor = UIColor(red: 1.0, green: 0.74, blue: 0.23, alpha: 1.0)
 
@@ -189,6 +192,7 @@ final class NativeTerminalView: UITextView {
     // MARK: Actions
 
     @objc private func keyTapped(_ sender: UIButton) {
+        UIDevice.current.playInputClick()
         guard let title = sender.title(for: .normal) else { return }
         if title == "⚙️" {
             toggleSettings()


### PR DESCRIPTION
💡 **What:** Added native iOS typing sounds to the custom keyboard accessory keys (like arrows, esc, tab, toggles) in the terminal view.
🎯 **Why:** Custom `UIInputView` accessory rows do not inherit standard keyboard clicks by default. This makes the keys feel "dead" or unresponsive compared to typing on the regular iOS system keyboard beneath them.
♿ **Accessibility:** Provides auditory confirmation that a custom accessory key was successfully pressed, benefiting both sighted and visually impaired users.
📸 **Before/After:** No visual changes, auditory enhancement only.

---
*PR created automatically by Jules for task [13434137452636313243](https://jules.google.com/task/13434137452636313243) started by @emkey1*