### PR TITLE
🎨 Palette: Improve transient visual feedback and accessibility for App Diagnostics

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+## 2025-03-24 - Accessibility Hints and Animations in Toolbar Buttons
+**Learning:** Toolbar buttons in SwiftUI, especially those executing complex or transient tasks (like diagnostics or copying reports), lack implicit context for VoiceOver users, and abrupt state changes look unpolished.
+**Action:** Always wrap boolean state changes triggering transient visual states (like a "Copied" text replacement) in `withAnimation {}`. Additionally, apply specific `accessibilityHint`s to toolbar buttons (e.g., "Closes the diagnostics view" or "Executes the in-app sanity checks") and dynamically update `accessibilityLabel` based on state.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,9 +25,11 @@
 ## 2025-03-10 - Lack of Animation for Transient UI Feedback
 **Learning:** Transient UI feedback states (like "Copied!" text appearing for a few seconds) can feel abrupt and unpolished if they simply snap into existence and snap away. SwiftUI makes it extremely easy to add standard transitions and animations by wrapping state changes in `withAnimation`.
 **Action:** When adding transient text, icons, or visual feedback to buttons or other UI elements, always wrap the boolean state toggles in `withAnimation {}` to provide a graceful transition (fade/slide) instead of a harsh pop-in/pop-out.
+
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+
 ## 2025-03-24 - Accessibility Hints and Animations in Toolbar Buttons
 **Learning:** Toolbar buttons in SwiftUI, especially those executing complex or transient tasks (like diagnostics or copying reports), lack implicit context for VoiceOver users, and abrupt state changes look unpolished.
 **Action:** Always wrap boolean state changes triggering transient visual states (like a "Copied" text replacement) in `withAnimation {}`. Additionally, apply specific `accessibilityHint`s to toolbar buttons (e.g., "Closes the diagnostics view" or "Executes the in-app sanity checks") and dynamically update `accessibilityLabel` based on state.

--- a/ios/Sources/App/AppDiagnosticsView.swift
+++ b/ios/Sources/App/AppDiagnosticsView.swift
@@ -876,21 +876,31 @@ struct AppDiagnosticsView: View {
                     Button("Close") {
                         dismiss()
                     }
+                    .accessibilityHint("Closes the diagnostics view")
                 }
                 ToolbarItemGroup(placement: .primaryAction) {
                     Button(copiedReport ? "Copied" : "Copy Report") {
                         runner.copyReportToPasteboard()
-                        copiedReport = true
+                        withAnimation {
+                            copiedReport = true
+                        }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                            copiedReport = false
+                            withAnimation {
+                                copiedReport = false
+                            }
                         }
                     }
+                    .accessibilityLabel(copiedReport ? "Copied diagnostics report" : "Copy diagnostics report")
+                    .accessibilityHint("Copies the diagnostics report to the clipboard")
                     .disabled(runner.report.isEmpty)
 
                     Button(runner.isRunning ? "Running..." : (runner.checks.isEmpty ? "Run Diagnostics" : "Run Again")) {
-                        copiedReport = false
+                        withAnimation {
+                            copiedReport = false
+                        }
                         runner.run()
                     }
+                    .accessibilityHint("Executes the in-app sanity checks")
                     .disabled(runner.isRunning)
                 }
             }


### PR DESCRIPTION
💡 **What:**
- Wrapped the transient UI state changes for the "Copy Report" button (`copiedReport = true`/`copiedReport = false`) within `withAnimation` blocks to provide a smooth, graceful transition instead of an abrupt snap.
- Added dynamic `accessibilityLabel` to the "Copy Report" button to explicitly announce the state (e.g. "Copied diagnostics report" vs "Copy diagnostics report").
- Added clear `accessibilityHint`s to the "Close", "Copy Report", and "Run Diagnostics" / "Run Again" toolbar buttons.

🎯 **Why:**
- Without animation, the transient textual change ("Copy Report" -> "Copied" -> "Copy Report") feels jarring and unpolished.
- Icon-only or contextually-dependent toolbar buttons often leave screen reader users without sufficient understanding of the button's action. The addition of hints and dynamic labels clarifies intent.

📸 **Before/After:**
- **Before:** Buttons snapped states immediately, and VoiceOver only read the raw text without hints.
- **After:** Buttons fade nicely between states, and VoiceOver receives contextual hints like "Copies the diagnostics report to the clipboard".

♿ **Accessibility:**
- VoiceOver users will now understand the explicit outcome of interacting with the diagnostics toolbar buttons via newly added `accessibilityHint`s and dynamic `accessibilityLabel`s on state changes.

---
*PR created automatically by Jules for task [8028483653522659701](https://jules.google.com/task/8028483653522659701) started by @emkey1*