### PR TITLE
🎨 Palette: Improve accessibility of transient copy states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+
+## 2026-08-06 - Transient Action Accessibility
+**Learning:** Users with screen readers may miss transient visual state changes (e.g. 'Copied' text).
+**Action:** Use `UINotificationFeedbackGenerator` and `UIAccessibility.post` for actions with transient state feedback.

--- a/ios/Sources/App/AppDiagnosticsView.swift
+++ b/ios/Sources/App/AppDiagnosticsView.swift
@@ -880,9 +880,15 @@ struct AppDiagnosticsView: View {
                 ToolbarItemGroup(placement: .primaryAction) {
                     Button(copiedReport ? "Copied" : "Copy Report") {
                         runner.copyReportToPasteboard()
-                        copiedReport = true
+                        UINotificationFeedbackGenerator().notificationOccurred(.success)
+                        UIAccessibility.post(notification: .announcement, argument: "Report copied")
+                        withAnimation {
+                            copiedReport = true
+                        }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                            copiedReport = false
+                            withAnimation {
+                                copiedReport = false
+                            }
                         }
                     }
                     .disabled(runner.report.isEmpty)

--- a/ios/Sources/App/TerminalSettingsView.swift
+++ b/ios/Sources/App/TerminalSettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct TerminalSettingsView: View {
     @ObservedObject private var appearanceSettings: TerminalTabAppearanceSettings
@@ -154,6 +155,8 @@ struct TerminalSettingsView: View {
 
                     Button {
                         _ = tabManager.copyFirstTabColors(tabId: tabId)
+                        UINotificationFeedbackGenerator().notificationOccurred(.success)
+                        UIAccessibility.post(notification: .announcement, argument: "Colors copied")
                         withAnimation {
                             copiedColors = true
                         }


### PR DESCRIPTION
💡 **What**: Added auditory, haptic, and visual transitions to "Copy Report" and "Copy First Tab Values" transient states.
🎯 **Why**: When a user clicks to copy, the visual text changes to "Copied" for a brief duration. Screen readers miss this visual-only change, and users can miss it without physical or visual feedback.
📸 **Before/After**: No visual screenshot change to the static UI, but animations are now smooth.
♿ **Accessibility**: Uses `UIAccessibility.post(notification: .announcement)` and `UINotificationFeedbackGenerator().notificationOccurred(.success)` to inform users with haptics and VoiceOver that the copy was successful.

---
*PR created automatically by Jules for task [9969481786434960282](https://jules.google.com/task/9969481786434960282) started by @emkey1*