### PR TITLE
🎨 Palette: Add non-visual feedback to diagnostic report copy

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+
+## 2025-05-18 - Non-Visual Confirmation for Transient UI Actions
+**Learning:** Copying text in transient UI locations (like diagnostic views or toolbars) often lacks sufficient non-visual feedback for VoiceOver users and those relying on haptics, even if a visual "Copied!" text is shown.
+**Action:** Always pair clipboard operations (`UIPasteboard`) with `UINotificationFeedbackGenerator().notificationOccurred(.success)` and `UIAccessibility.post(notification: .announcement, argument: "Copied...")` to provide comprehensive non-visual confirmation.

--- a/ios/Sources/App/AppDiagnosticsView.swift
+++ b/ios/Sources/App/AppDiagnosticsView.swift
@@ -87,6 +87,8 @@ private final class AppDiagnosticsRunner: ObservableObject {
     func copyReportToPasteboard() {
         guard !report.isEmpty else { return }
         UIPasteboard.general.string = report
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+        UIAccessibility.post(notification: .announcement, argument: "Copied report")
     }
 
     private static func performRun() async -> AppDiagnosticsRunResult {
@@ -880,11 +882,17 @@ struct AppDiagnosticsView: View {
                 ToolbarItemGroup(placement: .primaryAction) {
                     Button(copiedReport ? "Copied" : "Copy Report") {
                         runner.copyReportToPasteboard()
-                        copiedReport = true
+                        withAnimation {
+                            copiedReport = true
+                        }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                            copiedReport = false
+                            withAnimation {
+                                copiedReport = false
+                            }
                         }
                     }
+                    .accessibilityLabel(copiedReport ? "Copied report" : "Copy report")
+                    .accessibilityHint("Copies the diagnostic report to the clipboard")
                     .disabled(runner.report.isEmpty)
 
                     Button(runner.isRunning ? "Running..." : (runner.checks.isEmpty ? "Run Diagnostics" : "Run Again")) {


### PR DESCRIPTION
**💡 What:** 
Added haptic feedback and VoiceOver announcement when copying the diagnostic report in `AppDiagnosticsView.swift`. Used `withAnimation` for the transient button state change and added explicit `accessibilityHint`.
**🎯 Why:** 
Copying text in transient contexts offers no non-visual confirmation by default. This makes it unclear for VoiceOver users or those relying on haptics if the action succeeded. The animation prevents the visual UI from feeling jumpy.
**♿ Accessibility:** 
Users will now feel a haptic pulse and hear VoiceOver read "Copied report" when interacting with the button. Added `.accessibilityHint` explaining the button's action.

---
*PR created automatically by Jules for task [17174169958827067340](https://jules.google.com/task/17174169958827067340) started by @emkey1*