### PR TITLE
🎨 Palette: [UX improvement] Add accessible transient feedback to Diagnostics Copy Report button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+## 2025-07-19 - Auditory and Haptic Feedback for Transient Actions in Settings/Diagnostics
+**Learning:** Utilities and diagnostic views often have actions like "Copy Report" that offer little visual feedback when clicked. While `withAnimation` helps soften transient state changes, users rely heavily on multi-sensory feedback to confirm successful completion of utility tasks without leaving their current flow.
+**Action:** Always combine haptic feedback (`UINotificationFeedbackGenerator().notificationOccurred(.success)`) and an explicit VoiceOver announcement (`UIAccessibility.post(notification: .announcement, argument: "...")`) with `withAnimation` visual toggles on utilities like "Copy" buttons to provide comprehensive confirmation.

--- a/ios/Sources/App/AppDiagnosticsView.swift
+++ b/ios/Sources/App/AppDiagnosticsView.swift
@@ -880,12 +880,22 @@ struct AppDiagnosticsView: View {
                 ToolbarItemGroup(placement: .primaryAction) {
                     Button(copiedReport ? "Copied" : "Copy Report") {
                         runner.copyReportToPasteboard()
-                        copiedReport = true
+
+                        UINotificationFeedbackGenerator().notificationOccurred(.success)
+                        UIAccessibility.post(notification: .announcement, argument: "Copied report")
+
+                        withAnimation {
+                            copiedReport = true
+                        }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                            copiedReport = false
+                            withAnimation {
+                                copiedReport = false
+                            }
                         }
                     }
                     .disabled(runner.report.isEmpty)
+                    .accessibilityLabel(copiedReport ? "Copied Report" : "Copy Report")
+                    .accessibilityHint("Copies the diagnostic report to the clipboard")
 
                     Button(runner.isRunning ? "Running..." : (runner.checks.isEmpty ? "Run Diagnostics" : "Run Again")) {
                         copiedReport = false


### PR DESCRIPTION
💡 **What:** Added comprehensive feedback (animation, haptics, VoiceOver announcements, and dynamic a11y labels/hints) to the "Copy Report" button in `AppDiagnosticsView`.
🎯 **Why:** The previous implementation abruptly changed text with no tactile or auditory confirmation. This provides a more robust and accessible experience that multi-sensorially confirms the copy action without leaving the user guessing.
📸 **Before/After:** The button smoothly transitions text, triggers a success haptic, and explicitly announces "Copied report" to VoiceOver users.
♿ **Accessibility:** Added `UIAccessibility.post`, dynamic `.accessibilityLabel`, and an `.accessibilityHint`.

---
*PR created automatically by Jules for task [15983001919977060362](https://jules.google.com/task/15983001919977060362) started by @emkey1*