### PR TITLE
🎨 Palette: Add native keyboard audio feedback to custom accessory views

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+## 2026-07-29 - Native Keyboard Audio Feedback for Custom Accessory Views
+**Learning:** Custom `UIInputView` accessory bars (like extra terminal keys) do not play the native iOS keyboard typing click sound automatically when tapped, making them feel disconnected from the standard keyboard.
+**Action:** When implementing custom keyboard keys, ensure the container view conforms to `UIInputViewAudioFeedback` (returning `true` for `enableInputClicksWhenVisible`), and manually call `UIDevice.current.playInputClick()` on the button's `.touchDown` event to provide instant, responsive auditory feedback.

--- a/ios/Sources/App/TerminalInputBridge.swift
+++ b/ios/Sources/App/TerminalInputBridge.swift
@@ -6,6 +6,10 @@ extension Notification.Name {
     static let terminalInputFocusRequested = Notification.Name("terminalInputFocusRequested")
 }
 
+class TerminalAccessoryInputView: UIInputView, UIInputViewAudioFeedback {
+    var enableInputClicksWhenVisible: Bool { true }
+}
+
 @MainActor
 struct TerminalInputBridge: UIViewRepresentable {
     @Binding var focusAnchor: Int
@@ -136,7 +140,7 @@ final class TerminalKeyInputView: UITextView {
     }
 
     override init(frame: CGRect, textContainer: NSTextContainer?) {
-        self.accessoryBar = UIInputView(frame: .zero, inputViewStyle: .keyboard)
+        self.accessoryBar = TerminalAccessoryInputView(frame: .zero, inputViewStyle: .keyboard)
         self.repeatKeyCommands = []
         super.init(frame: frame, textContainer: textContainer)
         configureAccessoryBar()
@@ -146,7 +150,7 @@ final class TerminalKeyInputView: UITextView {
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
-        self.accessoryBar = UIInputView(frame: .zero, inputViewStyle: .keyboard)
+        self.accessoryBar = TerminalAccessoryInputView(frame: .zero, inputViewStyle: .keyboard)
         self.repeatKeyCommands = []
         super.init(coder: coder)
         configureAccessoryBar()
@@ -218,6 +222,7 @@ final class TerminalKeyInputView: UITextView {
             button.configuration = config
             button.titleLabel?.font = UIFontMetrics.default.scaledFont(for: .systemFont(ofSize: 15, weight: .semibold))
             button.addTarget(self, action: action, for: .touchUpInside)
+            button.addTarget(self, action: #selector(playInputClick), for: .touchDown)
             return button
         }
 
@@ -278,6 +283,10 @@ final class TerminalKeyInputView: UITextView {
         makeCommand(input: UIKeyCommand.inputRightArrow, output: "\u{1B}[C")
         makeCommand(input: "\r", output: "\r")
         return commands
+    }
+
+    @objc private func playInputClick() {
+        UIDevice.current.playInputClick()
     }
 
     override var canBecomeFirstResponder: Bool {

--- a/ios/Sources/App/TerminalNativeTextView.swift
+++ b/ios/Sources/App/TerminalNativeTextView.swift
@@ -2,7 +2,7 @@ import UIKit
 
 // MARK: - Helper Class for Self-Sizing Accessory View
 
-final class TerminalAccessoryView: UIView {
+final class TerminalAccessoryView: UIInputView, UIInputViewAudioFeedback {
     var targetHeight: CGFloat = 44 {
         didSet { invalidateIntrinsicContentSize() }
     }
@@ -10,6 +10,8 @@ final class TerminalAccessoryView: UIView {
     override var intrinsicContentSize: CGSize {
         CGSize(width: UIView.noIntrinsicMetric, height: targetHeight)
     }
+
+    var enableInputClicksWhenVisible: Bool { true }
 }
 
 // MARK: - Custom Native View with Expandable Settings Drawer
@@ -82,7 +84,7 @@ final class NativeTerminalView: UITextView {
     // MARK: Accessory View Construction
 
     private func setupAccessoryView() {
-        containerView = TerminalAccessoryView(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 44))
+        containerView = TerminalAccessoryView(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 44), inputViewStyle: .keyboard)
         containerView.backgroundColor = UIColor(white: 0.15, alpha: 1.0)
         containerView.autoresizingMask = .flexibleHeight
 
@@ -125,6 +127,7 @@ final class NativeTerminalView: UITextView {
             }
 
             btn.addTarget(self, action: #selector(keyTapped(_:)), for: .touchUpInside)
+            btn.addTarget(self, action: #selector(playInputClick), for: .touchDown)
             keysStack.addArrangedSubview(btn)
         }
 
@@ -187,6 +190,10 @@ final class NativeTerminalView: UITextView {
     }
 
     // MARK: Actions
+
+    @objc private func playInputClick() {
+        UIDevice.current.playInputClick()
+    }
 
     @objc private func keyTapped(_ sender: UIButton) {
         guard let title = sender.title(for: .normal) else { return }


### PR DESCRIPTION
💡 What: Added native iOS keyboard clicking sounds (via `UIInputViewAudioFeedback` and `UIDevice.current.playInputClick()`) to the custom accessory buttons in the terminal view.
🎯 Why: Custom accessory bars above the keyboard feel detached from the native typing experience when they do not provide the same audio/haptic feedback as the standard system keyboard keys. This makes the UI feel more consistent and responsive.
📸 Before/After: N/A (Audio/haptic change only).
♿ Accessibility: Improves multimodal feedback for interactions, allowing users relying on auditory cues to confirm key presses on custom accessory buttons.

---
*PR created automatically by Jules for task [5709755533978939373](https://jules.google.com/task/5709755533978939373) started by @emkey1*