### PR TITLE
🎨 Palette: Enhance Copy Report button with visual and accessibility feedback

### DIFF
--- a/ios/Sources/App/AppDiagnosticsView.swift
+++ b/ios/Sources/App/AppDiagnosticsView.swift
@@ -878,13 +878,29 @@ struct AppDiagnosticsView: View {
                     }
                 }
                 ToolbarItemGroup(placement: .primaryAction) {
-                    Button(copiedReport ? "Copied" : "Copy Report") {
+                    Button {
                         runner.copyReportToPasteboard()
-                        copiedReport = true
+                        withAnimation {
+                            copiedReport = true
+                        }
+                        UINotificationFeedbackGenerator().notificationOccurred(.success)
+                        UIAccessibility.post(notification: .announcement, argument: "Report copied")
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                            copiedReport = false
+                            withAnimation {
+                                copiedReport = false
+                            }
+                        }
+                    } label: {
+                        HStack {
+                            Text(copiedReport ? "Copied!" : "Copy Report")
+                            if copiedReport {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .foregroundColor(.green)
+                            }
                         }
                     }
+                    .accessibilityLabel(copiedReport ? "Report copied" : "Copy Report")
+                    .accessibilityHint("Copies the diagnostic report to the clipboard")
                     .disabled(runner.report.isEmpty)
 
                     Button(runner.isRunning ? "Running..." : (runner.checks.isEmpty ? "Run Diagnostics" : "Run Again")) {


### PR DESCRIPTION
💡 What: Replaced the basic "Copy Report" button with a custom label showing an animated checkmark when copied, along with haptic feedback, VoiceOver announcements, and accessibility labels/hints.
🎯 Why: The original button lacked sufficient feedback, especially for accessibility. This provides a more polished and inclusive UX for copying diagnostic reports.
📸 Before/After: Visual change introduces a smooth crossfade to a checkmark state.
♿ Accessibility: Added `UIAccessibility.post(notification: .announcement, argument: "Report copied")`, `.accessibilityLabel`, and `.accessibilityHint` for better screen reader support.

---
*PR created automatically by Jules for task [7327703646635926368](https://jules.google.com/task/7327703646635926368) started by @emkey1*