### PR TITLE
🎨 Palette: Add haptics and a11y to transient copy actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+## 2026-08-03 - VoiceOver and Haptics for Transient Actions
+**Learning:** Silent or transient actions in the iOS UI (like 'Copied!' buttons) that dismiss their own context or provide only a brief visual update can leave screen reader users unaware of success.
+**Action:** Always combine visual updates with VoiceOver announcements (`UIAccessibility.post(notification: .announcement, argument: "...")`) and haptic feedback (`UINotificationFeedbackGenerator().notificationOccurred(.success)`) to provide non-visual confirmation.

--- a/ios/Sources/App/AppDiagnosticsView.swift
+++ b/ios/Sources/App/AppDiagnosticsView.swift
@@ -880,11 +880,22 @@ struct AppDiagnosticsView: View {
                 ToolbarItemGroup(placement: .primaryAction) {
                     Button(copiedReport ? "Copied" : "Copy Report") {
                         runner.copyReportToPasteboard()
-                        copiedReport = true
+
+                        UIAccessibility.post(notification: .announcement, argument: "Copied report")
+                        let generator = UINotificationFeedbackGenerator()
+                        generator.notificationOccurred(.success)
+
+                        withAnimation {
+                            copiedReport = true
+                        }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                            copiedReport = false
+                            withAnimation {
+                                copiedReport = false
+                            }
                         }
                     }
+                    .accessibilityLabel(copiedReport ? "Copied diagnostic report" : "Copy diagnostic report")
+                    .accessibilityHint("Copies the diagnostic report to the clipboard")
                     .disabled(runner.report.isEmpty)
 
                     Button(runner.isRunning ? "Running..." : (runner.checks.isEmpty ? "Run Diagnostics" : "Run Again")) {

--- a/ios/Sources/App/TerminalSettingsView.swift
+++ b/ios/Sources/App/TerminalSettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct TerminalSettingsView: View {
     @ObservedObject private var appearanceSettings: TerminalTabAppearanceSettings
@@ -154,6 +155,11 @@ struct TerminalSettingsView: View {
 
                     Button {
                         _ = tabManager.copyFirstTabColors(tabId: tabId)
+
+                        UIAccessibility.post(notification: .announcement, argument: "Copied first tab colors")
+                        let generator = UINotificationFeedbackGenerator()
+                        generator.notificationOccurred(.success)
+
                         withAnimation {
                             copiedColors = true
                         }


### PR DESCRIPTION
💡 What: Added non-visual confirmations to the "Copy First Tab Values" button in TerminalSettingsView and the "Copy Report" button in AppDiagnosticsView.
🎯 Why: Transient visual actions ("Copied!") can leave screen reader users unaware that an action succeeded. Combining visual changes with VoiceOver announcements and haptic feedback ensures accessibility for these interactions.
♿ Accessibility: Added `UIAccessibility.post` announcements for screen readers and `UINotificationFeedbackGenerator` haptics. Also fixed `import UIKit` in `TerminalSettingsView.swift` to support these accessibility features.

---
*PR created automatically by Jules for task [743369559949692661](https://jules.google.com/task/743369559949692661) started by @emkey1*