### PR TITLE
🎨 Palette: Add typing audio feedback to custom terminal keys

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+## 2026-07-01 - Add native typing audio feedback to iOS custom keyboard accessory view
+**Learning:** In iOS, standard `UIInputView` keyboards play typing click sounds by default. Custom keyboard accessory views (e.g. `UIView` with `UIButtons`) will *not* play typing sounds unless the view explicitly conforms to `UIInputViewAudioFeedback` and returns `true` for `enableInputClicksWhenVisible`, AND the key press handler explicitly calls `UIDevice.current.playInputClick()`.
+**Action:** When implementing custom software keyboards or accessory bars with buttons in iOS, ensure they conform to `UIInputViewAudioFeedback` and invoke `playInputClick()` to match the system UX for typing.

--- a/ios/Sources/App/TerminalNativeTextView.swift
+++ b/ios/Sources/App/TerminalNativeTextView.swift
@@ -2,13 +2,17 @@ import UIKit
 
 // MARK: - Helper Class for Self-Sizing Accessory View
 
-final class TerminalAccessoryView: UIView {
+final class TerminalAccessoryView: UIView, UIInputViewAudioFeedback {
     var targetHeight: CGFloat = 44 {
         didSet { invalidateIntrinsicContentSize() }
     }
 
     override var intrinsicContentSize: CGSize {
         CGSize(width: UIView.noIntrinsicMetric, height: targetHeight)
+    }
+
+    var enableInputClicksWhenVisible: Bool {
+        return true
     }
 }
 
@@ -190,6 +194,9 @@ final class NativeTerminalView: UITextView {
 
     @objc private func keyTapped(_ sender: UIButton) {
         guard let title = sender.title(for: .normal) else { return }
+
+        UIDevice.current.playInputClick()
+
         if title == "⚙️" {
             toggleSettings()
         } else if title == "Tab" {


### PR DESCRIPTION
💡 **What**: Added standard iOS typing audio feedback to the custom keys (Esc, Tab, Ctrl, /, -, Settings) in the terminal accessory view.
🎯 **Why**: Previously, tapping these buttons was silent, breaking the expected native iOS keyboard experience. Now they play the standard iOS input click sound, providing immediate, expected auditory feedback to the user.
📸 **Before/After**: The accessory bar looks the same, but tapping keys now plays the iOS click sound.
♿ **Accessibility**: Improves non-visual feedback during typing.

---
*PR created automatically by Jules for task [282619815143462468](https://jules.google.com/task/282619815143462468) started by @emkey1*