### PR TITLE
🎨 Palette: Add transient action feedback and animations to copy buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+## 2024-05-18 - Transient Action Accessibility and UX
+**Learning:** For silent or transient actions in the iOS UI (like copying text or applying values that update the UI momentarily), visual state changes alone are insufficient for screen reader users and lack tactile confirmation.
+**Action:** Always combine visual updates (wrapped in `withAnimation`) with VoiceOver announcements (`UIAccessibility.post(notification: .announcement, argument: "...")`) and haptic feedback (`UINotificationFeedbackGenerator().notificationOccurred(.success)`).

--- a/ios/Sources/App/AppDiagnosticsView.swift
+++ b/ios/Sources/App/AppDiagnosticsView.swift
@@ -880,9 +880,15 @@ struct AppDiagnosticsView: View {
                 ToolbarItemGroup(placement: .primaryAction) {
                     Button(copiedReport ? "Copied" : "Copy Report") {
                         runner.copyReportToPasteboard()
-                        copiedReport = true
+                        UINotificationFeedbackGenerator().notificationOccurred(.success)
+                        UIAccessibility.post(notification: .announcement, argument: "Copied report")
+                        withAnimation {
+                            copiedReport = true
+                        }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                            copiedReport = false
+                            withAnimation {
+                                copiedReport = false
+                            }
                         }
                     }
                     .disabled(runner.report.isEmpty)

--- a/ios/Sources/App/TerminalSettingsView.swift
+++ b/ios/Sources/App/TerminalSettingsView.swift
@@ -154,6 +154,8 @@ struct TerminalSettingsView: View {
 
                     Button {
                         _ = tabManager.copyFirstTabColors(tabId: tabId)
+                        UINotificationFeedbackGenerator().notificationOccurred(.success)
+                        UIAccessibility.post(notification: .announcement, argument: "Copied first tab colors")
                         withAnimation {
                             copiedColors = true
                         }


### PR DESCRIPTION
💡 **What**: Added `withAnimation` and `UINotificationFeedbackGenerator().notificationOccurred(.success)` along with VoiceOver announcements for the "Copy Report" (Diagnostics) and "Copy First Tab Values" (Settings) buttons.
🎯 **Why**: When a copy button triggers an action, a purely visual state change (e.g. changing text to "Copied!" for 2 seconds) is not announced to VoiceOver users and feels abrupt without animation. This adds tactile feedback and screen-reader announcements to make the interaction satisfying and accessible.
📸 **Before/After**: Code changes only.
♿ **Accessibility**: VoiceOver users now hear "Copied report" and "Copied first tab colors", and feel a success haptic, avoiding ambiguity when interacting with these buttons.

---
*PR created automatically by Jules for task [5041436502765566537](https://jules.google.com/task/5041436502765566537) started by @emkey1*