### PR TITLE
🎨 Palette: Add native typing sounds to terminal accessory bar

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+## 2024-07-22 - Custom UIInputView Requires Manual Audio Feedback Integration
+**Learning:** When implementing a custom keyboard accessory bar using `UIInputView` (e.g. for a terminal app), the native typing sounds are lost by default.
+**Action:** The custom `UIInputView` subclass must explicitly conform to the `UIInputViewAudioFeedback` protocol by returning `true` for `enableInputClicksWhenVisible`, and key press actions must manually call `UIDevice.current.playInputClick()` (e.g. on `.touchDown`) to match the user's expectation of native iOS keyboard sound effects.

--- a/ios/Sources/App/TerminalInputBridge.swift
+++ b/ios/Sources/App/TerminalInputBridge.swift
@@ -189,9 +189,9 @@ final class TerminalKeyInputView: UITextView {
         set { /* ignore external setters */ }
     }
 
+
     private var repeatKeyCommands: [RepeatCommand]
     private lazy var controlKeyCommands: [UIKeyCommand] = buildControlCommands()
-
 
     @objc private func playAccessoryClick() {
         UIDevice.current.playInputClick()

--- a/ios/Sources/App/TerminalInputBridge.swift
+++ b/ios/Sources/App/TerminalInputBridge.swift
@@ -86,8 +86,16 @@ struct TerminalInputBridge: UIViewRepresentable {
     }
 }
 
+
+private class TerminalAccessoryInputView: UIInputView, UIInputViewAudioFeedback {
+    var enableInputClicksWhenVisible: Bool {
+        return true
+    }
+}
+
 @MainActor
 final class TerminalKeyInputView: UITextView {
+
     var onInput: ((String) -> Void)?
     var onPaste: ((String) -> Void)?
     var onCopy: (() -> Void)?
@@ -136,7 +144,7 @@ final class TerminalKeyInputView: UITextView {
     }
 
     override init(frame: CGRect, textContainer: NSTextContainer?) {
-        self.accessoryBar = UIInputView(frame: .zero, inputViewStyle: .keyboard)
+        self.accessoryBar = TerminalAccessoryInputView(frame: .zero, inputViewStyle: .keyboard)
         self.repeatKeyCommands = []
         super.init(frame: frame, textContainer: textContainer)
         configureAccessoryBar()
@@ -146,7 +154,7 @@ final class TerminalKeyInputView: UITextView {
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
-        self.accessoryBar = UIInputView(frame: .zero, inputViewStyle: .keyboard)
+        self.accessoryBar = TerminalAccessoryInputView(frame: .zero, inputViewStyle: .keyboard)
         self.repeatKeyCommands = []
         super.init(coder: coder)
         configureAccessoryBar()
@@ -184,6 +192,11 @@ final class TerminalKeyInputView: UITextView {
     private var repeatKeyCommands: [RepeatCommand]
     private lazy var controlKeyCommands: [UIKeyCommand] = buildControlCommands()
 
+
+    @objc private func playAccessoryClick() {
+        UIDevice.current.playInputClick()
+    }
+
     private func configureAccessoryBar() {
         accessoryBar.allowsSelfSizing = true
         accessoryBar.translatesAutoresizingMaskIntoConstraints = false
@@ -218,6 +231,7 @@ final class TerminalKeyInputView: UITextView {
             button.configuration = config
             button.titleLabel?.font = UIFontMetrics.default.scaledFont(for: .systemFont(ofSize: 15, weight: .semibold))
             button.addTarget(self, action: action, for: .touchUpInside)
+            button.addTarget(self, action: #selector(playAccessoryClick), for: .touchDown)
             return button
         }
 


### PR DESCRIPTION
💡 What: Subclassed `UIInputView` to conform to `UIInputViewAudioFeedback` and manually invoke `UIDevice.current.playInputClick()` on accessory bar button interactions in the terminal input bridge.
🎯 Why: Custom accessory bars built with standard `UIInputView` lack native typing sounds by default, making interactions feel dead or disconnected compared to the standard software keyboard.
♿ Accessibility: Restores expected auditory feedback for VoiceOver and standard users alike when utilizing the specialized terminal modifier and navigation keys.

---
*PR created automatically by Jules for task [15165250162925276988](https://jules.google.com/task/15165250162925276988) started by @emkey1*