### PR TITLE
🎨 Palette: [UX improvement] Add non-visual confirmation to transient Copy action in Diagnostics

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+
+## 2025-05-18 - Non-Visual Confirmation for Transient UI Actions
+**Learning:** For silent or transient actions in the iOS UI (like copying text or sharing data) that only provide a brief visual state change (e.g., button changing to "Copied!"), users who rely on screen readers or are not looking directly at the UI can miss the confirmation completely.
+**Action:** Always provide non-visual confirmation by combining visual updates (`withAnimation`) with VoiceOver announcements (`UIAccessibility.post(notification: .announcement, argument: "...")`) and haptic feedback (`UINotificationFeedbackGenerator().notificationOccurred(.success)`).

--- a/ios/Sources/App/AppDiagnosticsView.swift
+++ b/ios/Sources/App/AppDiagnosticsView.swift
@@ -880,12 +880,21 @@ struct AppDiagnosticsView: View {
                 ToolbarItemGroup(placement: .primaryAction) {
                     Button(copiedReport ? "Copied" : "Copy Report") {
                         runner.copyReportToPasteboard()
-                        copiedReport = true
+
+                        UINotificationFeedbackGenerator().notificationOccurred(.success)
+                        UIAccessibility.post(notification: .announcement, argument: "Report copied to clipboard")
+
+                        withAnimation {
+                            copiedReport = true
+                        }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                            copiedReport = false
+                            withAnimation {
+                                copiedReport = false
+                            }
                         }
                     }
                     .disabled(runner.report.isEmpty)
+                    .accessibilityHint("Copies the diagnostic report to the clipboard")
 
                     Button(runner.isRunning ? "Running..." : (runner.checks.isEmpty ? "Run Diagnostics" : "Run Again")) {
                         copiedReport = false


### PR DESCRIPTION
💡 **What**: Added non-visual confirmations (haptic feedback, screen reader announcements) and animations to the "Copy Report" button's transient state in `AppDiagnosticsView.swift`.
🎯 **Why**: When users tap the button, the text simply changes to "Copied" for a brief moment. Screen reader users might completely miss this state change. Haptics and VoiceOver announcements assure the user the action succeeded.
📸 **Before/After**: N/A - Mostly an a11y/tactile change, though the visual change now animates gracefully using `withAnimation`.
♿ **Accessibility**: Added VoiceOver notification and an accessibility hint.

---
*PR created automatically by Jules for task [2973724628516917093](https://jules.google.com/task/2973724628516917093) started by @emkey1*