### PR TITLE
🎨 Palette: Add typing audio feedback to terminal accessory bar

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,4 +27,6 @@
 **Action:** When adding transient text, icons, or visual feedback to buttons or other UI elements, always wrap the boolean state toggles in `withAnimation {}` to provide a graceful transition (fade/slide) instead of a harsh pop-in/pop-out.
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
-**Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+## 2024-03-20 - Typing audio feedback for custom keyboard accessory bar
+**Learning:** Custom UIInputView keyboard accessory bars in iOS do not automatically play native keyboard click sounds when buttons are tapped.
+**Action:** Conformed the view to `UIInputViewAudioFeedback` with `enableInputClicksWhenVisible = true` and manually called `UIDevice.current.playInputClick()` on `.touchDown` for each button to restore expected auditory haptics.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,6 +27,7 @@
 **Action:** When adding transient text, icons, or visual feedback to buttons or other UI elements, always wrap the boolean state toggles in `withAnimation {}` to provide a graceful transition (fade/slide) instead of a harsh pop-in/pop-out.
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
+**Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
 ## 2024-03-20 - Typing audio feedback for custom keyboard accessory bar
 **Learning:** Custom UIInputView keyboard accessory bars in iOS do not automatically play native keyboard click sounds when buttons are tapped.
 **Action:** Conformed the view to `UIInputViewAudioFeedback` with `enableInputClicksWhenVisible = true` and manually called `UIDevice.current.playInputClick()` on `.touchDown` for each button to restore expected auditory haptics.

--- a/ios/Sources/App/TerminalInputBridge.swift
+++ b/ios/Sources/App/TerminalInputBridge.swift
@@ -87,7 +87,8 @@ struct TerminalInputBridge: UIViewRepresentable {
 }
 
 @MainActor
-final class TerminalKeyInputView: UITextView {
+final class TerminalKeyInputView: UITextView, UIInputViewAudioFeedback {
+    var enableInputClicksWhenVisible: Bool { true }
     var onInput: ((String) -> Void)?
     var onPaste: ((String) -> Void)?
     var onCopy: (() -> Void)?
@@ -218,6 +219,7 @@ final class TerminalKeyInputView: UITextView {
             button.configuration = config
             button.titleLabel?.font = UIFontMetrics.default.scaledFont(for: .systemFont(ofSize: 15, weight: .semibold))
             button.addTarget(self, action: action, for: .touchUpInside)
+            button.addTarget(self, action: #selector(playClick), for: .touchDown)
             return button
         }
 
@@ -278,6 +280,10 @@ final class TerminalKeyInputView: UITextView {
         makeCommand(input: UIKeyCommand.inputRightArrow, output: "\u{1B}[C")
         makeCommand(input: "\r", output: "\r")
         return commands
+    }
+
+    @objc private func playClick() {
+        UIDevice.current.playInputClick()
     }
 
     override var canBecomeFirstResponder: Bool {


### PR DESCRIPTION
This PR adds an accessibility/UX enhancement to the terminal emulator's custom accessory bar.

**💡 What:** We now conform `TerminalKeyInputView` to `UIInputViewAudioFeedback` and explicitly trigger the native system keyboard click sound when a user taps a custom keyboard accessory button (like escape, arrows, ctrl, etc.).
**🎯 Why:** Custom UIInputViews acting as keyboard accessories in iOS do not automatically broadcast their input clicks. Users expect keys on the software keyboard (even custom rows) to provide auditory and haptic feedback when typing.
**♿ Accessibility/UX:** Restores the expected system auditory haptics that are standard across iOS, making the terminal's software accessory keys feel like a native extension of the keyboard rather than disconnected buttons. System volume and haptic settings are automatically respected by the API.

---
*PR created automatically by Jules for task [2879360743328344409](https://jules.google.com/task/2879360743328344409) started by @emkey1*