### PR TITLE
🎨 Palette: Add native typing sounds to custom terminal accessory keys

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+## 2024-07-23 - Native Typing Sounds for Custom UIInputView Keys
+**Learning:** When building custom keyboard accessory keys (`UIInputView`) in iOS, native typing sounds do not play automatically. To provide the expected native typing feedback to VoiceOver and general users, the container view (e.g. `UITextView` or custom `UIInputView`) must conform to `UIInputViewAudioFeedback` with `enableInputClicksWhenVisible` returning `true`.
+**Action:** Always manually call `UIDevice.current.playInputClick()` on `.touchDown` for custom accessory keys to ensure responsive and accessible auditory feedback matching the native keyboard.

--- a/ios/Sources/App/TerminalInputBridge.swift
+++ b/ios/Sources/App/TerminalInputBridge.swift
@@ -87,7 +87,8 @@ struct TerminalInputBridge: UIViewRepresentable {
 }
 
 @MainActor
-final class TerminalKeyInputView: UITextView {
+final class TerminalKeyInputView: UITextView, UIInputViewAudioFeedback {
+    var enableInputClicksWhenVisible: Bool { return true }
     var onInput: ((String) -> Void)?
     var onPaste: ((String) -> Void)?
     var onCopy: (() -> Void)?
@@ -218,6 +219,7 @@ final class TerminalKeyInputView: UITextView {
             button.configuration = config
             button.titleLabel?.font = UIFontMetrics.default.scaledFont(for: .systemFont(ofSize: 15, weight: .semibold))
             button.addTarget(self, action: action, for: .touchUpInside)
+            button.addTarget(self, action: #selector(playInputClickSound), for: .touchDown)
             return button
         }
 
@@ -889,6 +891,10 @@ final class TerminalKeyInputView: UITextView {
         }
 
         keyboardObservers = [willShow, willHide, focusRequested]
+    }
+
+    @objc private func playInputClickSound() {
+        UIDevice.current.playInputClick()
     }
 
     // MARK: - Accessory button actions

--- a/ios/Sources/App/TerminalNativeTextView.swift
+++ b/ios/Sources/App/TerminalNativeTextView.swift
@@ -14,7 +14,8 @@ final class TerminalAccessoryView: UIView {
 
 // MARK: - Custom Native View with Expandable Settings Drawer
 
-final class NativeTerminalView: UITextView {
+final class NativeTerminalView: UITextView, UIInputViewAudioFeedback {
+    var enableInputClicksWhenVisible: Bool { return true }
     var onSettingsChanged: ((CGFloat, UIColor) -> Void)?
     var onInput: ((String) -> Void)?
     private var softKeyboardVisible: Bool = false
@@ -125,6 +126,7 @@ final class NativeTerminalView: UITextView {
             }
 
             btn.addTarget(self, action: #selector(keyTapped(_:)), for: .touchUpInside)
+            btn.addTarget(self, action: #selector(playInputClickSound), for: .touchDown)
             keysStack.addArrangedSubview(btn)
         }
 
@@ -187,6 +189,10 @@ final class NativeTerminalView: UITextView {
     }
 
     // MARK: Actions
+
+    @objc private func playInputClickSound() {
+        UIDevice.current.playInputClick()
+    }
 
     @objc private func keyTapped(_ sender: UIButton) {
         guard let title = sender.title(for: .normal) else { return }


### PR DESCRIPTION
💡 What: The UX enhancement added is native typing sounds for the custom `UIInputView` keys in the iOS terminal.
🎯 Why: Without this, tapping custom keys on iOS feels "dead" compared to the native keyboard, causing an inconsistent typing experience. By properly playing the native input click, users get standard system feedback confirming their actions.
📸 Before/After: No visual change; purely an audio/haptic UX addition.
♿ Accessibility: Ensures VoiceOver and system audio feedback matches native expected behavior for customized input keys.

---
*PR created automatically by Jules for task [8825281843089124021](https://jules.google.com/task/8825281843089124021) started by @emkey1*