### PR TITLE
🎨 Palette: Add haptics and a11y to settings copy action

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+## 2026-07-07 - Add Haptics to Settings Screen
+**Learning:** For silent or transient actions in the iOS UI (like copying text or applying a setting), providing non-visual confirmation through explicit VoiceOver announcements (`UIAccessibility.post`) and haptic feedback (`UINotificationFeedbackGenerator`) significantly improves accessibility and tactile feel, making the interaction clearer for all users.
+**Action:** When adding transient visual feedback like a 'Copied!' label, ensure `import UIKit` is included and explicitly post an accessibility announcement along with triggering a haptic success notification.

--- a/ios/Sources/App/TerminalSettingsView.swift
+++ b/ios/Sources/App/TerminalSettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct TerminalSettingsView: View {
     @ObservedObject private var appearanceSettings: TerminalTabAppearanceSettings
@@ -157,6 +158,9 @@ struct TerminalSettingsView: View {
                         withAnimation {
                             copiedColors = true
                         }
+                        UIAccessibility.post(notification: .announcement, argument: "Colors copied successfully")
+                        let generator = UINotificationFeedbackGenerator()
+                        generator.notificationOccurred(.success)
                         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                             withAnimation {
                                 copiedColors = false


### PR DESCRIPTION
Added explicit VoiceOver announcements and haptic feedback when copying terminal tab colors.

---
*PR created automatically by Jules for task [16414105255605960127](https://jules.google.com/task/16414105255605960127) started by @emkey1*