### PR TITLE
🎨 Palette: [UX improvement] Add accessibility and haptic feedback to copy buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+## 2024-08-01 - Enhance Transient UI Actions
+**Learning:** Transient UI states (like "Copied!" buttons) need non-visual reinforcement (VoiceOver and haptics) to provide robust feedback for all users.
+**Action:** When implementing transient UI changes (especially self-dismissing ones), combine visual state changes (with animations) with VoiceOver announcements (`UIAccessibility.post(notification: .announcement)`) and haptic feedback (`UINotificationFeedbackGenerator().notificationOccurred(.success)`).

--- a/ios/Sources/App/AppDiagnosticsView.swift
+++ b/ios/Sources/App/AppDiagnosticsView.swift
@@ -880,9 +880,15 @@ struct AppDiagnosticsView: View {
                 ToolbarItemGroup(placement: .primaryAction) {
                     Button(copiedReport ? "Copied" : "Copy Report") {
                         runner.copyReportToPasteboard()
-                        copiedReport = true
+                        withAnimation {
+                            copiedReport = true
+                        }
+                        UIAccessibility.post(notification: .announcement, argument: "Report copied to clipboard")
+                        UINotificationFeedbackGenerator().notificationOccurred(.success)
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                            copiedReport = false
+                            withAnimation {
+                                copiedReport = false
+                            }
                         }
                     }
                     .disabled(runner.report.isEmpty)

--- a/ios/Sources/App/TerminalSettingsView.swift
+++ b/ios/Sources/App/TerminalSettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct TerminalSettingsView: View {
     @ObservedObject private var appearanceSettings: TerminalTabAppearanceSettings
@@ -157,6 +158,8 @@ struct TerminalSettingsView: View {
                         withAnimation {
                             copiedColors = true
                         }
+                        UIAccessibility.post(notification: .announcement, argument: "Copied first tab colors")
+                        UINotificationFeedbackGenerator().notificationOccurred(.success)
                         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                             withAnimation {
                                 copiedColors = false


### PR DESCRIPTION
**💡 What**: Added VoiceOver announcements (`UIAccessibility.post`) and success haptic feedback (`UINotificationFeedbackGenerator`) to the "Copy First Tab Values" button in TerminalSettingsView and the "Copy Report" button in AppDiagnosticsView. Additionally wrapped the visual changes in `withAnimation` blocks to provide graceful visual transitions rather than abrupt appearances.

**🎯 Why**: Transient UI feedback states (like "Copied!" text appearing for a few seconds) can feel abrupt and unpolished if they simply snap into existence and snap away. More importantly, users who rely on screen readers or users who are not looking closely at the screen may completely miss the fact that the copy action succeeded because there was no non-visual confirmation.

**♿ Accessibility**: Significantly improved accessibility by ensuring screen reader users hear a clear confirmation (e.g., "Report copied to clipboard") when they activate these buttons. The added haptics provide a nice physical confirmation as well.

---
*PR created automatically by Jules for task [10561615517497273419](https://jules.google.com/task/10561615517497273419) started by @emkey1*