### PR TITLE
🎨 Palette: Add non-visual accessibility and haptic feedback to copy actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+## 2024-05-24 - Non-visual Feedback for Transient Actions
+**Learning:** Users relying on VoiceOver or non-visual interaction need explicit confirmation for transient actions like 'Copy', as visual-only state changes (like 'Copied!') are easily missed.
+**Action:** Add UINotificationFeedbackGenerator and UIAccessibility.post announcements to transient feedback actions in addition to visual state changes.

--- a/ios/Sources/App/AppDiagnosticsView.swift
+++ b/ios/Sources/App/AppDiagnosticsView.swift
@@ -880,15 +880,23 @@ struct AppDiagnosticsView: View {
                 ToolbarItemGroup(placement: .primaryAction) {
                     Button(copiedReport ? "Copied" : "Copy Report") {
                         runner.copyReportToPasteboard()
-                        copiedReport = true
+                        UINotificationFeedbackGenerator().notificationOccurred(.success)
+                        UIAccessibility.post(notification: .announcement, argument: "Copied report")
+                        withAnimation {
+                            copiedReport = true
+                        }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                            copiedReport = false
+                            withAnimation {
+                                copiedReport = false
+                            }
                         }
                     }
                     .disabled(runner.report.isEmpty)
 
                     Button(runner.isRunning ? "Running..." : (runner.checks.isEmpty ? "Run Diagnostics" : "Run Again")) {
-                        copiedReport = false
+                        withAnimation {
+                            copiedReport = false
+                        }
                         runner.run()
                     }
                     .disabled(runner.isRunning)

--- a/ios/Sources/App/TerminalSettingsView.swift
+++ b/ios/Sources/App/TerminalSettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct TerminalSettingsView: View {
     @ObservedObject private var appearanceSettings: TerminalTabAppearanceSettings
@@ -154,6 +155,8 @@ struct TerminalSettingsView: View {
 
                     Button {
                         _ = tabManager.copyFirstTabColors(tabId: tabId)
+                        UINotificationFeedbackGenerator().notificationOccurred(.success)
+                        UIAccessibility.post(notification: .announcement, argument: "Copied first tab colors")
                         withAnimation {
                             copiedColors = true
                         }


### PR DESCRIPTION
💡 What: Added haptic feedback and VoiceOver announcements to transient copy actions. 
🎯 Why: Visual-only feedback ('Copied!') is easily missed by users relying on VoiceOver. 
📸 Before/After: Visuals unchanged (except animation). 
♿ Accessibility: Improved VoiceOver announcements and wrapped state changes in withAnimation.

---
*PR created automatically by Jules for task [13044524294868836510](https://jules.google.com/task/13044524294868836510) started by @emkey1*