### PR TITLE
🎨 Palette: Add missing audio feedback to custom terminal keys

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+## 2024-05-20 - Custom UIInputView Audio Feedback
+**Learning:** When implementing custom `UIInputView` keyboard accessory bars on iOS, native typing sound effects are not played automatically.
+**Action:** The custom view must conform to the `UIInputViewAudioFeedback` protocol, returning `true` for `enableInputClicksWhenVisible`. Additionally, action handlers triggered by the custom keys must manually call `UIDevice.current.playInputClick()` to ensure expected native audio feedback.

--- a/ios/Sources/App/TerminalInputBridge.swift
+++ b/ios/Sources/App/TerminalInputBridge.swift
@@ -87,6 +87,13 @@ struct TerminalInputBridge: UIViewRepresentable {
 }
 
 @MainActor
+final class TerminalAccessoryInputView: UIInputView, UIInputViewAudioFeedback {
+    var enableInputClicksWhenVisible: Bool {
+        return true
+    }
+}
+
+@MainActor
 final class TerminalKeyInputView: UITextView {
     var onInput: ((String) -> Void)?
     var onPaste: ((String) -> Void)?
@@ -136,7 +143,7 @@ final class TerminalKeyInputView: UITextView {
     }
 
     override init(frame: CGRect, textContainer: NSTextContainer?) {
-        self.accessoryBar = UIInputView(frame: .zero, inputViewStyle: .keyboard)
+        self.accessoryBar = TerminalAccessoryInputView(frame: .zero, inputViewStyle: .keyboard)
         self.repeatKeyCommands = []
         super.init(frame: frame, textContainer: textContainer)
         configureAccessoryBar()
@@ -146,7 +153,7 @@ final class TerminalKeyInputView: UITextView {
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
-        self.accessoryBar = UIInputView(frame: .zero, inputViewStyle: .keyboard)
+        self.accessoryBar = TerminalAccessoryInputView(frame: .zero, inputViewStyle: .keyboard)
         self.repeatKeyCommands = []
         super.init(coder: coder)
         configureAccessoryBar()
@@ -172,7 +179,7 @@ final class TerminalKeyInputView: UITextView {
     private weak var optionButton: UIButton?
 
     // MARK: - FIXED ACCESSORY BAR
-    private let accessoryBar: UIInputView
+    private let accessoryBar: TerminalAccessoryInputView
 
     override var inputAccessoryView: UIView? {
         get {
@@ -893,50 +900,62 @@ final class TerminalKeyInputView: UITextView {
 
     // MARK: - Accessory button actions
     @objc private func handleEsc() {
+        UIDevice.current.playInputClick()
         onInput?("\u{1B}")
     }
     
     @objc private func handleTab() {
+        UIDevice.current.playInputClick()
         onInput?("\t")
     }
 
     @objc private func handleCtrlToggle(_ sender: UIButton) {
+        UIDevice.current.playInputClick()
         controlLatch.toggle()
     }
 
     @objc private func handleAltToggle(_ sender: UIButton) {
+        UIDevice.current.playInputClick()
         optionLatch.toggle()
     }
 
     @objc private func handleUp() {
+        UIDevice.current.playInputClick()
         onInput?(arrowSequence("A"))
     }
 
     @objc private func handleDown() {
+        UIDevice.current.playInputClick()
         onInput?(arrowSequence("B"))
     }
 
     @objc private func handleLeft() {
+        UIDevice.current.playInputClick()
         onInput?(arrowSequence("D"))
     }
 
     @objc private func handleRight() {
+        UIDevice.current.playInputClick()
         onInput?(arrowSequence("C"))
     }
 
     @objc private func handleFSlash() {
+        UIDevice.current.playInputClick()
         onInput?("/")
     }
 
     @objc private func handleDot() {
+        UIDevice.current.playInputClick()
         onInput?(".")
     }
 
     @objc private func handleMinus() {
+        UIDevice.current.playInputClick()
         onInput?("-")
     }
    
     @objc private func handlePipe() {
+        UIDevice.current.playInputClick()
         onInput?("|")
     }
     


### PR DESCRIPTION
💡 **What:** Adds native typing sounds (audio feedback) to the custom terminal keyboard accessory bar.
🎯 **Why:** Custom `UIInputView` keyboards do not play native click sounds by default. This makes typing on the custom terminal keys (arrows, modifiers, symbols) feel "dead" compared to the native iOS keyboard. 
♿ **Accessibility/UX:** Restores the expected auditory feedback standard on iOS keyboards, confirming to users that their tap was registered without needing visual confirmation.
📖 **Journaled:** Added learning to `.Jules/palette.md` explaining the `UIInputViewAudioFeedback` protocol requirement.

---
*PR created automatically by Jules for task [14988865717481076915](https://jules.google.com/task/14988865717481076915) started by @emkey1*