### PR TITLE
🎨 Palette: [AppDiagnostics] Add accessible feedback to Copy Report button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+
+## 2026-07-14 - AppDiagnosticsView Accessibility
+**Learning:** The 'Copy Report' button in diagnostics lacked screen reader feedback and an accessibility hint.
+**Action:** Add UIAccessibility.post announcements, UINotificationFeedbackGenerator haptic feedback, and explicit accessibilityHints to provide non-visual feedback for transient copy actions.

--- a/ios/Sources/App/AppDiagnosticsView.swift
+++ b/ios/Sources/App/AppDiagnosticsView.swift
@@ -880,12 +880,19 @@ struct AppDiagnosticsView: View {
                 ToolbarItemGroup(placement: .primaryAction) {
                     Button(copiedReport ? "Copied" : "Copy Report") {
                         runner.copyReportToPasteboard()
-                        copiedReport = true
+                        UINotificationFeedbackGenerator().notificationOccurred(.success)
+                        UIAccessibility.post(notification: .announcement, argument: "Diagnostics report copied to clipboard")
+                        withAnimation {
+                            copiedReport = true
+                        }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                            copiedReport = false
+                            withAnimation {
+                                copiedReport = false
+                            }
                         }
                     }
                     .disabled(runner.report.isEmpty)
+                    .accessibilityHint("Copies the full diagnostics report to your clipboard")
 
                     Button(runner.isRunning ? "Running..." : (runner.checks.isEmpty ? "Run Diagnostics" : "Run Again")) {
                         copiedReport = false


### PR DESCRIPTION
💡 What: Wrapped the `copiedReport` state toggle in `withAnimation`, added haptic feedback via `UINotificationFeedbackGenerator`, broadcasted a screen reader announcement via `UIAccessibility.post`, and added an `accessibilityHint` to the "Copy Report" button in `AppDiagnosticsView.swift`.
🎯 Why: Transient UI actions like "Copying" offer no non-visual feedback for VoiceOver users and visual transitions appear abruptly without animation.
📸 Before/After: Visual text previously snapped; now transitions smoothly.
♿ Accessibility: Ensures VoiceOver announces the copied state and clarifies the button's action through hints.

---
*PR created automatically by Jules for task [8832575408553099700](https://jules.google.com/task/8832575408553099700) started by @emkey1*