### PR TITLE
🎨 Palette: Add haptic and a11y feedback to copy diagnostics report action

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+
+## 2024-05-20 - Non-Visual Confirmation for Transient Actions
+**Learning:** Actions that only result in transient visual updates (like a button label changing from "Copy" to "Copied" for a brief period) leave screen reader users unaware that their action succeeded.
+**Action:** When implementing transient visual states for actions, always combine them with `UINotificationFeedbackGenerator().notificationOccurred(.success)` for haptic feedback and `UIAccessibility.post(notification: .announcement, argument: "...")` to announce the change to VoiceOver. Additionally, state changes controlling visual feedback should be wrapped in `withAnimation` blocks for smooth transitions instead of abrupt changes.

--- a/ios/Sources/App/AppDiagnosticsView.swift
+++ b/ios/Sources/App/AppDiagnosticsView.swift
@@ -880,9 +880,17 @@ struct AppDiagnosticsView: View {
                 ToolbarItemGroup(placement: .primaryAction) {
                     Button(copiedReport ? "Copied" : "Copy Report") {
                         runner.copyReportToPasteboard()
-                        copiedReport = true
+
+                        UINotificationFeedbackGenerator().notificationOccurred(.success)
+                        UIAccessibility.post(notification: .announcement, argument: "Diagnostics report copied to clipboard")
+
+                        withAnimation {
+                            copiedReport = true
+                        }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                            copiedReport = false
+                            withAnimation {
+                                copiedReport = false
+                            }
                         }
                     }
                     .disabled(runner.report.isEmpty)


### PR DESCRIPTION
💡 **What:** Added haptic feedback (`UINotificationFeedbackGenerator`), a VoiceOver announcement (`UIAccessibility`), and a smooth transition (`withAnimation`) to the "Copy Report" button in `AppDiagnosticsView.swift`.
🎯 **Why:** To provide non-visual confirmation for a transient action (where the button temporarily says "Copied" and then switches back), ensuring screen reader users and all users get better feedback on success.
📸 **Before/After:** No major structural visual changes, but the transition from "Copy Report" to "Copied" is now animated smoothly rather than instantly popping in and out.
♿ **Accessibility:** Added `.announcement` to explicitly tell VoiceOver users the text was copied to the clipboard, as they would otherwise miss the transient label change. Recorded this learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [629106932815869808](https://jules.google.com/task/629106932815869808) started by @emkey1*