### PR TITLE
🎨 Palette: Add native keyboard clicks to terminal accessory bar

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+## 2026-07-28 - Native Keyboard Clicks on Custom Accessory Bar
+**Learning:** Custom UIKit `UIInputView` accessory bars require explicit conformance to `UIInputViewAudioFeedback` with `enableInputClicksWhenVisible = true` and manual invocation of `UIDevice.current.playInputClick()` to match native iOS keyboard click sounds.
+**Action:** When implementing custom accessory bars, ensure they subclass or extend `UIInputView` appropriately and bind `playInputClick` to `.touchDown` events to preserve native typing feel and audio feedback.

--- a/ios/Sources/App/TerminalInputBridge.swift
+++ b/ios/Sources/App/TerminalInputBridge.swift
@@ -86,6 +86,10 @@ struct TerminalInputBridge: UIViewRepresentable {
     }
 }
 
+private class TerminalAccessoryInputView: UIInputView, UIInputViewAudioFeedback {
+    var enableInputClicksWhenVisible: Bool { true }
+}
+
 @MainActor
 final class TerminalKeyInputView: UITextView {
     var onInput: ((String) -> Void)?
@@ -136,7 +140,7 @@ final class TerminalKeyInputView: UITextView {
     }
 
     override init(frame: CGRect, textContainer: NSTextContainer?) {
-        self.accessoryBar = UIInputView(frame: .zero, inputViewStyle: .keyboard)
+        self.accessoryBar = TerminalAccessoryInputView(frame: .zero, inputViewStyle: .keyboard)
         self.repeatKeyCommands = []
         super.init(frame: frame, textContainer: textContainer)
         configureAccessoryBar()
@@ -146,7 +150,7 @@ final class TerminalKeyInputView: UITextView {
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
-        self.accessoryBar = UIInputView(frame: .zero, inputViewStyle: .keyboard)
+        self.accessoryBar = TerminalAccessoryInputView(frame: .zero, inputViewStyle: .keyboard)
         self.repeatKeyCommands = []
         super.init(coder: coder)
         configureAccessoryBar()
@@ -172,7 +176,7 @@ final class TerminalKeyInputView: UITextView {
     private weak var optionButton: UIButton?
 
     // MARK: - FIXED ACCESSORY BAR
-    private let accessoryBar: UIInputView
+    private let accessoryBar: TerminalAccessoryInputView
 
     override var inputAccessoryView: UIView? {
         get {
@@ -218,6 +222,7 @@ final class TerminalKeyInputView: UITextView {
             button.configuration = config
             button.titleLabel?.font = UIFontMetrics.default.scaledFont(for: .systemFont(ofSize: 15, weight: .semibold))
             button.addTarget(self, action: action, for: .touchUpInside)
+            button.addTarget(self, action: #selector(playInputClick), for: .touchDown)
             return button
         }
 
@@ -889,6 +894,10 @@ final class TerminalKeyInputView: UITextView {
         }
 
         keyboardObservers = [willShow, willHide, focusRequested]
+    }
+
+    @objc private func playInputClick() {
+        UIDevice.current.playInputClick()
     }
 
     // MARK: - Accessory button actions


### PR DESCRIPTION
💡 What: Modified the `TerminalInputBridge`'s `UIInputView` accessory bar to explicitly conform to `UIInputViewAudioFeedback` and manually trigger `UIDevice.current.playInputClick()` on touch down events for all buttons.

🎯 Why: Custom keyboard accessory buttons on iOS feel "dead" or unresponsive when they do not emit the native iOS keyboard click sound. This small touch of audio feedback makes the custom accessory bar integrate seamlessly with the native iOS keyboard experience.

📸 Before/After: Visuals are unchanged; interaction now provides native audio feedback on tap.

♿ Accessibility: Ensures that users relying on audio cues from keyboard presses receive the same feedback from the terminal accessory bar as they do from standard keyboard keys.

---
*PR created automatically by Jules for task [1119261472448955821](https://jules.google.com/task/1119261472448955821) started by @emkey1*