### PR TITLE
🎨 Palette: Add haptic and a11y feedback to color copy action

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+## 2026-08-02 - Transient Action Accessibility
+**Learning:** Silent or transient actions (like copying text) that only update UI visually need explicit non-visual confirmation for VoiceOver users.
+**Action:** Combine visual updates with UIAccessibility.post announcements and UINotificationFeedbackGenerator haptics to ensure all users receive feedback.

--- a/ios/Sources/App/TerminalSettingsView.swift
+++ b/ios/Sources/App/TerminalSettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct TerminalSettingsView: View {
     @ObservedObject private var appearanceSettings: TerminalTabAppearanceSettings
@@ -157,6 +158,8 @@ struct TerminalSettingsView: View {
                         withAnimation {
                             copiedColors = true
                         }
+                        UINotificationFeedbackGenerator().notificationOccurred(.success)
+                        UIAccessibility.post(notification: .announcement, argument: "Copied first tab colors")
                         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                             withAnimation {
                                 copiedColors = false


### PR DESCRIPTION
💡 **What**: Added `UINotificationFeedbackGenerator().notificationOccurred(.success)` and `UIAccessibility.post(notification: .announcement, argument: "Copied first tab colors")` to the "Copy First Tab Values" button in `TerminalSettingsView`.

🎯 **Why**: When a user pressed this button, it only changed text to "Copied!" visually, and reversed the change 2 seconds later. This provided no clear confirmation for non-visual VoiceOver users or general tactile feedback that the action succeeded.

📸 **Before/After**: Visually identical, but the copy action now vibrates the device softly on success and loudly announces "Copied first tab colors" to VoiceOver.

♿ **Accessibility**: Significant improvement for VoiceOver users by providing an explicit `.announcement` notification upon triggering a transient button state change.

---
*PR created automatically by Jules for task [8275451042634426797](https://jules.google.com/task/8275451042634426797) started by @emkey1*