### PR TITLE
🎨 Palette: Animate and make accessible the App Diagnostics copy action

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+## 2026-07-03 - Missing Animation and Announcements for Transient UI States
+**Learning:** Discovered that the App Diagnostics 'Copy Report' button updated its text to 'Copied' without any transition animation and without notifying screen readers of the state change. This resulted in an abrupt visual jump and left VoiceOver users unaware that the copy action succeeded.
+**Action:** Always wrap transient visual text changes in `withAnimation {}` for graceful transitions. Concurrently, use `UIAccessibility.post(notification: .announcement, argument: "...")` and ensure the button has a dynamic `.accessibilityLabel` that reflects the current state to guarantee the transient feedback is accessible.

--- a/ios/Sources/App/AppDiagnosticsView.swift
+++ b/ios/Sources/App/AppDiagnosticsView.swift
@@ -880,12 +880,19 @@ struct AppDiagnosticsView: View {
                 ToolbarItemGroup(placement: .primaryAction) {
                     Button(copiedReport ? "Copied" : "Copy Report") {
                         runner.copyReportToPasteboard()
-                        copiedReport = true
+                        withAnimation {
+                            copiedReport = true
+                        }
+                        UIAccessibility.post(notification: .announcement, argument: "Copied report")
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                            copiedReport = false
+                            withAnimation {
+                                copiedReport = false
+                            }
                         }
                     }
                     .disabled(runner.report.isEmpty)
+                    .accessibilityLabel(copiedReport ? "Copied diagnostic report" : "Copy diagnostic report")
+                    .accessibilityHint("Copies the diagnostics report to the clipboard")
 
                     Button(runner.isRunning ? "Running..." : (runner.checks.isEmpty ? "Run Diagnostics" : "Run Again")) {
                         copiedReport = false


### PR DESCRIPTION
💡 What: Added a smooth animation when transitioning the "Copy Report" button state to "Copied" in the App Diagnostics view, along with VoiceOver accessibility announcements.
🎯 Why: The original state change was abrupt visually and completely invisible to screen readers, leaving users with accessibility needs unaware that their action succeeded.
📸 Before/After: Visual jump replaced with a cross-fade transition.
♿ Accessibility: VoiceOver now announces "Copied report" upon success, and the button's `accessibilityLabel` dynamically updates between "Copy diagnostic report" and "Copied diagnostic report" with an explanatory `accessibilityHint`.

---
*PR created automatically by Jules for task [8645914076903737279](https://jules.google.com/task/8645914076903737279) started by @emkey1*