### PR TITLE
🎨 Palette: Add native typing sounds to terminal accessory keys

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+## 2025-04-20 - Missing native typing sound on custom keyboard accessory bar
+**Learning:** Custom input accessory views (keyboard rows) do not provide native keyboard click sounds by default.
+**Action:** When implementing custom keyboard keys, conform to `UIInputViewAudioFeedback` returning true for `enableInputClicksWhenVisible` and add `UIDevice.current.playInputClick()` on `.touchDown` for custom buttons.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           submodules: recursive
       - name: Compute changed files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v44
       - name: Determine build plan
         id: plan
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           submodules: recursive
       - name: Compute changed files
         id: changed-files
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@v46
       - name: Determine build plan
         id: plan
         env:

--- a/ios/Sources/App/TerminalNativeTextView.swift
+++ b/ios/Sources/App/TerminalNativeTextView.swift
@@ -2,13 +2,17 @@ import UIKit
 
 // MARK: - Helper Class for Self-Sizing Accessory View
 
-final class TerminalAccessoryView: UIView {
+final class TerminalAccessoryView: UIView, UIInputViewAudioFeedback {
     var targetHeight: CGFloat = 44 {
         didSet { invalidateIntrinsicContentSize() }
     }
 
     override var intrinsicContentSize: CGSize {
         CGSize(width: UIView.noIntrinsicMetric, height: targetHeight)
+    }
+
+    var enableInputClicksWhenVisible: Bool {
+        return true
     }
 }
 
@@ -124,6 +128,7 @@ final class NativeTerminalView: UITextView {
                 btn.accessibilityLabel = key
             }
 
+            btn.addTarget(self, action: #selector(playClick), for: .touchDown)
             btn.addTarget(self, action: #selector(keyTapped(_:)), for: .touchUpInside)
             keysStack.addArrangedSubview(btn)
         }
@@ -187,6 +192,10 @@ final class NativeTerminalView: UITextView {
     }
 
     // MARK: Actions
+
+    @objc private func playClick() {
+        UIDevice.current.playInputClick()
+    }
 
     @objc private func keyTapped(_ sender: UIButton) {
         guard let title = sender.title(for: .normal) else { return }


### PR DESCRIPTION
💡 **What:** Added native typing sounds (`UIDevice.current.playInputClick()`) to the custom keyboard accessory view in the terminal.
🎯 **Why:** Custom input accessory keys lack native sound and haptic feedback by default. Adding this makes typing on the custom keys (like arrows, esc, tab) feel like typing on the native system keyboard, improving the user experience and making the interaction feel more responsive.
📸 **Before/After:** No visual change.
♿ **Accessibility:** Added native system audio feedback for users who rely on typing sounds to confirm key presses.

---
*PR created automatically by Jules for task [1903978345696754352](https://jules.google.com/task/1903978345696754352) started by @emkey1*