### PR TITLE
🎨 Palette: Add VoiceOver/haptic feedback for transient copy action

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+
+## 2026-07-02 - Transient Visual States and Accessibility
+**Learning:** Transient visual states in SwiftUI (like showing 'Copied!' temporarily) need explicit VoiceOver announcements and haptic feedback, as they can be missed by non-sighted users.
+**Action:** When implementing silent or transient actions in the UI, provide non-visual confirmation by combining visual updates with VoiceOver announcements (`UIAccessibility.post`) and haptic feedback (`UINotificationFeedbackGenerator`).

--- a/ios/Sources/App/TerminalSettingsView.swift
+++ b/ios/Sources/App/TerminalSettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct TerminalSettingsView: View {
     @ObservedObject private var appearanceSettings: TerminalTabAppearanceSettings
@@ -157,6 +158,8 @@ struct TerminalSettingsView: View {
                         withAnimation {
                             copiedColors = true
                         }
+                        UINotificationFeedbackGenerator().notificationOccurred(.success)
+                        UIAccessibility.post(notification: .announcement, argument: "Copied first tab colors")
                         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                             withAnimation {
                                 copiedColors = false


### PR DESCRIPTION
💡 What: Added haptic feedback (`UINotificationFeedbackGenerator`) and explicit VoiceOver announcements (`UIAccessibility.post`) to the "Copy First Tab Values" button in `TerminalSettingsView.swift`.
🎯 Why: The "Copied!" state is transient (lasts 2 seconds). Without non-visual feedback, screen reader users and users relying on haptics miss the confirmation that their action succeeded.
📸 Before/After: N/A (non-visual change)
♿ Accessibility: Ensures the transient state change is announced to VoiceOver and provides physical confirmation via haptics.

---
*PR created automatically by Jules for task [5661078961408477759](https://jules.google.com/task/5661078961408477759) started by @emkey1*