### PR TITLE
🎨 Palette: Add haptic and VoiceOver feedback to Copy Colors button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+
+## 2026-08-09 - Transient UI Feedback
+**Learning:** Silent visual state changes (like 'Copied!' buttons) can be missed by non-visual users and feel unresponsive.
+**Action:** Combine visual updates with VoiceOver announcements (UIAccessibility.post) and haptic feedback (UINotificationFeedbackGenerator) for better accessibility and UX.

--- a/ios/Sources/App/TerminalSettingsView.swift
+++ b/ios/Sources/App/TerminalSettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct TerminalSettingsView: View {
     @ObservedObject private var appearanceSettings: TerminalTabAppearanceSettings
@@ -157,6 +158,10 @@ struct TerminalSettingsView: View {
                         withAnimation {
                             copiedColors = true
                         }
+
+                        UINotificationFeedbackGenerator().notificationOccurred(.success)
+                        UIAccessibility.post(notification: .announcement, argument: "Copied first tab colors")
+
                         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                             withAnimation {
                                 copiedColors = false


### PR DESCRIPTION
💡 What: Added haptic feedback and a VoiceOver announcement to the "Copy First Tab Values" button in Terminal Settings.
🎯 Why: The transient "Copied!" visual state change was silent for non-visual users and lacked physical feedback, making it feel less responsive.
📸 Before/After: Visuals unchanged, but interactions now provide haptic success feedback and screen reader announcements.
♿ Accessibility: Screen reader users will now hear "Copied first tab colors" immediately when the action succeeds.

---
*PR created automatically by Jules for task [2512520319093260397](https://jules.google.com/task/2512520319093260397) started by @emkey1*