### PR TITLE
🎨 Palette: [Add non-visual confirmation for transient actions]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-03-20 - Redundant Visual Values and Slider Accessibility
 **Learning:** SwiftUI Sliders often rely on separate text views (e.g., in an HStack) to display their current value. Screen readers will read the slider and then redundantly read the visual text label as a separate element, causing confusion.
 **Action:** When implementing Sliders with visual value labels, always add `.accessibilityValue(...)` to the Slider itself, and add `.accessibilityHidden(true)` to the redundant text element so it is hidden from VoiceOver.
+
+## 2025-05-22 - Transient Actions Non-Visual Confirmation
+**Learning:** Transient state changes (like "Copied!") often lack non-visual confirmation for VoiceOver users, and physical feedback can improve the user experience for everyone.
+**Action:** Always add non-visual confirmation by combining visual updates with VoiceOver announcements (`UIAccessibility.post(notification: .announcement, argument: "...")`) and haptic feedback (`UINotificationFeedbackGenerator().notificationOccurred(.success)`) for transient actions like copying text.

--- a/ios/Sources/App/AppDiagnosticsView.swift
+++ b/ios/Sources/App/AppDiagnosticsView.swift
@@ -880,18 +880,26 @@ struct AppDiagnosticsView: View {
                 ToolbarItemGroup(placement: .primaryAction) {
                     Button(copiedReport ? "Copied" : "Copy Report") {
                         runner.copyReportToPasteboard()
-                        copiedReport = true
+                        UINotificationFeedbackGenerator().notificationOccurred(.success)
+                        UIAccessibility.post(notification: .announcement, argument: "Report copied to clipboard")
+                        withAnimation {
+                            copiedReport = true
+                        }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                            copiedReport = false
+                            withAnimation {
+                                copiedReport = false
+                            }
                         }
                     }
                     .disabled(runner.report.isEmpty)
+                    .accessibilityHint("Copies the diagnostic report to the clipboard")
 
                     Button(runner.isRunning ? "Running..." : (runner.checks.isEmpty ? "Run Diagnostics" : "Run Again")) {
                         copiedReport = false
                         runner.run()
                     }
                     .disabled(runner.isRunning)
+                    .accessibilityHint("Executes the diagnostic checks")
                 }
             }
         }

--- a/ios/Sources/App/TerminalSettingsView.swift
+++ b/ios/Sources/App/TerminalSettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct TerminalSettingsView: View {
     @ObservedObject private var appearanceSettings: TerminalTabAppearanceSettings
@@ -154,6 +155,8 @@ struct TerminalSettingsView: View {
 
                     Button {
                         _ = tabManager.copyFirstTabColors(tabId: tabId)
+                        UINotificationFeedbackGenerator().notificationOccurred(.success)
+                        UIAccessibility.post(notification: .announcement, argument: "Colors copied from first tab")
                         withAnimation {
                             copiedColors = true
                         }


### PR DESCRIPTION
🎨 Palette: [Add non-visual confirmation for transient actions]

💡 What: Added haptic feedback (`UINotificationFeedbackGenerator`) and VoiceOver announcements (`UIAccessibility.post`) to transient "Copy" actions in `AppDiagnosticsView` and `TerminalSettingsView`. Also added smooth transitions using `withAnimation` and `accessibilityHint`s.
🎯 Why: Transient UI states (like "Copied!" appearing for 2 seconds) often lack non-visual confirmation, leaving screen reader users uncertain if the action succeeded. Smooth animations and haptics also improve the experience for all users.
♿ Accessibility: Ensures VoiceOver users hear a confirmation ("Report copied to clipboard", "Colors copied from first tab") when copying, and provides physical haptic feedback. Added clear hints to related buttons.

---
*PR created automatically by Jules for task [13694643828859281034](https://jules.google.com/task/13694643828859281034) started by @emkey1*