### PR TITLE
🎨 Palette: Add native typing sounds to terminal accessory keys

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+## 2025-03-22 - Missing Native Typing Sounds on Custom Keyboard Accessory Keys
+**Learning:** When implementing custom `UIInputView` keyboard accessory bars on iOS, the keys will be completely silent when tapped, breaking user expectations of tactile audio feedback while typing. Standard keys play the "click" sound, but custom buttons do not automatically inherit this behavior.
+**Action:** To provide expected native typing sounds, ensure the view containing the custom keys conforms to `UIInputViewAudioFeedback` with `enableInputClicksWhenVisible` returning `true`. Then, manually call `UIDevice.current.playInputClick()` within each key press action handler.

--- a/ios/Sources/App/TerminalInputBridge.swift
+++ b/ios/Sources/App/TerminalInputBridge.swift
@@ -87,7 +87,9 @@ struct TerminalInputBridge: UIViewRepresentable {
 }
 
 @MainActor
-final class TerminalKeyInputView: UITextView {
+final class TerminalKeyInputView: UITextView, UIInputViewAudioFeedback {
+    var enableInputClicksWhenVisible: Bool { return true }
+
     var onInput: ((String) -> Void)?
     var onPaste: ((String) -> Void)?
     var onCopy: (() -> Void)?
@@ -893,50 +895,62 @@ final class TerminalKeyInputView: UITextView {
 
     // MARK: - Accessory button actions
     @objc private func handleEsc() {
+        UIDevice.current.playInputClick()
         onInput?("\u{1B}")
     }
     
     @objc private func handleTab() {
+        UIDevice.current.playInputClick()
         onInput?("\t")
     }
 
     @objc private func handleCtrlToggle(_ sender: UIButton) {
+        UIDevice.current.playInputClick()
         controlLatch.toggle()
     }
 
     @objc private func handleAltToggle(_ sender: UIButton) {
+        UIDevice.current.playInputClick()
         optionLatch.toggle()
     }
 
     @objc private func handleUp() {
+        UIDevice.current.playInputClick()
         onInput?(arrowSequence("A"))
     }
 
     @objc private func handleDown() {
+        UIDevice.current.playInputClick()
         onInput?(arrowSequence("B"))
     }
 
     @objc private func handleLeft() {
+        UIDevice.current.playInputClick()
         onInput?(arrowSequence("D"))
     }
 
     @objc private func handleRight() {
+        UIDevice.current.playInputClick()
         onInput?(arrowSequence("C"))
     }
 
     @objc private func handleFSlash() {
+        UIDevice.current.playInputClick()
         onInput?("/")
     }
 
     @objc private func handleDot() {
+        UIDevice.current.playInputClick()
         onInput?(".")
     }
 
     @objc private func handleMinus() {
+        UIDevice.current.playInputClick()
         onInput?("-")
     }
    
     @objc private func handlePipe() {
+        UIDevice.current.playInputClick()
         onInput?("|")
     }
     


### PR DESCRIPTION
💡 **What:** Added native typing sounds (audio/haptic feedback) to the custom terminal keyboard accessory keys.
🎯 **Why:** Custom `UIInputView` accessory buttons are completely silent by default on iOS, which breaks user expectations of tactile and audio feedback while typing.
📸 **Before/After:** No visual change.
♿ **Accessibility:** Provides expected audio/haptic confirmation of key presses, which is critical non-visual feedback for all users.

---
*PR created automatically by Jules for task [1057178079744188697](https://jules.google.com/task/1057178079744188697) started by @emkey1*